### PR TITLE
Apply canonical KV layer footers

### DIFF
--- a/.github/ISSUE_TEMPLATE/help_request.md
+++ b/.github/ISSUE_TEMPLATE/help_request.md
@@ -18,3 +18,7 @@ labels: help
 - [ ] Other
 
 ## Any privacy or storage constraints?
+
+---
+
+🔒 Layer: Framework | KV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,3 +102,7 @@ It improves usability, onboarding, and safety documentation only.
 ### Notes
 This is the first stable format version of the KnowledgeVault system.
 Future versions should remain backward-compatible whenever possible.
+
+---
+
+🔒 Layer: Framework | KV

--- a/DO_NOT_STORE_HERE.md
+++ b/DO_NOT_STORE_HERE.md
@@ -19,3 +19,7 @@ If you need to store these, use:
 - separate secure storage
 
 When in doubt: don’t store it here.
+
+---
+
+🔒 Layer: Framework | KV

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -118,3 +118,7 @@ Your vault is standalone by default. If you later choose, you can:
 - **Enable AI-compatible review workflows** using the documented guides in `docs/`
 
 None of these are required. They exist for users who want them.
+
+---
+
+🔒 Layer: Framework | KV

--- a/PATCH_README.md
+++ b/PATCH_README.md
@@ -8,3 +8,7 @@ Adds:
 Install:
 - Copy contents into repo root
 - Commit
+
+---
+
+🔒 Layer: Framework | KV

--- a/README.md
+++ b/README.md
@@ -103,3 +103,7 @@ This kit is part of **StegVerse**: an open framework for expectations, identity,
 ## License
 
 See [`LICENSE`](./LICENSE).
+
+---
+
+🔒 Layer: Framework | KV

--- a/SAFETY.md
+++ b/SAFETY.md
@@ -60,3 +60,7 @@ Before opting in, read:
 
 StegVerse favors **clarity and replaceability**.
 Safety should be improved over time, without locking users into one vendor or one app.
+
+---
+
+🔒 Layer: Framework | KV

--- a/STATUS.md
+++ b/STATUS.md
@@ -24,3 +24,7 @@ next_steps:
   - Allow substantive Unreleased changes or supported merged fixes to enter verified publication automatically
   - Keep first-contact use independent of accounts, hosted services, mandatory SDKs, and vault telemetry
 last_reviewed_utc: 2026-07-14T09:30:00Z
+
+---
+
+🔒 Layer: Framework | KV

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -152,3 +152,7 @@ See [`docs/DATA_SHARING.md`](./docs/DATA_SHARING.md) for full details.
 For more structure and examples, read:
 
 ➡️ [`GETTING_STARTED.md`](./GETTING_STARTED.md)
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/AI_COMPATIBLE.md
+++ b/docs/AI_COMPATIBLE.md
@@ -82,3 +82,7 @@ If you are building a tool that reads KnowledgeVault:
 5. Log all access in `_AI/Logs/` (if applicable)
 
 See `docs/AI_Ingestion.md` for the reference implementation.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/AI_Ingestion.md
+++ b/docs/AI_Ingestion.md
@@ -40,3 +40,7 @@ You can run this later via:
 - GitHub Actions (next step)
 
 Output is plain Markdown — portable and safe.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/AUTOMATION_CONTRACTS.md
+++ b/docs/AUTOMATION_CONTRACTS.md
@@ -42,3 +42,7 @@ A downstream update is required only when a destination already publishes a dire
 ## Change rule
 
 A change that intentionally alters one of these contracts must update all affected workflows, evidence schemas, documentation, and `tools/test_automation_contracts.py` in the same change set.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -158,6 +158,7 @@ The current determination is no update required for all four. Evidence is stored
 12. A supported merged fix must be recorded in Unreleased state before publication.
 13. Optional ecosystem references must not become baseline dependencies.
 14. Do not convert this repository into an identity authority, surveillance surface, mandatory hosted service, financial product, or broad ecosystem-governance repository.
+15. Canonical KV footers are applied only through the dedicated `format/**` automation lane before required-footer enforcement is activated.
 
 ---
 
@@ -174,6 +175,7 @@ The current determination is no update required for all four. Evidence is stored
 - Implement only the smallest demonstrated fix for a supported candidate.
 - Do not invent onboarding automation without evidence.
 - Implement data-sharing behavior only under a separately governed scope; current text is documentation, not an active system.
+- Let `format/kv-footers` populate canonical layer footers; enable mandatory footer checks only after its formatting PR validates successfully.
 
 No open issue currently owns required work for the verified `0.1.2` release.
 

--- a/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -16,7 +16,7 @@ This file is the repo-local continuation source of truth. Read it before reposit
 
 Baseline use must remain functional without an account, hosted service, SDK, database, workflow dependency, or vault telemetry.
 
-Integrity tooling verifies package and copy behavior only. Automation-contract tooling verifies repository consistency only. Release-cycle receipts record repository outcomes only. None certifies the truth, safety, completeness, authority, or admissibility of user-authored content.
+Integrity tooling verifies package and copy behavior only. Automation-contract tooling verifies repository consistency only. Release-cycle receipts record repository outcomes only. This automation does not certify the truth, safety, completeness, authority, or admissibility of user-authored content.
 
 ---
 

--- a/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -190,3 +190,7 @@ Recommended next activation condition:
 This handoff preserves the current release, reusable release-cycle state, all release evidence surfaces, automation behavior, initialization contract, downstream determinations, onboarding-friction lifecycle, decisions, permitted scope, and conditional successor rules.
 
 The complete thread is ready for archiving without any additional part of the thread needed to move forward.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/CONVERSATION_CONTINUITY.md
+++ b/docs/CONVERSATION_CONTINUITY.md
@@ -279,3 +279,7 @@ It is one of the primary reasons the vault exists.
 The vault preserves memory.
 The reload packet restores working context.
 The human remains the authority.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/DATA_SHARING.md
+++ b/docs/DATA_SHARING.md
@@ -186,3 +186,7 @@ If you share `04_Media`, your photos/videos may be included in visual datasets. 
 ---
 
 Last updated: 2026-04-24
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/EMOJI_RELATIONSHIP_GRAMMAR.md
+++ b/docs/EMOJI_RELATIONSHIP_GRAMMAR.md
@@ -42,3 +42,7 @@ Those are **not reliably typed**, and can differ across fonts/editors.
 - CI runs a lint that **warns** when disallowed arrow characters are detected.
 - To make CI **fail** on warnings, set repository variable:
   - `STEGDB_EMOJI_LINT_STRICT=1`
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/EMOJI_STYLE_GUIDE.md
+++ b/docs/EMOJI_STYLE_GUIDE.md
@@ -24,3 +24,7 @@ Avoid editor-specific arrow glyphs. Use either:
 
 - ➜ (emoji)
 - `-->` (ASCII)
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -35,3 +35,7 @@ Examples demonstrate structure, not a requirement to expose private information.
 Release manifests and checksums verify packaged files; they do not certify that user-authored content is true, safe, complete, or appropriate to share.
 
 New examples should remain small, manually understandable, and usable without optional StegVerse tooling.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/IOS_SETUP.md
+++ b/docs/IOS_SETUP.md
@@ -63,3 +63,7 @@ Use Files for:
 Do not store personal records in this public starter kit repo.
 
 If you are using a Git repo for your real vault, make it **private**.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/IOS_VAULT_UPDATE_GUIDE.md
+++ b/docs/IOS_VAULT_UPDATE_GUIDE.md
@@ -120,3 +120,7 @@ This process ensures:
 
 Future versions may include an automated update helper.  
 For now, manual updates are the safest approach.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/KV_LAYERING_RULES.md
+++ b/docs/KV_LAYERING_RULES.md
@@ -47,18 +47,7 @@ Markdown docs in either layer get a standard footer at the bottom.
 Example:
 
 ```md
+
 ---
 
-<!-- StegDB: kv.layer.v1 | LAYER=FRAMEWORK | SCOPE=Public kit (no personal data) -->
-
-🧭 **KV Layer:** FRAMEWORK  
-🏷️ **KV Scope:** Public kit (no personal data)  
-🔒 **KV Safety:** Never store personal info here  
-🧬 **StegDB:** managed • rule=kv.layer.v1
-```
-
-To auto-apply footers locally (no moves/deletes):
-
-```bash
-python3 tools/kv_layer_check.py --mode auto-label
-```
+🔒 Layer: Framework | KV

--- a/docs/KV_LAYERING_RULES.md
+++ b/docs/KV_LAYERING_RULES.md
@@ -1,52 +1,73 @@
 # KV Layer Boundary Rules (kv.layer.v1)
 
-This repo enforces a **hard boundary** between:
+This repository enforces a clear boundary between:
 
-- **FRAMEWORK** (public kit docs + tooling)
-- **RUNTIME_TEMPLATE** (seed files that will exist inside a user's personal KnowledgeVault)
+- **FRAMEWORK** — public kit documentation, tooling, workflows, and repository metadata.
+- **RUNTIME_TEMPLATE** — placeholder files copied into a user's private KnowledgeVault.
 
-## ✅ Goal
+## Goal
 
-Make it *obvious* what belongs where, and make CI fail fast if something drifts.
+Make intended placement obvious and detect drift without inspecting or mutating user-authored personal vault content.
 
 ---
 
-## 🧭 Layers
+## Layers
 
 ### FRAMEWORK
-**Where:** root docs + `docs/**` + `tools/**` + `.github/**`
 
-**Meaning:** public starter kit only — **no personal data**.
+**Where:** root documentation plus `docs/**`, `tools/**`, `.github/**`, and `.stegdb/**`.
+
+**Meaning:** public starter-kit material only. Do not place user-authored personal data here.
 
 ### RUNTIME_TEMPLATE
-**Where:** `vault_template/KnowledgeVault/**`
 
-**Meaning:** safe placeholder seed files users copy into their private vault.
+**Where:** `vault_template/KnowledgeVault/**`.
 
----
-
-## 🔒 Hard-fail markers
-
-If any of these appear in any Markdown file, CI fails:
-
-- `Privacy Level: restricted`
-- `BEGIN:VCARD`
-- `SSN`
-- `Social Security`
-- `Driver's License`
-- `Passport`
-
-Tune in `.stegdb/kv-layer.v1.json`.
+**Meaning:** safe placeholder and policy seed files that users may copy into a private vault.
 
 ---
 
-## 🏷️ Footer labeling
+## Forbidden footer claims
 
-Markdown docs in either layer get a standard footer at the bottom.
+The checker rejects exact Markdown footer lines that incorrectly claim a public repository file is part of a personal vault, including:
 
-Example:
+- `🔒 Layer: Personal Vault | KV`
+- `🔒 Layer: Personal | KV`
+
+Ordinary safety documentation may discuss personal vaults, passports, identifiers, restricted records, or other sensitive topics. Those prose references are not treated as evidence that personal data is present.
+
+Configuration lives in `.stegdb/kv-layer.v1.json`.
+
+---
+
+## Footer labeling
+
+Canonical Markdown footers are:
 
 ```md
+---
+
+🔒 Layer: Framework | KV
+```
+
+and:
+
+```md
+---
+
+🔒 Layer: Vault Template | KV
+```
+
+The dedicated `format/**` workflow may add or normalize these footers. It does not move or delete files.
+
+To apply the same operation in a local checkout:
+
+```bash
+python3 tools/kv_layer_check.py --mode auto-label
+python3 tools/kv_layer_check.py --mode validate
+```
+
+Footer examples inside prose or fenced code must remain untouched. Only a recognized trailing footer block may be replaced.
 
 ---
 

--- a/docs/MULTI_DEVICE_USAGE.md
+++ b/docs/MULTI_DEVICE_USAGE.md
@@ -127,3 +127,7 @@ This keeps KnowledgeVault:
 ✔ Easy to use  
 ✔ Flexible  
 ✔ Future‑intelligent
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/PLAYLIST_EXPORT_PLAYERS.md
+++ b/docs/PLAYLIST_EXPORT_PLAYERS.md
@@ -94,3 +94,7 @@ Your playlist memories exist as:
 - Human-readable lists
 
 This means future tools — or future AI — can rebuild your playlists anytime.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/PRESENCE_BASED_SHARING.md
+++ b/docs/PRESENCE_BASED_SHARING.md
@@ -115,3 +115,7 @@ All while keeping your personal archive under your control.
 
 Your KnowledgeVault is the **master memory archive**.  
 Shared albums, notes, and folders are **windows you open when you choose**.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/RELEASE_CANDIDATE_CHECKLIST.md
+++ b/docs/RELEASE_CANDIDATE_CHECKLIST.md
@@ -78,3 +78,7 @@ Downstream publication must preserve the baseline position:
 ## 8. Completion condition
 
 The release process is complete only when the verified commit is tagged, release evidence is durably referenced, the handoff reflects the new state, and downstream verification ownership is recorded.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/SHORTCUTS_ADD_A_MEMORY_SPEC.md
+++ b/docs/SHORTCUTS_ADD_A_MEMORY_SPEC.md
@@ -224,3 +224,7 @@ Optional:
 - Shortcuts can’t “auto-match typed names to contacts” in a live search box.
 - “Create Contact” requires user confirmation (privacy by design).
 - GPS requires location permission; allow “Skip” always.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/STEGVERSE_BRIDGE.md
+++ b/docs/STEGVERSE_BRIDGE.md
@@ -92,3 +92,7 @@ If you are building a StegVerse-compatible tool:
 ---
 
 This document is not linked from README.md or WELCOME.md. It exists for users who seek deeper integration.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/TECHNICAL_REVIEW_PATH.md
+++ b/docs/TECHNICAL_REVIEW_PATH.md
@@ -62,3 +62,7 @@ It is not yet optimized for broad casual adoption.
 That is acceptable for this stage.
 
 The next activation goal is to make the conversation-continuity path obvious without stripping the deeper architecture.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/VAULT_BACKUP_GUIDE.md
+++ b/docs/VAULT_BACKUP_GUIDE.md
@@ -129,3 +129,7 @@ Backups ensure your memories survive:
 - Service changes over time
 
 With this backup plan, your vault becomes truly resilient.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/Your First 5 KnowledgeVault Notes.md
+++ b/docs/Your First 5 KnowledgeVault Notes.md
@@ -89,3 +89,7 @@ This anchors your timeline and makes future recall much easier.
 These notes are meant to grow over time — just start simple.
 
 Your KnowledgeVault becomes powerful not from complexity, but from **consistent, human entries over time**.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/examples/Device_Migration_Packet.md
+++ b/docs/examples/Device_Migration_Packet.md
@@ -71,3 +71,7 @@ After acceptance, update device-specific references and record the migration in 
 ## Completion condition
 
 Migration is complete only when the destination is verified, differences are resolved or explicitly accepted, the owner designates the destination as current, and rollback handling is recorded.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/examples/Health_Record_Chronology.md
+++ b/docs/examples/Health_Record_Chronology.md
@@ -41,3 +41,7 @@ Request or locate the missing source record, then append it without overwriting 
 ## Privacy boundary
 
 Use local references instead of copying unnecessary sensitive content into a handoff intended for sharing.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/examples/Multi_Session_AI_Collaboration.md
+++ b/docs/examples/Multi_Session_AI_Collaboration.md
@@ -40,3 +40,7 @@ A later session may summarize, compare, and identify conflicts. It may not merge
 ## Next permitted action
 
 Present the conflicting milestone priorities and unsupported dependency to the owner for resolution. Record the decision and its source before continuing implementation.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/examples/Project_Continuation_Packet.md
+++ b/docs/examples/Project_Continuation_Packet.md
@@ -82,3 +82,7 @@ This continuation packet may be closed when:
 ## Minimal reload prompt
 
 > Read this project continuation packet and the listed authoritative files. Summarize the current state, distinguish completed work from proposals, identify unresolved owner decisions, and recommend only the next permitted action. Do not authorize file deletion or movement.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/examples/Reload_Packet_Example.md
+++ b/docs/examples/Reload_Packet_Example.md
@@ -67,3 +67,7 @@ The current release is best understood as a technical-signal release for systems
 ## Continuation note
 
 A future session should continue from the next work list above and preserve the constraints.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/examples/Research_Evidence_Review.md
+++ b/docs/examples/Research_Evidence_Review.md
@@ -40,3 +40,7 @@ Confirm the dataset version and add an independent source before strengthening t
 ## AI boundary
 
 An AI may organize and compare the registered sources. It must identify which statements are source-supported, inferred, disputed, or missing.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/examples/Version_Replacement_and_Migration.md
+++ b/docs/examples/Version_Replacement_and_Migration.md
@@ -39,3 +39,7 @@ Use this packet when adopting a newer Continuity Vault Kit without allowing the 
 ## Next permitted action
 
 Record owner acceptance, then retire the temporary candidate copy. If any difference remains unresolved, keep the prior vault authoritative and document the conflict.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/release_evidence/README.md
+++ b/docs/release_evidence/README.md
@@ -14,3 +14,7 @@ A receipt records the tested commit, workflow run, artifact name, package digest
 ## Scope boundary
 
 A successful receipt verifies packaging integrity for the tested repository state. It does not certify the truth, safety, completeness, authority, or admissibility of user-authored vault content.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/release_evidence/latest.md
+++ b/docs/release_evidence/latest.md
@@ -18,3 +18,7 @@
 The workflow completed release tooling tests, safe initialization tests, repository automation contract validation, a clean rebuild, manifest validation, and full archive verification.
 
 This receipt verifies package integrity, installer copy behavior, and repository automation contract consistency only. It does not certify user-authored content.
+
+---
+
+🔒 Layer: Framework | KV

--- a/docs/release_evidence/latest_cycle.md
+++ b/docs/release_evidence/latest_cycle.md
@@ -10,3 +10,7 @@
 - **Generated UTC:** `2026-07-14T15:40:43Z`
 
 This receipt records repository release-cycle state only. It does not certify user-authored content.
+
+---
+
+🔒 Layer: Framework | KV

--- a/tools/kv_layer_check.py
+++ b/tools/kv_layer_check.py
@@ -17,7 +17,6 @@ import fnmatch
 import json
 import os
 import re
-import sys
 from pathlib import Path
 from typing import List, Tuple
 
@@ -97,18 +96,30 @@ def parse_footer(text: str) -> Tuple[str | None, str | None]:
 
 
 def strip_existing_footer(text: str) -> str:
-    markers = (
-        "🔒 Layer:",
-        "StegDB: kv.layer.v1",
-        "🧭 **KV Layer:**",
-        "🧬 **StegDB:** managed • rule=kv.layer.v1",
+    """Remove only a recognized footer block at the end of the document.
+
+    Footer examples embedded in prose or fenced code are preserved. This avoids
+    truncating documentation that explains the canonical footer format.
+    """
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n").rstrip()
+
+    simple = re.compile(
+        r"\n---\n\n🔒\s*Layer:\s*(?:Framework|Vault Template|Personal Vault|Personal)\s*\|\s*KV\s*$"
     )
-    index = max((text.rfind(marker) for marker in markers), default=-1)
-    if index < 0:
-        return text
-    separator = text.rfind("\n---", 0, index)
-    cut = separator if separator >= 0 else index
-    return text[:cut].rstrip() + "\n"
+    match = simple.search(normalized)
+    if match:
+        return normalized[: match.start()].rstrip() + "\n"
+
+    legacy = re.compile(
+        r"\n---\n(?:\n|.)*?"
+        r"(?:<!--\s*StegDB:\s*kv\.layer\.v1[^>]*-->|🧭\s*\*\*KV Layer:\*\*)"
+        r"(?:\n|.)*$"
+    )
+    match = legacy.search(normalized)
+    if match and len(normalized) - match.start() <= 1200:
+        return normalized[: match.start()].rstrip() + "\n"
+
+    return normalized + "\n"
 
 
 def build_footer(layer: str) -> str:
@@ -172,7 +183,11 @@ def main() -> int:
             continue
 
         text = path.read_text(encoding="utf-8", errors="replace")
-        found_forbidden = [line for line in forbidden_lines if re.search(rf"(?m)^\s*{re.escape(line)}\s*$", text)]
+        found_forbidden = [
+            line
+            for line in forbidden_lines
+            if re.search(rf"(?m)^\s*{re.escape(line)}\s*$", text)
+        ]
         if found_forbidden:
             violations.append((rel, "FORBIDDEN_FOOTER", ", ".join(sorted(found_forbidden))))
             continue

--- a/vault_template/KnowledgeVault/00_Inbox/Quick_Notes.md
+++ b/vault_template/KnowledgeVault/00_Inbox/Quick_Notes.md
@@ -17,3 +17,7 @@ Place (optional):
 Feelings or thoughts:
 
 Media saved? (filename if any)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/00_Inbox/README.md
+++ b/vault_template/KnowledgeVault/00_Inbox/README.md
@@ -7,3 +7,7 @@ Weekly goal:
 - Move into the correct folder (Notes / Research / Records / Projects / Media)
 
 This folder should trend toward empty.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/01_Notes/README.md
+++ b/vault_template/KnowledgeVault/01_Notes/README.md
@@ -6,3 +6,7 @@ Recommended:
 - One file per day/topic: `YYYY-MM-DD Topic – Description.md`
 - Use headings + bullet points
 - Link to supporting PDFs or images by relative path
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/01_Notes/_Templates/Note Template.md
+++ b/vault_template/KnowledgeVault/01_Notes/_Templates/Note Template.md
@@ -11,3 +11,7 @@ Source:
 ## Key Points
 
 ## Related
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/02_Research/README.md
+++ b/vault_template/KnowledgeVault/02_Research/README.md
@@ -6,3 +6,7 @@ Prefer:
 - PDF copies of sources
 - Markdown summaries
 - A simple citations section in each note
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/02_Research/_Templates/Research Template.md
+++ b/vault_template/KnowledgeVault/02_Research/_Templates/Research Template.md
@@ -11,3 +11,7 @@ Source:
 ## Key Points
 
 ## Related
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/03_Records/README.md
+++ b/vault_template/KnowledgeVault/03_Records/README.md
@@ -6,3 +6,7 @@ Recommendations:
 - PDF/A when possible
 - Store supporting emails as PDF exports
 - Keep a brief Markdown summary for each major record set
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/03_Records/_Templates/Records Template.md
+++ b/vault_template/KnowledgeVault/03_Records/_Templates/Records Template.md
@@ -11,3 +11,7 @@ Source:
 ## Key Points
 
 ## Related
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/04_Media/README.md
+++ b/vault_template/KnowledgeVault/04_Media/README.md
@@ -5,3 +5,7 @@ Images, audio, video.
 Recommendation:
 - Put raw media here
 - Put interpretation/notes in 01_Notes or 02_Research
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/05_Projects/README.md
+++ b/vault_template/KnowledgeVault/05_Projects/README.md
@@ -5,3 +5,7 @@ Project-specific folders or notes.
 Good pattern:
 - `05_Projects/ProjectName/`
 - `YYYY-MM-DD` status notes inside
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/05_Projects/_Events/README.md
+++ b/vault_template/KnowledgeVault/05_Projects/_Events/README.md
@@ -16,3 +16,7 @@ Use:
 
 Example:
 `2026-02-04 — Lily Birthday Party`
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Capture_Playbook.md
+++ b/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Capture_Playbook.md
@@ -25,3 +25,7 @@ If you want a great highlight film (and possibly 3D later), ask 2–5 people to 
 
 ## Notes for privacy
 Only capture what you’re comfortable sharing for this event.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Consent_and_Permissions.md
+++ b/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Consent_and_Permissions.md
@@ -25,3 +25,7 @@ Nothing leaves the private vault without explicit permission.
 
 ## Notes
 (Anything special: kids, sensitive locations, etc.)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Event_Manifest.md
+++ b/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Event_Manifest.md
@@ -32,3 +32,7 @@ created_at_utc: ""
 
 ## Notes
 (Anything else.)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Media_Index.md
+++ b/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Media_Index.md
@@ -31,3 +31,7 @@ It helps AI and humans assemble timelines and edits later.
 - Videos:
 - Audio:
 - Notes:
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Participants.md
+++ b/vault_template/KnowledgeVault/05_Projects/_Events/_Templates/Participants.md
@@ -25,3 +25,7 @@ Format:
 
 ## Notes
 - If someone should not be tagged or included in exports, mark it here.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/05_Projects/_Templates/Projects Template.md
+++ b/vault_template/KnowledgeVault/05_Projects/_Templates/Projects Template.md
@@ -11,3 +11,7 @@ Source:
 ## Key Points
 
 ## Related
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/06_Archive/README.md
+++ b/vault_template/KnowledgeVault/06_Archive/README.md
@@ -3,3 +3,7 @@
 Cold storage inside the vault (completed, old, or rarely used).
 
 Do not delete. Move here when inactive.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/README.md
+++ b/vault_template/KnowledgeVault/README.md
@@ -7,3 +7,7 @@ This template produces a portable personal vault.
 
 If you want to propose changes to doctrine, edit StegDB:
 `StegDB/canonical/overlays/KnowledgeVaultOverlay/canon/`
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/AI_Log_Index.md
+++ b/vault_template/KnowledgeVault/_AI/AI_Log_Index.md
@@ -10,3 +10,7 @@ This section records when AI systems are given access to vault information.
 
 ## Logs (most recent first)
 - (Add entries here)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/AI_Review_Session_Flow.md
+++ b/vault_template/KnowledgeVault/_AI/AI_Review_Session_Flow.md
@@ -136,3 +136,7 @@ Review sessions should become:
 • Faster to complete
 
 As AI improves pattern recognition over time.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/GUIDE.md
+++ b/vault_template/KnowledgeVault/_AI/GUIDE.md
@@ -147,3 +147,7 @@ Help the user make decisions their future self will understand.
 
 Your job is not to be impressive.  
 Your job is to make the system feel easy.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/Logs/AI_Log_Template.md
+++ b/vault_template/KnowledgeVault/_AI/Logs/AI_Log_Template.md
@@ -39,4 +39,8 @@ Paths shared (if any):
 
 ## Stored Outputs
 Links to saved outputs in `_AI/Exports/`:
-- 
+-
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/Logs/README.md
+++ b/vault_template/KnowledgeVault/_AI/Logs/README.md
@@ -6,3 +6,7 @@ Use:
 - AI_Log_Template.md for each session
 - One file per session
 - Store sensitive content locally, not in public repos
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/README.md
+++ b/vault_template/KnowledgeVault/_AI/README.md
@@ -7,3 +7,7 @@ It should never contain private secrets unless encrypted and intentionally share
 - `_Queue/` — proposed changes (human review required)
 - `_Applied/` — a log of what was applied and when
 - `_Rules/` — rules used to generate suggestions
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/Reflections/YYYY-MM-DD_ZRE.md
+++ b/vault_template/KnowledgeVault/_AI/Reflections/YYYY-MM-DD_ZRE.md
@@ -14,3 +14,7 @@ Balance without self-erasure.
 
 ## Reminder
 Symbolic reflection only — not predictions or advice.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/_Applied/tag_suggestions/README.md
+++ b/vault_template/KnowledgeVault/_AI/_Applied/tag_suggestions/README.md
@@ -6,3 +6,7 @@ Purpose:
 - audit trail
 - rollback reference (if needed)
 - helps train future suggestion thresholds
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/_Queue/tag_suggestions/2026-02-04T1515Z_tag_suggestions.md
+++ b/vault_template/KnowledgeVault/_AI/_Queue/tag_suggestions/2026-02-04T1515Z_tag_suggestions.md
@@ -45,3 +45,7 @@ scope:
 **Action:**
 - [ ] Apply all
 - [ ] Skip
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/_Queue/tag_suggestions/README.md
+++ b/vault_template/KnowledgeVault/_AI/_Queue/tag_suggestions/README.md
@@ -7,3 +7,7 @@ Workflow:
 1) Suggestions appear here
 2) Human reviews and applies (or rejects)
 3) Applied actions are recorded in `_AI/_Applied/tag_suggestions/`
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_AI/_Rules/Tag_Suggestion_Rules_v0.1.md
+++ b/vault_template/KnowledgeVault/_AI/_Rules/Tag_Suggestion_Rules_v0.1.md
@@ -61,3 +61,7 @@ Reason:
 - No automatic writes to memory files
 - No inference of sensitive tags (health, politics, finances) without explicit user input
 - No face recognition or message scraping
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Entity_File_Templates-Standard.md
+++ b/vault_template/KnowledgeVault/_Entities/Entity_File_Templates-Standard.md
@@ -170,3 +170,7 @@ These templates ensure:
 • Compatibility with future AI tools
 • Human readability without special software
 • Strong linking without database lock-in
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Organizations/README.md
+++ b/vault_template/KnowledgeVault/_Entities/Organizations/README.md
@@ -8,3 +8,7 @@ Purpose:
 - Support long-term recall and AI-assisted organization
 
 Not every company or group needs a file — only those with meaningful involvement.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Organizations/_Backfill_Orgs.md
+++ b/vault_template/KnowledgeVault/_Entities/Organizations/_Backfill_Orgs.md
@@ -4,3 +4,7 @@
 - UT Austin — 2012–2016
 - Dell — 2020–Present
 - Austin Community Church — 2021–Present
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Organizations/_Template.md
+++ b/vault_template/KnowledgeVault/_Entities/Organizations/_Template.md
@@ -69,3 +69,7 @@ Changes, endings, major milestones.
 `public | private | restricted`
 
 Defines how AI should treat this file.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/People/README.md
+++ b/vault_template/KnowledgeVault/_Entities/People/README.md
@@ -10,3 +10,7 @@ Purpose:
 Do not add every contact here — only people who appear in meaningful memories.
 
 Files in this folder may be marked with a privacy level to control AI access.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/People/_Backfill_Key_People.md
+++ b/vault_template/KnowledgeVault/_Entities/People/_Backfill_Key_People.md
@@ -8,3 +8,7 @@ For each, create a People file later.
 - Dad — Parent — Childhood → Present
 - Sam — Child — 2012 → Present
 - Alex — Close Friend — 2018 → Present
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/People/_Template.md
+++ b/vault_template/KnowledgeVault/_Entities/People/_Template.md
@@ -54,3 +54,7 @@ Use this section to track evolving context.
 `public | private | restricted`
 
 Defines how AI should treat this file.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Places/Places/_Backfill_Key_Places.md
+++ b/vault_template/KnowledgeVault/_Entities/Places/Places/_Backfill_Key_Places.md
@@ -6,3 +6,7 @@ List meaningful locations from life.
 - College Campus — UT Austin
 - First Apartment — Austin, TX
 - Grandma’s House — Waco, TX
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Places/README.md
+++ b/vault_template/KnowledgeVault/_Entities/Places/README.md
@@ -8,3 +8,7 @@ Purpose:
 - Enable long-term spatial memory and AI-assisted recall
 
 Not every GPS location should have a file — only places with recurring or meaningful memories.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Places/_Template.md
+++ b/vault_template/KnowledgeVault/_Entities/Places/_Template.md
@@ -67,3 +67,7 @@ Moved away — now visited occasionally
 `public | private | restricted`
 
 Defines how AI should treat this file.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Projects/README.md
+++ b/vault_template/KnowledgeVault/_Entities/Projects/README.md
@@ -7,3 +7,7 @@ Projects are different from events:
 - A project unfolds over weeks, months, or years
 
 Projects connect memories, people, places, and milestones into a coherent life story.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Projects/_Backfill_Projects.md
+++ b/vault_template/KnowledgeVault/_Entities/Projects/_Backfill_Projects.md
@@ -3,3 +3,7 @@
 - Health Recovery — Started 2023
 - Family Memory Preservation — Ongoing
 - Career Growth at Dell — 2020–Present
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/Projects/_Template.md
+++ b/vault_template/KnowledgeVault/_Entities/Projects/_Template.md
@@ -87,3 +87,7 @@ What changed because of this project?
 
 ## Privacy Level
 `public | private | restricted`
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Entities/README.md
+++ b/vault_template/KnowledgeVault/_Entities/README.md
@@ -62,3 +62,7 @@ Family physician since 2022
 ```
 
 This is your personal entity reference. It is not shared with any service unless you explicitly choose to.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/AI Ingestion Index.md
+++ b/vault_template/KnowledgeVault/_Index/AI Ingestion Index.md
@@ -24,3 +24,7 @@ Templates define note structure and can be used to interpret meaning:
 - Media Highlight
 - Song Moment
 - Event Log
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Index_Auto-Linking_Rules.md
+++ b/vault_template/KnowledgeVault/_Index/Index_Auto-Linking_Rules.md
@@ -148,3 +148,7 @@ Over time, linking should make the vault:
 • Still readable as plain Markdown
 
 Structure should enhance memory — not replace it.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Legacy_Message.md
+++ b/vault_template/KnowledgeVault/_Index/Legacy_Message.md
@@ -14,3 +14,7 @@ Some areas may be marked private.
 Please respect those boundaries.
 
 I created this so that my story, relationships, and experiences would not be lost to time or technology.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Location Index.md
+++ b/vault_template/KnowledgeVault/_Index/Location Index.md
@@ -10,3 +10,7 @@
 ### Colorado
 - Denver
   - [Travel Log – Ski Trip](../01_Notes/...)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Master_Index.md
+++ b/vault_template/KnowledgeVault/_Index/Master_Index.md
@@ -20,3 +20,7 @@ This vault is designed for long-term preservation across decades.
 - Provide the AI access to `_Index/` first
 - Then selectively share topic folders
 - Keep sensitive data encrypted or withheld unless necessary
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Now/Now.md
+++ b/vault_template/KnowledgeVault/_Index/Now/Now.md
@@ -65,3 +65,7 @@ Short-term aims:
 Freeform reflections about this stage of life.
 What feels important right now?
 What feels uncertain?
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Now/README.md
+++ b/vault_template/KnowledgeVault/_Index/Now/README.md
@@ -8,3 +8,7 @@ Purpose:
 - Prevent the vault from being only historical
 
 Update this occasionally — not daily. It’s a high-level “current chapter” view.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Onboarding/Life_Chapters.md
+++ b/vault_template/KnowledgeVault/_Index/Onboarding/Life_Chapters.md
@@ -40,3 +40,7 @@ Short description:
 Focus:
 Ongoing projects:
 Short description:
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Onboarding/START_HERE.md
+++ b/vault_template/KnowledgeVault/_Index/Onboarding/START_HERE.md
@@ -59,3 +59,7 @@ That’s it.
 
 From here, just start logging memories when they happen.
 The system will slowly build around you.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/People_Index.md
+++ b/vault_template/KnowledgeVault/_Index/People_Index.md
@@ -1,1 +1,5 @@
 
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Relationships/Organizations_to_Projects.md
+++ b/vault_template/KnowledgeVault/_Index/Relationships/Organizations_to_Projects.md
@@ -7,3 +7,7 @@ Examples:
 
 [[Dell]] — employer during — [[Austin Career Chapter]]  
 [[Austin High School]] — education period — [[Lily Education Journey]]
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Relationships/People_to_Organizations.md
+++ b/vault_template/KnowledgeVault/_Index/Relationships/People_to_Organizations.md
@@ -8,3 +8,7 @@ Examples:
 Sam — student — [[Austin High School]]  
 Alex — coworker — [[Dell]]  
 Coach Ramirez — coach — [[Austin Youth Soccer]]
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Relationships/People_to_People.md
+++ b/vault_template/KnowledgeVault/_Index/Relationships/People_to_People.md
@@ -9,3 +9,7 @@ Sam — sibling — Lily
 Alex — coworker — Chris (Met at Dell, 2023)  
 Mom — parent — Lily  
 Coach Ramirez — mentor — Sam
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Relationships/People_to_Places.md
+++ b/vault_template/KnowledgeVault/_Index/Relationships/People_to_Places.md
@@ -8,3 +8,7 @@ Examples:
 Sam — grew up in — [[Grandma's House]]  
 Lily — learned to swim at — [[Community Pool]]  
 Alex — works at — [[Dell Austin Campus]]
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Relationships/People_to_Projects.md
+++ b/vault_template/KnowledgeVault/_Index/Relationships/People_to_Projects.md
@@ -8,3 +8,7 @@ Examples:
 Sam — participant — [[Family Europe Trip]]  
 Alex — collaborator — [[Camper Van Build]]  
 Dr. Ramirez — advisor — [[Health Recovery Project]]
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Relationships/Places_to_Projects.md
+++ b/vault_template/KnowledgeVault/_Index/Relationships/Places_to_Projects.md
@@ -7,3 +7,7 @@ Examples:
 
 [[Home Garage]] — build location — [[Camper Van Build]]  
 [[Rocky Mountains]] — travel location — [[Family Europe Trip]]
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Relationships/README.md
+++ b/vault_template/KnowledgeVault/_Index/Relationships/README.md
@@ -8,3 +8,7 @@ Purpose:
 - Preserve continuity of personal history
 
 This is a reference layer — not every connection must be listed here. Focus on meaningful patterns.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Reviews/AI_Review_Triggers.md
+++ b/vault_template/KnowledgeVault/_Index/Reviews/AI_Review_Triggers.md
@@ -12,3 +12,7 @@ AI should:
 - Suggest gently
 - Never auto-edit
 - Accept “not now” without repeated prompting
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Reviews/README.md
+++ b/vault_template/KnowledgeVault/_Index/Reviews/README.md
@@ -9,3 +9,7 @@ Purpose:
 
 Reviews are reminders, not obligations.
 They help maintain continuity over years and decades.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Reviews/Review_Log.md
+++ b/vault_template/KnowledgeVault/_Index/Reviews/Review_Log.md
@@ -16,3 +16,7 @@ Each entry here records when a review occurred and what was updated.
 
 ### Notes
 Felt like a transitional month. Energy improving.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Reviews/Review_Schedule.md
+++ b/vault_template/KnowledgeVault/_Index/Reviews/Review_Schedule.md
@@ -47,3 +47,7 @@ Review yearly
 Purpose:
 - Add summary of major life themes
 - Ensure continuity across years
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Timeline/2026.md
+++ b/vault_template/KnowledgeVault/_Index/Timeline/2026.md
@@ -22,3 +22,7 @@ Short summary of what defined this year.
 
 ## Notes
 Freeform reflections about this year.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Timeline/Life_Timeline.md
+++ b/vault_template/KnowledgeVault/_Index/Timeline/Life_Timeline.md
@@ -27,3 +27,7 @@ This file summarizes major life chapters by year.
 ## 2024
 - First camping season with camper van
 - Increased focus on family travel
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Timeline/README.md
+++ b/vault_template/KnowledgeVault/_Index/Timeline/README.md
@@ -8,3 +8,7 @@ Purpose:
 - Provide a high-level map without reading every memory file
 
 This is a summary layer. It does not replace detailed notes, events, or project files.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Timeline_Index.md
+++ b/vault_template/KnowledgeVault/_Index/Timeline_Index.md
@@ -4,3 +4,7 @@ Add major life / project events here with links.
 
 ## 2026
 - 2026-01-26 — Vault kit initialized (this file)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Index/Topics_Index.md
+++ b/vault_template/KnowledgeVault/_Index/Topics_Index.md
@@ -10,3 +10,7 @@ Create a small section per topic and link to primary notes.
 
 ## Projects
 - (Add links)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_LightMode/Add.md
+++ b/vault_template/KnowledgeVault/_LightMode/Add.md
@@ -15,3 +15,7 @@ Something bigger involving people or places
 ## 🚀 Project Update
 Progress on something ongoing  
 → Open the project file and add notes
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_LightMode/Capture.md
+++ b/vault_template/KnowledgeVault/_LightMode/Capture.md
@@ -48,3 +48,7 @@ AI and future-you will later help:
 - Link to events
 - Add tags
 - Move to the right place
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_LightMode/Explore.md
+++ b/vault_template/KnowledgeVault/_LightMode/Explore.md
@@ -13,3 +13,7 @@ See your life geographically
 
 ## 🚀 Projects
 See your life by what you’ve built and worked toward
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_LightMode/Light_Mode_Dashboard-specification.md
+++ b/vault_template/KnowledgeVault/_LightMode/Light_Mode_Dashboard-specification.md
@@ -182,3 +182,7 @@ The vault can be deep and complex beneath the surface.
 Light Mode ensures the user only sees what needs gentle care — nothing more.
 
 It exists to make long-term continuity sustainable, not burdensome.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_LightMode/START.md
+++ b/vault_template/KnowledgeVault/_LightMode/START.md
@@ -25,3 +25,7 @@ Welcome. You only need these sections most of the time.
 
 ## 🔄 Occasional Maintenance
 - [Review Suggestions](../_Index/Reviews/)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Meta/FORMAT_VERSION.md
+++ b/vault_template/KnowledgeVault/_Meta/FORMAT_VERSION.md
@@ -1,3 +1,7 @@
 KnowledgeVault Format Version: 0.2.0
 Compatible With: 0.1.x+
 Last Structural Change: YYYY-MM-DD
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Meta/link_integrity.md
+++ b/vault_template/KnowledgeVault/_Meta/link_integrity.md
@@ -8,3 +8,7 @@ These links are known-good navigation anchors.
 - [Genesis Entry](../01_Notes/2026-01-26%20Vault%20–%20KnowledgeVault%20System%20Initialized.md)
 
 If any of these fail to open, the vault structure may have been altered.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/AI_Access_Policy.md
+++ b/vault_template/KnowledgeVault/_Policy/AI_Access_Policy.md
@@ -17,3 +17,7 @@ When you share documents with AI, record:
 - when
 - purpose
 in a note under `01_Notes/` (optional)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/AI_Ingestion_Behavior.md
+++ b/vault_template/KnowledgeVault/_Policy/AI_Ingestion_Behavior.md
@@ -219,3 +219,7 @@ It organizes information — it does not interpret identity.
 This specification ensures that **any future AI system** can safely assist with KnowledgeVault organization using open formats and human oversight.
 
 No proprietary AI platform is required for compliance.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/AI_Review_Prompt_Behavior.md
+++ b/vault_template/KnowledgeVault/_Policy/AI_Review_Prompt_Behavior.md
@@ -157,3 +157,7 @@ No app-specific notification system is required.
 If uncertainty exists about whether a prompt is appropriate:
 
 **The AI should remain silent.**
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/AI_Suggestion_Approval_Mechanism.md
+++ b/vault_template/KnowledgeVault/_Policy/AI_Suggestion_Approval_Mechanism.md
@@ -175,3 +175,7 @@ If any rule is unclear, the system must default to:
 **Do nothing and request human input.**
 
 Safety is always preferred over automation.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/Data_Sharing_Policy.md
+++ b/vault_template/KnowledgeVault/_Policy/Data_Sharing_Policy.md
@@ -88,3 +88,7 @@ Keep notes here about any audits, disputes, or questions:
 ---
 
 Last updated: (fill in date)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/Intake_Workflow.md
+++ b/vault_template/KnowledgeVault/_Policy/Intake_Workflow.md
@@ -15,3 +15,7 @@ When editing Markdown files on iOS, open them from a text editor app rather than
 ## Monthly maintenance (10 min)
 - Export any app-locked notes into Markdown/PDF and store in `01_Notes/`
 - Mirror vault to secondary cloud (optional)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/Legacy_and_Export.md
+++ b/vault_template/KnowledgeVault/_Policy/Legacy_and_Export.md
@@ -83,3 +83,7 @@ Future AI systems can read:
 - Narrative notes
 
 The vault is designed to be a **portable life knowledge graph**.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/Naming_Standard.md
+++ b/vault_template/KnowledgeVault/_Policy/Naming_Standard.md
@@ -11,3 +11,7 @@ Why:
 - Sorts chronologically everywhere
 - Survives every platform and app
 - Enables timeline reconstruction decades later
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/Retention_and_Preservation.md
+++ b/vault_template/KnowledgeVault/_Policy/Retention_and_Preservation.md
@@ -11,3 +11,7 @@ Quarterly:
 
 Yearly:
 - Create a “year snapshot” export for long-term cold storage
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/Tag_Dictionary.md
+++ b/vault_template/KnowledgeVault/_Policy/Tag_Dictionary.md
@@ -125,3 +125,7 @@ AI systems should:
 - Prefer existing tags over creating new ones
 - Suggest tags from this dictionary when patterns are detected
 - Avoid inventing new namespaces without user approval
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/Vault_Evolution_Vault_Migration.md
+++ b/vault_template/KnowledgeVault/_Policy/Vault_Evolution_Vault_Migration.md
@@ -148,3 +148,7 @@ KnowledgeVault should remain:
 
 Frameworks evolve.  
 Memories endure.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Policy/Vault_Health_Check.md
+++ b/vault_template/KnowledgeVault/_Policy/Vault_Health_Check.md
@@ -17,3 +17,7 @@ Use this checklist when moving the vault to a new device or platform.
 - No files rely on proprietary formats
 
 If these pass, the vault is structurally sound.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_System/Guides/KNOWLEDGEVAULT_BACKUP_EXPORT_GUIDE.md
+++ b/vault_template/KnowledgeVault/_System/Guides/KNOWLEDGEVAULT_BACKUP_EXPORT_GUIDE.md
@@ -121,3 +121,7 @@ GitHub protects the **framework**.
 
 You can rebuild structure.  
 You cannot recreate lost memories.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/ChatGPT/ChatGPT Conversation Template.md
+++ b/vault_template/KnowledgeVault/_Templates/ChatGPT/ChatGPT Conversation Template.md
@@ -25,3 +25,7 @@ Model:
 ## Conversation
 
 (Paste conversation transcript below)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Day Log.md
+++ b/vault_template/KnowledgeVault/_Templates/Day Log.md
@@ -89,3 +89,7 @@ Example:
 Attended energy conference. Met Alex Martinez. Discussed possible solar project.
 
 This section helps future-you quickly recall why this day is significant.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Emotional State.md
+++ b/vault_template/KnowledgeVault/_Templates/Emotional State.md
@@ -75,3 +75,7 @@ Rest, conversation, nature, music, progress on a task?
 ## 🔮 What Future-You Should Know
 
 If you read this years later, what would help you understand this moment?
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Event_Template.md
+++ b/vault_template/KnowledgeVault/_Templates/Event_Template.md
@@ -25,3 +25,7 @@ Event Type: {{EVENT_TYPE}}
 ## Follow-ups (optional)
 - {{FOLLOWUP_1}}
 - {{FOLLOWUP_2}}
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Life Event.md
+++ b/vault_template/KnowledgeVault/_Templates/Life Event.md
@@ -59,3 +59,7 @@ One paragraph for your future self:
 - What mattered
 - What you learned
 - What you wish you’d remembered
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Log_Event_Template.md
+++ b/vault_template/KnowledgeVault/_Templates/Log_Event_Template.md
@@ -22,3 +22,7 @@ Event Type: {{EVENT_TYPE}}
 
 ## Follow-up / Outcome (optional)
 {{FOLLOWUP}}
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Media Highlight.md
+++ b/vault_template/KnowledgeVault/_Templates/Media Highlight.md
@@ -33,3 +33,7 @@ Suggested location:
 - People Notes:
 - Travel Log:
 - Emotional Snapshot:
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Notes/Note Template.md
+++ b/vault_template/KnowledgeVault/_Templates/Notes/Note Template.md
@@ -13,3 +13,7 @@ Related:
 ## References
 
 ## Follow-up
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/People Note.md
+++ b/vault_template/KnowledgeVault/_Templates/People Note.md
@@ -75,3 +75,7 @@ Search using:
 This note exists to help future-you say:
 
 > “Ohhh right, that’s who that was.”
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Playlist Export.md
+++ b/vault_template/KnowledgeVault/_Templates/Playlist Export.md
@@ -71,3 +71,7 @@ Comforting, nostalgic, hopeful, healing, energizing…
 - People Notes:
 - Day Logs:
 - Life Events:
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Projects/Project Log Template.md
+++ b/vault_template/KnowledgeVault/_Templates/Projects/Project Log Template.md
@@ -12,3 +12,7 @@ Project:
 ## Issues
 
 ## Next Steps
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/README.md
+++ b/vault_template/KnowledgeVault/_Templates/README.md
@@ -25,3 +25,7 @@ For conversation continuity, see:
 
 - `docs/CONVERSATION_CONTINUITY.md`
 - `docs/examples/Reload_Packet_Example.md`
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Records/Record Summary Template.md
+++ b/vault_template/KnowledgeVault/_Templates/Records/Record Summary Template.md
@@ -14,3 +14,7 @@ Related Person/Org:
 
 ## Linked File
 (Place link to the PDF or image in 03_Records/)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Research/Research Note Template.md
+++ b/vault_template/KnowledgeVault/_Templates/Research/Research Note Template.md
@@ -14,3 +14,7 @@ Topic:
 ## My Interpretation
 
 ## Related Files
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Scent Memory.md
+++ b/vault_template/KnowledgeVault/_Templates/Scent Memory.md
@@ -60,3 +60,7 @@ Who you associate this scent with:
 ## 🌱 Why This Matters
 
 What future-you might want to remember about this sensory moment.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Sight Memory.md
+++ b/vault_template/KnowledgeVault/_Templates/Sight Memory.md
@@ -35,3 +35,7 @@ Photos or videos connected to this moment.
 ---
 
 ## 🔗 Related Notes
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Song Moment.md
+++ b/vault_template/KnowledgeVault/_Templates/Song Moment.md
@@ -7,3 +7,7 @@
 - Why it stuck:
 
 Link to: `04_Media/Audio/song_log.csv` (row timestamp)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Sound Memory.md
+++ b/vault_template/KnowledgeVault/_Templates/Sound Memory.md
@@ -28,3 +28,7 @@ Ocean waves at night, a child’s laugh, a train in the distance, hospital monit
 ---
 
 ## 🔗 Related Notes
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Special Media.md
+++ b/vault_template/KnowledgeVault/_Templates/Special Media.md
@@ -50,3 +50,7 @@ Filename(s):
 
 How this moment felt:
 What stage of life this represents:
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Taste Memory.md
+++ b/vault_template/KnowledgeVault/_Templates/Taste Memory.md
@@ -28,3 +28,7 @@ Grandma’s soup, campfire marshmallows, hospital cafeteria coffee.
 ---
 
 ## 🔗 Related Notes
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Touch Memory.md
+++ b/vault_template/KnowledgeVault/_Templates/Touch Memory.md
@@ -28,3 +28,7 @@ Cold metal railing, warm sand, a child’s tiny hand, rough tree bark.
 ---
 
 ## 🔗 Related Notes
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Travel Log.md
+++ b/vault_template/KnowledgeVault/_Templates/Travel Log.md
@@ -73,3 +73,7 @@ Suggested location:
 ## 🔮 Future Value
 
 Why this trip might matter later:
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_Templates/Writing Piece.md
+++ b/vault_template/KnowledgeVault/_Templates/Writing Piece.md
@@ -57,3 +57,7 @@ Where it might be used:
 ## 📄 Main Text
 
 (Place the writing here or link to the primary file location.)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_migration/Format_Policy.md
+++ b/vault_template/KnowledgeVault/_migration/Format_Policy.md
@@ -13,3 +13,7 @@ Preferred formats:
 | Audio | .wav, .mp3 | .flac | app-only formats |
 
 If a format becomes obsolete, convert to the preferred format and record the change in `Migration_Log.md`.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_migration/Migration_Log.md
+++ b/vault_template/KnowledgeVault/_migration/Migration_Log.md
@@ -5,3 +5,7 @@ Converted older .pages documents to PDF/A due to Apple Pages format changes.
 
 ## 2038-11-02
 Batch converted HEIC images to JPG for broader compatibility.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_migration/README.md
+++ b/vault_template/KnowledgeVault/_migration/README.md
@@ -48,3 +48,7 @@ Release checksums prove package integrity only. They do not prove that a migrati
 ## Current state
 
 No structural migration is required between the currently documented `0.1.x` releases. When a future release changes the vault format, its migration file must be added here before that release is tagged.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/docs/ZRE_COMPATIBILITY.md
+++ b/vault_template/KnowledgeVault/docs/ZRE_COMPATIBILITY.md
@@ -15,3 +15,7 @@ Compatibility must NOT:
 - produce deterministic “scores” as truth
 - claim outcomes (e.g., “this will fail/succeed”)
 - be presented as advice or fate
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/docs/ZRE_DAILY_REFLECTION_GENERATOR_SPEC.md
+++ b/vault_template/KnowledgeVault/docs/ZRE_DAILY_REFLECTION_GENERATOR_SPEC.md
@@ -37,3 +37,7 @@ The generator must avoid:
 - predictions
 - medical/legal/financial advice
 - deterministic personality claims
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/docs/ZRE_Overview.md
+++ b/vault_template/KnowledgeVault/docs/ZRE_Overview.md
@@ -16,3 +16,7 @@ No raw birth date/time/location is required once the translated profile exists.
 ## ZRE Recompute (Rare)
 Requires explicit user permission to access raw birth data in order to regenerate the translated profile.
 This is never automatic.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/docs/ZRE_Privacy_and_Consent.md
+++ b/vault_template/KnowledgeVault/docs/ZRE_Privacy_and_Consent.md
@@ -28,3 +28,7 @@ This file determines:
 - which mode runs (lite/enhanced/off)
 - whether translated profile may be used
 - frequency (daily/weekly/seasonal)
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/docs/ZRE_SHARECARD_EXCHANGE_FLOW.md
+++ b/vault_template/KnowledgeVault/docs/ZRE_SHARECARD_EXCHANGE_FLOW.md
@@ -26,3 +26,7 @@ Each person produces a share card:
 - ShareCard contains no DOB/time/location.
 - Users should only share what they are comfortable with.
 - You may optionally omit moon/rising for additional privacy.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/docs/_Policy/ZRE_BEHAVIOR.md
+++ b/vault_template/KnowledgeVault/docs/_Policy/ZRE_BEHAVIOR.md
@@ -16,3 +16,7 @@ ZRE provides symbolic reflection prompts only.
 ## Required Disclaimer
 Every output must include:
 > Symbolic reflection only — not predictions, diagnosis, or advice.
+
+---
+
+🔒 Layer: Vault Template | KV


### PR DESCRIPTION
## Purpose
Activate the dedicated `format/**` lane so repository Markdown receives canonical layer footers without manual file-by-file editing.

## Expected automation
`KV Format Branch (Auto-footer)` should run on this branch, apply:

- `🔒 Layer: Framework | KV` to framework Markdown;
- `🔒 Layer: Vault Template | KV` to vault-template Markdown;

and commit the normalized files back to this branch. The ordinary KV guardrail workflow then validates the resulting PR without moving, deleting, or inspecting user-authored personal vault content.

## Follow-on gate
After this PR is green and merged, enable `.stegdb/kv-layer.v1.json` `markdown_footer.required: true` in a small successor PR.
