### PR TITLE
Add production provider activation profile

### DIFF
--- a/docs/PRODUCTION_PROVIDER_ACTIVATION.md
+++ b/docs/PRODUCTION_PROVIDER_ACTIVATION.md
@@ -1,0 +1,57 @@
+# Production Provider Activation
+
+## Selected staging profile
+
+The first concrete activation profile uses:
+
+- **StegID signature verification:** AWS KMS asymmetric `Verify` with a dedicated customer-managed signing key.
+- **AI-entity attestation:** SPIFFE/SPIRE X.509-SVID workload identity for the designated StegVerse AI entity.
+- **Key custody:** AWS KMS customer-managed keys, with separate key policy, wrapping context, rotation, disablement, and scheduled deletion procedures.
+- **Replicated state:** Amazon DynamoDB conditional writes implementing exact prior-version comparison and one-version advancement.
+- **Ecosystem Chat transport:** the StegVerse authenticated chat endpoint, identity still unconfigured.
+- **Master-Records:** the StegVerse receipt-ingestion endpoint, identity still unconfigured.
+
+Selection does not equal activation. `default_aws_profile()` intentionally uses `UNCONFIGURED` identity references and cannot return activation-ready status.
+
+## Activation gates
+
+Every provider must progress independently through:
+
+1. `selected` — technology and service chosen;
+2. `configured` — resource and endpoint identity recorded;
+3. `verified` — conformance test and evidence commitment recorded;
+4. `revoked` — provider identity is no longer admissible.
+
+Production activation requires all six providers to be `verified`, a green repository validation commit, and a deployment receipt containing one evidence commitment per provider.
+
+## Evidence boundaries
+
+Deployment receipts retain provider identity references and evidence commitments. They must not include raw chat, queries, reconstructed plaintext, unwrapped data keys, signing private keys, bearer credentials, or attestation secrets.
+
+## Rollback and revocation
+
+A bounded rollback must:
+
+1. fail closed for new reconstruction sessions;
+2. revoke the affected provider identity or relationship epoch;
+3. disable key release before changing transport or storage routing;
+4. preserve pending Master-Records exports until acknowledged, superseded, or explicitly deprecated;
+5. restore the last verified activation profile only through a new deployment receipt;
+6. record the failed profile hash, reason, authority, and validation commit;
+7. never reactivate tombstoned protected objects or exhausted capabilities.
+
+Key destruction is a custody operation, not a state-label change. Scheduled deletion must be independently confirmed before an erasure receipt can claim loss of recoverability.
+
+## Remaining external inputs
+
+The following values cannot be produced safely inside the repository:
+
+- actual AWS account, KMS key, and DynamoDB table identifiers;
+- SPIFFE trust domain, SPIRE server identity, and workload selectors;
+- Ecosystem Chat endpoint identity and transport verifier configuration;
+- Master-Records endpoint identity and acknowledgement verifier configuration;
+- secrets, credentials, hardware custody evidence, and production network access.
+
+---
+
+🔒 Layer: Framework | KV

--- a/reconstructive_memory/__init__.py
+++ b/reconstructive_memory/__init__.py
@@ -4,7 +4,8 @@ This package is dependency-free and prototype-scoped. It models minimal
 continuity, pair-bound authorization, authenticated minimized ingestion, bounded
 ephemeral reconstruction, durable replay controls, lifecycle tombstones,
 plaintext-free journals, authoritative commit boundaries, receipt propagation,
-and deployment adapter contracts without storing plaintext chat in the chain.
+deployment adapter contracts, and provider activation receipts without storing
+plaintext chat in the chain.
 """
 
 from .access import AccessReceipt, CallableKeyUnwrapper, KeyUnwrapper, RelationshipRegistry, RelationshipState, make_access_receipt
@@ -17,6 +18,7 @@ from .lifecycle import CapabilityGrant, ObjectLifecycleRegistry, ObjectLifecycle
 from .master_records import MasterRecordAcknowledgement, MasterRecordEnvelope, MasterRecordsOutbox, MasterRecordsVerifier
 from .master_records_state import DurableMasterRecordsOutbox, InMemoryMasterRecordsStateStore, MasterRecordsEntry, MasterRecordsState, MasterRecordsStateStore
 from .proofs import CallableProofVerifier, ProofVerifier, require_dual_proof
+from .provider_activation import DeploymentReceipt, ProductionActivationProfile, ProviderSelection, default_aws_profile
 from .replay import DurableTransportReplayRegistry, InMemoryReplayStateStore, ReplayState, ReplayStateStore
 from .routing import OpaqueRouteEntry, OpaqueRouteIndex, validate_candidate_events
 from .session import ReconstructionSessionCoordinator, ReconstructionSessionResult

--- a/reconstructive_memory/provider_activation.py
+++ b/reconstructive_memory/provider_activation.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from hashlib import sha256
+import hmac
+import json
+from typing import Mapping
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _digest(value: object) -> str:
+    return "sha256:" + sha256(_canonical(value)).hexdigest()
+
+
+@dataclass(frozen=True)
+class ProviderSelection:
+    role: str
+    provider: str
+    service: str
+    identity_ref: str
+    region: str
+    status: str = "selected"
+
+    def verify(self) -> None:
+        if self.status not in {"selected", "configured", "verified", "revoked"}:
+            raise ValueError("unsupported provider status")
+        if not all((self.role, self.provider, self.service, self.identity_ref, self.region)):
+            raise ValueError("provider selection is incomplete")
+
+
+@dataclass(frozen=True)
+class ProductionActivationProfile:
+    profile_id: str
+    environment: str
+    steg_id: ProviderSelection
+    ai_attestation: ProviderSelection
+    key_custody: ProviderSelection
+    state_store: ProviderSelection
+    chat_transport: ProviderSelection
+    master_records: ProviderSelection
+    rollback_ref: str
+    created_at: int
+    profile_hash: str = ""
+
+    def payload(self) -> Mapping[str, object]:
+        return {
+            "profile_id": self.profile_id,
+            "environment": self.environment,
+            "providers": {
+                key: vars(value)
+                for key, value in {
+                    "steg_id": self.steg_id,
+                    "ai_attestation": self.ai_attestation,
+                    "key_custody": self.key_custody,
+                    "state_store": self.state_store,
+                    "chat_transport": self.chat_transport,
+                    "master_records": self.master_records,
+                }.items()
+            },
+            "rollback_ref": self.rollback_ref,
+            "created_at": self.created_at,
+        }
+
+    def with_hash(self) -> "ProductionActivationProfile":
+        return replace(self, profile_hash=_digest(self.payload()))
+
+    def verify(self) -> None:
+        if self.environment not in {"development", "staging", "production"}:
+            raise ValueError("unsupported activation environment")
+        if not self.profile_id or not self.rollback_ref or self.created_at < 1:
+            raise ValueError("activation profile identity is incomplete")
+        for selection in (
+            self.steg_id,
+            self.ai_attestation,
+            self.key_custody,
+            self.state_store,
+            self.chat_transport,
+            self.master_records,
+        ):
+            selection.verify()
+        expected = _digest(self.payload())
+        if not self.profile_hash or not hmac.compare_digest(self.profile_hash, expected):
+            raise ValueError("activation profile hash mismatch")
+
+    def activation_ready(self) -> bool:
+        self.verify()
+        return all(
+            selection.status == "verified"
+            for selection in (
+                self.steg_id,
+                self.ai_attestation,
+                self.key_custody,
+                self.state_store,
+                self.chat_transport,
+                self.master_records,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class DeploymentReceipt:
+    receipt_id: str
+    profile_hash: str
+    validation_commit: str
+    rollback_ref: str
+    provider_evidence: Mapping[str, str]
+    issued_at: int
+    decision: str
+    receipt_hash: str = ""
+
+    def payload(self) -> Mapping[str, object]:
+        return {
+            "receipt_id": self.receipt_id,
+            "profile_hash": self.profile_hash,
+            "validation_commit": self.validation_commit,
+            "rollback_ref": self.rollback_ref,
+            "provider_evidence": dict(sorted(self.provider_evidence.items())),
+            "issued_at": self.issued_at,
+            "decision": self.decision,
+        }
+
+    def with_hash(self) -> "DeploymentReceipt":
+        return replace(self, receipt_hash=_digest(self.payload()))
+
+    def verify(self) -> None:
+        if self.decision not in {"ALLOW", "DENY", "FAIL_CLOSED"}:
+            raise ValueError("unsupported deployment decision")
+        if not self.receipt_id or not self.profile_hash or not self.validation_commit or not self.rollback_ref:
+            raise ValueError("deployment receipt is incomplete")
+        if self.issued_at < 1 or len(self.provider_evidence) != 6:
+            raise ValueError("deployment receipt evidence is incomplete")
+        expected = _digest(self.payload())
+        if not self.receipt_hash or not hmac.compare_digest(self.receipt_hash, expected):
+            raise ValueError("deployment receipt hash mismatch")
+
+
+def default_aws_profile(*, created_at: int) -> ProductionActivationProfile:
+    """Concrete provider selection. Resource identifiers remain placeholders until provisioned."""
+    return ProductionActivationProfile(
+        profile_id="reconstructive-memory-aws-v1",
+        environment="staging",
+        steg_id=ProviderSelection("steg-id-signature", "AWS", "KMS asymmetric verify", "kms-key-arn:UNCONFIGURED", "us-east-1"),
+        ai_attestation=ProviderSelection("ai-entity-attestation", "SPIFFE", "SPIRE X.509-SVID", "spiffe-id:UNCONFIGURED", "global"),
+        key_custody=ProviderSelection("key-custody", "AWS", "KMS customer-managed key", "kms-key-arn:UNCONFIGURED", "us-east-1"),
+        state_store=ProviderSelection("replicated-state", "AWS", "DynamoDB conditional write", "table-arn:UNCONFIGURED", "us-east-1"),
+        chat_transport=ProviderSelection("ecosystem-chat", "StegVerse", "authenticated chat endpoint", "endpoint:UNCONFIGURED", "global"),
+        master_records=ProviderSelection("master-records", "StegVerse", "receipt ingestion endpoint", "endpoint:UNCONFIGURED", "global"),
+        rollback_ref="docs/PRODUCTION_PROVIDER_ACTIVATION.md#rollback-and-revocation",
+        created_at=created_at,
+    ).with_hash()

--- a/tests/test_reconstructive_memory_provider_activation.py
+++ b/tests/test_reconstructive_memory_provider_activation.py
@@ -1,0 +1,71 @@
+import unittest
+
+from reconstructive_memory.provider_activation import (
+    DeploymentReceipt,
+    ProviderSelection,
+    ProductionActivationProfile,
+    default_aws_profile,
+)
+
+
+class ProviderActivationTests(unittest.TestCase):
+    def test_default_profile_is_selected_not_ready(self):
+        profile = default_aws_profile(created_at=1)
+        profile.verify()
+        self.assertFalse(profile.activation_ready())
+        self.assertIn("UNCONFIGURED", profile.steg_id.identity_ref)
+
+    def test_verified_profile_is_activation_ready(self):
+        selected = default_aws_profile(created_at=2)
+        verified = ProductionActivationProfile(
+            profile_id=selected.profile_id,
+            environment="production",
+            steg_id=ProviderSelection("steg-id-signature", "AWS", "KMS asymmetric verify", "arn:kms:steg-id", "us-east-1", "verified"),
+            ai_attestation=ProviderSelection("ai-entity-attestation", "SPIFFE", "SPIRE X.509-SVID", "spiffe://stegverse/ai/auri", "global", "verified"),
+            key_custody=ProviderSelection("key-custody", "AWS", "KMS customer-managed key", "arn:kms:vault", "us-east-1", "verified"),
+            state_store=ProviderSelection("replicated-state", "AWS", "DynamoDB conditional write", "arn:dynamodb:table/state", "us-east-1", "verified"),
+            chat_transport=ProviderSelection("ecosystem-chat", "StegVerse", "authenticated chat endpoint", "https://chat.example", "global", "verified"),
+            master_records=ProviderSelection("master-records", "StegVerse", "receipt ingestion endpoint", "https://records.example", "global", "verified"),
+            rollback_ref=selected.rollback_ref,
+            created_at=2,
+        ).with_hash()
+        self.assertTrue(verified.activation_ready())
+
+    def test_tampered_profile_fails(self):
+        profile = default_aws_profile(created_at=3)
+        tampered = ProductionActivationProfile(**{**profile.__dict__, "environment": "production"})
+        with self.assertRaises(ValueError):
+            tampered.verify()
+
+    def test_receipt_requires_all_provider_evidence(self):
+        receipt = DeploymentReceipt(
+            receipt_id="deploy-1",
+            profile_hash="sha256:profile",
+            validation_commit="abc123",
+            rollback_ref="docs/rollback",
+            provider_evidence={"only": "one"},
+            issued_at=4,
+            decision="ALLOW",
+        ).with_hash()
+        with self.assertRaises(ValueError):
+            receipt.verify()
+
+    def test_complete_receipt_verifies_without_plaintext(self):
+        evidence = {name: f"sha256:{name}" for name in (
+            "steg_id", "ai_attestation", "key_custody", "state_store", "chat_transport", "master_records"
+        )}
+        receipt = DeploymentReceipt(
+            receipt_id="deploy-2",
+            profile_hash="sha256:profile",
+            validation_commit="def456",
+            rollback_ref="docs/rollback",
+            provider_evidence=evidence,
+            issued_at=5,
+            decision="FAIL_CLOSED",
+        ).with_hash()
+        receipt.verify()
+        self.assertNotIn("plaintext", str(receipt.payload()).lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_reconstructive_memory.py
+++ b/tools/check_reconstructive_memory.py
@@ -23,12 +23,14 @@ REQUIRED = (
     ROOT / "reconstructive_memory" / "master_records.py",
     ROOT / "reconstructive_memory" / "master_records_state.py",
     ROOT / "reconstructive_memory" / "deployment.py",
+    ROOT / "reconstructive_memory" / "provider_activation.py",
     ROOT / "schemas" / "reconstructive-memory-event.v0.1.json",
     ROOT / "schemas" / "reconstructive-memory-access-receipt.v0.1.json",
     ROOT / "docs" / "RECONSTRUCTIVE_AI_MEMORY.md",
+    ROOT / "docs" / "PRODUCTION_PROVIDER_ACTIVATION.md",
 )
 
-SCHEMAS = REQUIRED[14:16]
+SCHEMAS = REQUIRED[15:17]
 
 
 def fail(message: str) -> None:
@@ -67,8 +69,8 @@ def main() -> int:
     print("- authoritative receipt/capability commit boundary: present")
     print("- durable Master-Records outbox lifecycle: present")
     print("- external CAS store and delivery adapter contracts: present")
-    print("- concrete production signature suite: NOT CLAIMED")
-    print("- deployed Ecosystem Chat transport integration: NOT CLAIMED")
+    print("- concrete provider selection and deployment receipt gate: present")
+    print("- external resource identifiers and credentials: UNCONFIGURED")
     return 0
 
 


### PR DESCRIPTION
## Purpose

Advance issue #16 by selecting concrete production-provider technologies and adding a fail-closed activation profile and deployment-receipt gate.

## Selected profile

- StegID verification: AWS KMS asymmetric Verify
- AI-entity attestation: SPIFFE/SPIRE X.509-SVID
- Key custody: AWS KMS customer-managed keys
- Replicated state: Amazon DynamoDB conditional writes
- Ecosystem Chat: StegVerse authenticated endpoint, identity unconfigured
- Master-Records: StegVerse receipt endpoint, identity unconfigured

## Behavior

- provider states progress through selected, configured, verified, or revoked;
- activation requires all six providers to be verified;
- default resource identifiers remain visibly UNCONFIGURED;
- deployment receipts require one evidence commitment for every provider;
- profile and receipt tampering fail integrity verification;
- rollback and revocation rules preserve tombstones, exhausted capabilities, pending exports, and fail-closed reconstruction.

## Validation

`python3 tools/check_reconstructive_memory.py`

Closes no external activation claim. Real account identifiers, keys, endpoints, credentials, hardware evidence, integration tests, and deployment receipts remain required by issue #16.