### PR TITLE
Add fail-closed production provider readiness gate

### DIFF
--- a/.github/workflows/provider-readiness.yml
+++ b/.github/workflows/provider-readiness.yml
@@ -1,0 +1,50 @@
+name: Production Provider Readiness
+
+on:
+  pull_request:
+    paths:
+      - "config/production-provider-profile*.json"
+      - "reconstructive_memory/readiness.py"
+      - "tests/test_reconstructive_memory_readiness.py"
+      - "tools/check_provider_readiness.py"
+      - ".github/workflows/provider-readiness.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "config/production-provider-profile*.json"
+      - "reconstructive_memory/readiness.py"
+      - "tests/test_reconstructive_memory_readiness.py"
+      - "tools/check_provider_readiness.py"
+      - ".github/workflows/provider-readiness.yml"
+  workflow_dispatch:
+    inputs:
+      profile_path:
+        description: Repository path to a configured provider profile
+        required: false
+        default: config/production-provider-profile.template.json
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Compile readiness boundary
+        run: python3 -m compileall -q reconstructive_memory/readiness.py tools/check_provider_readiness.py tests/test_reconstructive_memory_readiness.py
+      - name: Run readiness tests
+        run: python3 -m unittest tests.test_reconstructive_memory_readiness
+      - name: Confirm template remains fail-closed
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          set +e
+          python3 tools/check_provider_readiness.py config/production-provider-profile.template.json
+          code=$?
+          test "$code" -eq 1
+      - name: Validate requested profile
+        if: github.event_name == 'workflow_dispatch'
+        run: python3 tools/check_provider_readiness.py "${{ inputs.profile_path }}"

--- a/config/production-provider-profile.template.json
+++ b/config/production-provider-profile.template.json
@@ -1,0 +1,45 @@
+{
+  "environment": "staging",
+  "providers": {
+    "stegid_verify": {
+      "technology": "aws-kms-asymmetric-verify",
+      "resource_id": "UNCONFIGURED",
+      "region": "UNCONFIGURED",
+      "evidence_commitment": "UNCONFIGURED"
+    },
+    "ai_entity_attestation": {
+      "technology": "spiffe-spire-x509-svid",
+      "resource_id": "UNCONFIGURED",
+      "trust_domain": "UNCONFIGURED",
+      "evidence_commitment": "UNCONFIGURED"
+    },
+    "key_custody": {
+      "technology": "aws-kms-customer-managed-key",
+      "resource_id": "UNCONFIGURED",
+      "region": "UNCONFIGURED",
+      "evidence_commitment": "UNCONFIGURED"
+    },
+    "authoritative_state": {
+      "technology": "amazon-dynamodb-conditional-writes",
+      "resource_id": "UNCONFIGURED",
+      "region": "UNCONFIGURED",
+      "evidence_commitment": "UNCONFIGURED"
+    },
+    "ecosystem_chat": {
+      "technology": "stegverse-authenticated-https",
+      "resource_id": "UNCONFIGURED",
+      "endpoint": "UNCONFIGURED",
+      "evidence_commitment": "UNCONFIGURED"
+    },
+    "master_records": {
+      "technology": "stegverse-receipt-ingestion-https",
+      "resource_id": "UNCONFIGURED",
+      "endpoint": "UNCONFIGURED",
+      "evidence_commitment": "UNCONFIGURED"
+    }
+  },
+  "rollback": {
+    "procedure_ref": "UNCONFIGURED",
+    "revocation_receipt_ref": "UNCONFIGURED"
+  }
+}

--- a/reconstructive_memory/__init__.py
+++ b/reconstructive_memory/__init__.py
@@ -4,8 +4,8 @@ This package is dependency-free and prototype-scoped. It models minimal
 continuity, pair-bound authorization, authenticated minimized ingestion, bounded
 ephemeral reconstruction, durable replay controls, lifecycle tombstones,
 plaintext-free journals, authoritative commit boundaries, receipt propagation,
-deployment adapter contracts, and provider activation receipts without storing
-plaintext chat in the chain.
+deployment adapter contracts, provider activation receipts, and fail-closed
+provider readiness without storing plaintext chat in the chain.
 """
 
 from .access import AccessReceipt, CallableKeyUnwrapper, KeyUnwrapper, RelationshipRegistry, RelationshipState, make_access_receipt
@@ -19,6 +19,7 @@ from .master_records import MasterRecordAcknowledgement, MasterRecordEnvelope, M
 from .master_records_state import DurableMasterRecordsOutbox, InMemoryMasterRecordsStateStore, MasterRecordsEntry, MasterRecordsState, MasterRecordsStateStore
 from .proofs import CallableProofVerifier, ProofVerifier, require_dual_proof
 from .provider_activation import DeploymentReceipt, ProductionActivationProfile, ProviderSelection, default_aws_profile
+from .readiness import REQUIRED_PROVIDERS, ReadinessReport, load_and_validate, validate_provider_profile
 from .replay import DurableTransportReplayRegistry, InMemoryReplayStateStore, ReplayState, ReplayStateStore
 from .routing import OpaqueRouteEntry, OpaqueRouteIndex, validate_candidate_events
 from .session import ReconstructionSessionCoordinator, ReconstructionSessionResult

--- a/reconstructive_memory/readiness.py
+++ b/reconstructive_memory/readiness.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+from pathlib import Path
+from typing import Mapping
+from urllib.parse import urlparse
+
+
+REQUIRED_PROVIDERS = (
+    "stegid_verify",
+    "ai_entity_attestation",
+    "key_custody",
+    "authoritative_state",
+    "ecosystem_chat",
+    "master_records",
+)
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _commitment(value: object) -> str:
+    return "sha256:" + sha256(_canonical(value)).hexdigest()
+
+
+def _configured(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip()) and value != "UNCONFIGURED"
+
+
+@dataclass(frozen=True)
+class ReadinessReport:
+    environment: str
+    ready: bool
+    failures: tuple[str, ...]
+    profile_commitment: str
+
+    def payload(self) -> Mapping[str, object]:
+        return {
+            "environment": self.environment,
+            "ready": self.ready,
+            "failures": list(self.failures),
+            "profile_commitment": self.profile_commitment,
+        }
+
+
+def validate_provider_profile(profile: Mapping[str, object]) -> ReadinessReport:
+    failures: list[str] = []
+    environment = str(profile.get("environment", ""))
+    if environment not in {"staging", "production"}:
+        failures.append("environment must be staging or production")
+
+    providers = profile.get("providers")
+    if not isinstance(providers, Mapping):
+        providers = {}
+        failures.append("providers object is required")
+
+    for name in REQUIRED_PROVIDERS:
+        provider = providers.get(name)
+        if not isinstance(provider, Mapping):
+            failures.append(f"provider missing: {name}")
+            continue
+        for field in ("technology", "resource_id", "evidence_commitment"):
+            if not _configured(provider.get(field)):
+                failures.append(f"{name}.{field} is unconfigured")
+        if name in {"stegid_verify", "key_custody", "authoritative_state"} and not _configured(provider.get("region")):
+            failures.append(f"{name}.region is unconfigured")
+        if name == "ai_entity_attestation" and not _configured(provider.get("trust_domain")):
+            failures.append("ai_entity_attestation.trust_domain is unconfigured")
+        if name in {"ecosystem_chat", "master_records"}:
+            endpoint = provider.get("endpoint")
+            if not _configured(endpoint):
+                failures.append(f"{name}.endpoint is unconfigured")
+            else:
+                parsed = urlparse(str(endpoint))
+                if parsed.scheme != "https" or not parsed.netloc:
+                    failures.append(f"{name}.endpoint must be an absolute HTTPS URL")
+
+    rollback = profile.get("rollback")
+    if not isinstance(rollback, Mapping):
+        failures.append("rollback object is required")
+    else:
+        for field in ("procedure_ref", "revocation_receipt_ref"):
+            if not _configured(rollback.get(field)):
+                failures.append(f"rollback.{field} is unconfigured")
+
+    return ReadinessReport(
+        environment=environment,
+        ready=not failures,
+        failures=tuple(failures),
+        profile_commitment=_commitment(profile),
+    )
+
+
+def load_and_validate(path: str | Path) -> ReadinessReport:
+    profile = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(profile, Mapping):
+        raise ValueError("provider profile must be a JSON object")
+    return validate_provider_profile(profile)

--- a/tests/test_reconstructive_memory_readiness.py
+++ b/tests/test_reconstructive_memory_readiness.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import unittest
+
+from reconstructive_memory.readiness import validate_provider_profile
+
+
+class ProviderReadinessTests(unittest.TestCase):
+    def complete_profile(self):
+        return {
+            "environment": "staging",
+            "providers": {
+                "stegid_verify": {"technology": "aws-kms-asymmetric-verify", "resource_id": "kms-stegid-test", "region": "test-region-1", "evidence_commitment": "sha256:test-stegid"},
+                "ai_entity_attestation": {"technology": "spiffe-spire-x509-svid", "resource_id": "spiffe-test-ai", "trust_domain": "test.invalid", "evidence_commitment": "sha256:test-spiffe"},
+                "key_custody": {"technology": "aws-kms-customer-managed-key", "resource_id": "kms-custody-test", "region": "test-region-1", "evidence_commitment": "sha256:test-custody"},
+                "authoritative_state": {"technology": "amazon-dynamodb-conditional-writes", "resource_id": "state-table-test", "region": "test-region-1", "evidence_commitment": "sha256:test-state"},
+                "ecosystem_chat": {"technology": "stegverse-authenticated-https", "resource_id": "chat-test", "endpoint": "https://chat.test.invalid/continuity", "evidence_commitment": "sha256:test-chat"},
+                "master_records": {"technology": "stegverse-receipt-ingestion-https", "resource_id": "records-test", "endpoint": "https://records.test.invalid/receipts", "evidence_commitment": "sha256:test-records"},
+            },
+            "rollback": {"procedure_ref": "docs/test-rollback", "revocation_receipt_ref": "sha256:test-rollback"},
+        }
+
+    def test_complete_profile_is_ready(self):
+        report = validate_provider_profile(self.complete_profile())
+        self.assertTrue(report.ready)
+        self.assertEqual(report.failures, ())
+        self.assertTrue(report.profile_commitment.startswith("sha256:"))
+
+    def test_template_profile_fails_closed(self):
+        profile = self.complete_profile()
+        profile["providers"]["key_custody"]["resource_id"] = "UNCONFIGURED"
+        report = validate_provider_profile(profile)
+        self.assertFalse(report.ready)
+        self.assertIn("key_custody.resource_id is unconfigured", report.failures)
+
+    def test_non_https_endpoint_is_rejected(self):
+        profile = self.complete_profile()
+        profile["providers"]["master_records"]["endpoint"] = "http://records.test.invalid/receipts"
+        report = validate_provider_profile(profile)
+        self.assertFalse(report.ready)
+        self.assertIn("master_records.endpoint must be an absolute HTTPS URL", report.failures)
+
+    def test_rollback_evidence_is_required(self):
+        profile = self.complete_profile()
+        profile["rollback"]["revocation_receipt_ref"] = "UNCONFIGURED"
+        report = validate_provider_profile(profile)
+        self.assertFalse(report.ready)
+        self.assertIn("rollback.revocation_receipt_ref is unconfigured", report.failures)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_provider_readiness.py
+++ b/tools/check_provider_readiness.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+from reconstructive_memory.readiness import load_and_validate
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: check_provider_readiness.py <profile.json>", file=sys.stderr)
+        return 2
+    path = Path(argv[1])
+    try:
+        report = load_and_validate(path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"PROVIDER READINESS INVALID: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report.payload(), indent=2, sort_keys=True))
+    if not report.ready:
+        print("PROVIDER ACTIVATION BLOCKED", file=sys.stderr)
+        return 1
+    print("PROVIDER ACTIVATION READY")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Purpose

Advance issue #16 with a machine-readable provider configuration template and a fail-closed readiness gate for real deployment resources.

## Added

- `config/production-provider-profile.template.json` with visible `UNCONFIGURED` placeholders;
- provider readiness validation for all six selected provider roles;
- absolute HTTPS enforcement for Ecosystem Chat and Master-Records endpoints;
- required rollback procedure and revocation receipt references;
- a CLI that returns success only for a fully configured profile;
- unit tests for complete, incomplete, insecure-endpoint, and missing-rollback cases;
- a dedicated workflow that proves the template remains blocked and can validate a configured repository profile through manual dispatch.

## Security boundary

This PR does not provision cloud resources or accept credentials. It prevents activation claims until real resource identifiers, evidence commitments, endpoint identities, and rollback references are supplied in a configured profile.

## Validation

- `python3 -m unittest tests.test_reconstructive_memory_readiness`
- `python3 tools/check_provider_readiness.py <configured-profile.json>`

Issue #16 remains open until a configured profile and signed deployment evidence exist.