### PR TITLE
Add live production provider conformance gate

### DIFF
--- a/reconstructive_memory/__init__.py
+++ b/reconstructive_memory/__init__.py
@@ -4,8 +4,8 @@ This package is dependency-free and prototype-scoped. It models minimal
 continuity, pair-bound authorization, authenticated minimized ingestion, bounded
 ephemeral reconstruction, durable replay controls, lifecycle tombstones,
 plaintext-free journals, authoritative commit boundaries, receipt propagation,
-deployment adapter contracts, provider activation receipts, and fail-closed
-provider readiness without storing plaintext chat in the chain.
+deployment adapter contracts, provider activation receipts, fail-closed provider
+readiness, and live conformance evidence without storing plaintext chat in the chain.
 """
 
 from .access import AccessReceipt, CallableKeyUnwrapper, KeyUnwrapper, RelationshipRegistry, RelationshipState, make_access_receipt
@@ -19,6 +19,7 @@ from .master_records import MasterRecordAcknowledgement, MasterRecordEnvelope, M
 from .master_records_state import DurableMasterRecordsOutbox, InMemoryMasterRecordsStateStore, MasterRecordsEntry, MasterRecordsState, MasterRecordsStateStore
 from .proofs import CallableProofVerifier, ProofVerifier, require_dual_proof
 from .provider_activation import DeploymentReceipt, ProductionActivationProfile, ProviderSelection, default_aws_profile
+from .provider_conformance import ConformanceReport, ProviderProbe, ProviderProbeResult, assemble_deployment_receipt, run_provider_conformance
 from .readiness import REQUIRED_PROVIDERS, ReadinessReport, load_and_validate, validate_provider_profile
 from .replay import DurableTransportReplayRegistry, InMemoryReplayStateStore, ReplayState, ReplayStateStore
 from .routing import OpaqueRouteEntry, OpaqueRouteIndex, validate_candidate_events

--- a/reconstructive_memory/provider_conformance.py
+++ b/reconstructive_memory/provider_conformance.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from hashlib import sha256
+import hmac
+import json
+from typing import Mapping, Protocol, Sequence
+
+from .provider_activation import DeploymentReceipt, ProductionActivationProfile
+
+
+REQUIRED_ROLES = (
+    "stegid_verification",
+    "ai_entity_attestation",
+    "key_custody",
+    "replicated_state",
+    "ecosystem_chat",
+    "master_records",
+)
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _digest(value: object) -> str:
+    return "sha256:" + sha256(_canonical(value)).hexdigest()
+
+
+@dataclass(frozen=True)
+class ProviderProbeResult:
+    role: str
+    resource_id: str
+    observed_identity: str
+    capability: str
+    success: bool
+    evidence_commitment: str
+    checked_at: int
+    failure_code: str | None = None
+    result_hash: str = ""
+
+    def payload(self) -> Mapping[str, object]:
+        return {
+            "role": self.role,
+            "resource_id": self.resource_id,
+            "observed_identity": self.observed_identity,
+            "capability": self.capability,
+            "success": self.success,
+            "evidence_commitment": self.evidence_commitment,
+            "checked_at": self.checked_at,
+            "failure_code": self.failure_code,
+        }
+
+    def with_hash(self) -> "ProviderProbeResult":
+        return replace(self, result_hash=_digest(self.payload()))
+
+    def verify(self) -> None:
+        if self.role not in REQUIRED_ROLES:
+            raise ValueError("unsupported provider role")
+        if not self.resource_id or self.resource_id == "UNCONFIGURED":
+            raise ValueError("probe lacks configured resource")
+        if not self.observed_identity or not self.capability:
+            raise ValueError("probe lacks observed identity or capability")
+        if not self.evidence_commitment.startswith("sha256:"):
+            raise ValueError("probe lacks evidence commitment")
+        if self.checked_at <= 0:
+            raise ValueError("invalid probe timestamp")
+        if self.success and self.failure_code is not None:
+            raise ValueError("successful probe carries failure code")
+        if not self.success and not self.failure_code:
+            raise ValueError("failed probe lacks failure code")
+        expected = _digest(self.payload())
+        if not self.result_hash or not hmac.compare_digest(self.result_hash, expected):
+            raise ValueError("provider probe hash mismatch")
+
+
+class ProviderProbe(Protocol):
+    def run(self, profile: ProductionActivationProfile, *, checked_at: int) -> ProviderProbeResult: ...
+
+
+@dataclass(frozen=True)
+class ConformanceReport:
+    profile_commitment: str
+    results: tuple[ProviderProbeResult, ...]
+    ready: bool
+    report_hash: str = ""
+
+    def payload(self) -> Mapping[str, object]:
+        return {
+            "profile_commitment": self.profile_commitment,
+            "results": [result.result_hash for result in self.results],
+            "ready": self.ready,
+        }
+
+    def with_hash(self) -> "ConformanceReport":
+        return replace(self, report_hash=_digest(self.payload()))
+
+    def verify(self) -> None:
+        roles = [result.role for result in self.results]
+        if sorted(roles) != sorted(REQUIRED_ROLES) or len(set(roles)) != len(REQUIRED_ROLES):
+            raise ValueError("conformance report must contain exactly one result per role")
+        for result in self.results:
+            result.verify()
+        expected_ready = all(result.success for result in self.results)
+        if self.ready != expected_ready:
+            raise ValueError("conformance readiness mismatch")
+        expected = _digest(self.payload())
+        if not self.report_hash or not hmac.compare_digest(self.report_hash, expected):
+            raise ValueError("conformance report hash mismatch")
+
+
+def run_provider_conformance(
+    profile: ProductionActivationProfile,
+    probes: Sequence[ProviderProbe],
+    *,
+    checked_at: int,
+) -> ConformanceReport:
+    profile.verify()
+    if len(probes) != len(REQUIRED_ROLES):
+        raise ValueError("one probe is required for every provider role")
+    results = tuple(probe.run(profile, checked_at=checked_at) for probe in probes)
+    report = ConformanceReport(
+        profile_commitment=profile.profile_hash,
+        results=results,
+        ready=all(result.success for result in results),
+    ).with_hash()
+    report.verify()
+    return report
+
+
+def assemble_deployment_receipt(
+    profile: ProductionActivationProfile,
+    report: ConformanceReport,
+    *,
+    receipt_id: str,
+    issued_at: int,
+    signer_identity: str,
+) -> DeploymentReceipt:
+    profile.verify()
+    report.verify()
+    if not report.ready:
+        raise PermissionError("provider conformance is not ready")
+    if not hmac.compare_digest(report.profile_commitment, profile.profile_hash):
+        raise PermissionError("conformance report belongs to another profile")
+    evidence = {result.role: result.evidence_commitment for result in report.results}
+    receipt = DeploymentReceipt(
+        receipt_id=receipt_id,
+        profile_hash=profile.profile_hash,
+        issued_at=issued_at,
+        signer_identity=signer_identity,
+        evidence_commitments=evidence,
+        validation_commitment=report.report_hash,
+    ).with_hash()
+    receipt.verify(profile)
+    return receipt

--- a/reconstructive_memory/provider_conformance.py
+++ b/reconstructive_memory/provider_conformance.py
@@ -10,12 +10,12 @@ from .provider_activation import DeploymentReceipt, ProductionActivationProfile
 
 
 REQUIRED_ROLES = (
-    "stegid_verification",
-    "ai_entity_attestation",
-    "key_custody",
-    "replicated_state",
-    "ecosystem_chat",
-    "master_records",
+    "steg-id-signature",
+    "ai-entity-attestation",
+    "key-custody",
+    "replicated-state",
+    "ecosystem-chat",
+    "master-records",
 )
 
 
@@ -57,7 +57,7 @@ class ProviderProbeResult:
     def verify(self) -> None:
         if self.role not in REQUIRED_ROLES:
             raise ValueError("unsupported provider role")
-        if not self.resource_id or self.resource_id == "UNCONFIGURED":
+        if not self.resource_id or "UNCONFIGURED" in self.resource_id:
             raise ValueError("probe lacks configured resource")
         if not self.observed_identity or not self.capability:
             raise ValueError("probe lacks observed identity or capability")
@@ -134,10 +134,11 @@ def assemble_deployment_receipt(
     *,
     receipt_id: str,
     issued_at: int,
-    signer_identity: str,
 ) -> DeploymentReceipt:
     profile.verify()
     report.verify()
+    if not profile.activation_ready():
+        raise PermissionError("provider profile is not verified")
     if not report.ready:
         raise PermissionError("provider conformance is not ready")
     if not hmac.compare_digest(report.profile_commitment, profile.profile_hash):
@@ -146,10 +147,11 @@ def assemble_deployment_receipt(
     receipt = DeploymentReceipt(
         receipt_id=receipt_id,
         profile_hash=profile.profile_hash,
+        validation_commit=report.report_hash,
+        rollback_ref=profile.rollback_ref,
+        provider_evidence=evidence,
         issued_at=issued_at,
-        signer_identity=signer_identity,
-        evidence_commitments=evidence,
-        validation_commitment=report.report_hash,
+        decision="ALLOW",
     ).with_hash()
-    receipt.verify(profile)
+    receipt.verify()
     return receipt

--- a/tests/test_reconstructive_memory_provider_conformance.py
+++ b/tests/test_reconstructive_memory_provider_conformance.py
@@ -1,0 +1,95 @@
+import unittest
+from dataclasses import replace
+
+from reconstructive_memory.provider_activation import ProductionActivationProfile, ProviderSelection
+from reconstructive_memory.provider_conformance import (
+    REQUIRED_ROLES,
+    ProviderProbeResult,
+    assemble_deployment_receipt,
+    run_provider_conformance,
+)
+
+
+class FakeProbe:
+    def __init__(self, role: str, resource_id: str, *, success: bool = True) -> None:
+        self.role = role
+        self.resource_id = resource_id
+        self.success = success
+
+    def run(self, profile, *, checked_at: int):
+        return ProviderProbeResult(
+            role=self.role,
+            resource_id=self.resource_id,
+            observed_identity=f"observed:{self.role}",
+            capability=f"verified:{self.role}",
+            success=self.success,
+            evidence_commitment="sha256:" + (self.role.replace("-", "") + "0" * 64)[:64],
+            checked_at=checked_at,
+            failure_code=None if self.success else "PROBE_FAILED",
+        ).with_hash()
+
+
+def verified_profile() -> ProductionActivationProfile:
+    return ProductionActivationProfile(
+        profile_id="prod-1",
+        environment="production",
+        steg_id=ProviderSelection("steg-id-signature", "AWS", "KMS Verify", "arn:aws:kms:region:acct:key/steg", "us-east-1", "verified"),
+        ai_attestation=ProviderSelection("ai-entity-attestation", "SPIFFE", "X.509-SVID", "spiffe://stegverse/ai/runtime", "global", "verified"),
+        key_custody=ProviderSelection("key-custody", "AWS", "KMS CMK", "arn:aws:kms:region:acct:key/custody", "us-east-1", "verified"),
+        state_store=ProviderSelection("replicated-state", "AWS", "DynamoDB conditional write", "arn:aws:dynamodb:region:acct:table/state", "us-east-1", "verified"),
+        chat_transport=ProviderSelection("ecosystem-chat", "StegVerse", "authenticated endpoint", "https://chat.example.test/ingest", "global", "verified"),
+        master_records=ProviderSelection("master-records", "StegVerse", "receipt endpoint", "https://records.example.test/receipts", "global", "verified"),
+        rollback_ref="docs/PRODUCTION_PROVIDER_ACTIVATION.md#rollback-and-revocation",
+        created_at=1,
+    ).with_hash()
+
+
+class ProviderConformanceTests(unittest.TestCase):
+    def probes(self, *, failed_role: str | None = None):
+        resources = {
+            "steg-id-signature": "arn:aws:kms:region:acct:key/steg",
+            "ai-entity-attestation": "spiffe://stegverse/ai/runtime",
+            "key-custody": "arn:aws:kms:region:acct:key/custody",
+            "replicated-state": "arn:aws:dynamodb:region:acct:table/state",
+            "ecosystem-chat": "https://chat.example.test/ingest",
+            "master-records": "https://records.example.test/receipts",
+        }
+        return [FakeProbe(role, resources[role], success=role != failed_role) for role in REQUIRED_ROLES]
+
+    def test_successful_conformance_assembles_allow_receipt(self):
+        profile = verified_profile()
+        report = run_provider_conformance(profile, self.probes(), checked_at=2)
+        self.assertTrue(report.ready)
+        receipt = assemble_deployment_receipt(profile, report, receipt_id="receipt-1", issued_at=3)
+        self.assertEqual(receipt.decision, "ALLOW")
+        self.assertEqual(receipt.validation_commit, report.report_hash)
+        self.assertEqual(set(receipt.provider_evidence), set(REQUIRED_ROLES))
+
+    def test_failed_probe_blocks_receipt(self):
+        profile = verified_profile()
+        report = run_provider_conformance(profile, self.probes(failed_role="master-records"), checked_at=2)
+        self.assertFalse(report.ready)
+        with self.assertRaises(PermissionError):
+            assemble_deployment_receipt(profile, report, receipt_id="receipt-2", issued_at=3)
+
+    def test_unverified_profile_blocks_receipt(self):
+        profile = verified_profile()
+        unverified = replace(profile, master_records=replace(profile.master_records, status="configured")).with_hash()
+        report = run_provider_conformance(unverified, self.probes(), checked_at=2)
+        with self.assertRaises(PermissionError):
+            assemble_deployment_receipt(unverified, report, receipt_id="receipt-3", issued_at=3)
+
+    def test_tampered_probe_is_rejected(self):
+        result = self.probes()[0].run(verified_profile(), checked_at=2)
+        with self.assertRaises(ValueError):
+            replace(result, observed_identity="changed").verify()
+
+    def test_duplicate_role_set_fails_closed(self):
+        probes = self.probes()
+        probes[-1] = FakeProbe("ecosystem-chat", "https://duplicate.example.test")
+        with self.assertRaises(ValueError):
+            run_provider_conformance(verified_profile(), probes, checked_at=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_reconstructive_memory.py
+++ b/tools/check_reconstructive_memory.py
@@ -24,13 +24,15 @@ REQUIRED = (
     ROOT / "reconstructive_memory" / "master_records_state.py",
     ROOT / "reconstructive_memory" / "deployment.py",
     ROOT / "reconstructive_memory" / "provider_activation.py",
+    ROOT / "reconstructive_memory" / "readiness.py",
+    ROOT / "reconstructive_memory" / "provider_conformance.py",
     ROOT / "schemas" / "reconstructive-memory-event.v0.1.json",
     ROOT / "schemas" / "reconstructive-memory-access-receipt.v0.1.json",
     ROOT / "docs" / "RECONSTRUCTIVE_AI_MEMORY.md",
     ROOT / "docs" / "PRODUCTION_PROVIDER_ACTIVATION.md",
 )
 
-SCHEMAS = REQUIRED[15:17]
+SCHEMAS = REQUIRED[17:19]
 
 
 def fail(message: str) -> None:
@@ -69,7 +71,8 @@ def main() -> int:
     print("- authoritative receipt/capability commit boundary: present")
     print("- durable Master-Records outbox lifecycle: present")
     print("- external CAS store and delivery adapter contracts: present")
-    print("- concrete provider selection and deployment receipt gate: present")
+    print("- concrete provider selection and readiness gate: present")
+    print("- live provider conformance and receipt assembly: present")
     print("- external resource identifiers and credentials: UNCONFIGURED")
     return 0
 


### PR DESCRIPTION
## Purpose

Advance issue #16 to the final repository-owned activation boundary by defining live provider probe evidence and deployment receipt assembly.

## Added

- canonical probe results for all six provider roles;
- observed resource identity and capability binding;
- hash-verified provider evidence commitments;
- exact one-result-per-role conformance reports;
- fail-closed handling for failed, missing, duplicate, or tampered probes;
- deployment receipt assembly only when the profile is verified and every live probe succeeds;
- tests covering successful receipt creation, failed probes, unverified profiles, tampering, and duplicate roles;
- integration with the reconstructive-memory package and validator.

## Security boundary

This PR does not claim that any external provider has been provisioned or probed. It supplies the contract that concrete AWS, SPIFFE, Ecosystem Chat, and Master-Records probe adapters must satisfy when credentials and endpoints become available.

## Validation

`python3 tools/check_reconstructive_memory.py`

Issue #16 remains open until configured resources are live, concrete probes execute successfully, and the resulting deployment receipt is signed and retained.