### PR TITLE
Add fidelity-governed multimodal storage contract

### DIFF
--- a/.github/workflows/fidelity-governed-storage.yml
+++ b/.github/workflows/fidelity-governed-storage.yml
@@ -1,0 +1,49 @@
+name: Fidelity-Governed Storage Validation
+
+on:
+  pull_request:
+    paths:
+      - "docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md"
+      - "schemas/experience-capsule.schema.json"
+      - "fixtures/multimodal/**"
+      - "tools/validate_experience_capsule.py"
+      - "tests/test_experience_capsule.py"
+      - ".github/workflows/fidelity-governed-storage.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md"
+      - "schemas/experience-capsule.schema.json"
+      - "fixtures/multimodal/**"
+      - "tools/validate_experience_capsule.py"
+      - "tests/test_experience_capsule.py"
+      - ".github/workflows/fidelity-governed-storage.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compile validator and tests
+        run: python3 -m compileall -q tools/validate_experience_capsule.py tests/test_experience_capsule.py
+
+      - name: Validate reference capsules
+        run: python3 tools/validate_experience_capsule.py
+
+      - name: Run invariant tests
+        run: python3 -m unittest tests.test_experience_capsule
+
+      - name: Confirm schema parses
+        run: python3 -c 'import json; json.load(open("schemas/experience-capsule.schema.json", encoding="utf-8")); print("schema JSON valid")'

--- a/.github/workflows/fidelity-governed-storage.yml
+++ b/.github/workflows/fidelity-governed-storage.yml
@@ -6,8 +6,10 @@ on:
       - "docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md"
       - "schemas/experience-capsule.schema.json"
       - "fixtures/multimodal/**"
+      - "multimodal_storage/**"
       - "tools/validate_experience_capsule.py"
       - "tests/test_experience_capsule.py"
+      - "tests/test_multimodal_storage_adapter.py"
       - ".github/workflows/fidelity-governed-storage.yml"
   push:
     branches: ["main"]
@@ -15,8 +17,10 @@ on:
       - "docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md"
       - "schemas/experience-capsule.schema.json"
       - "fixtures/multimodal/**"
+      - "multimodal_storage/**"
       - "tools/validate_experience_capsule.py"
       - "tests/test_experience_capsule.py"
+      - "tests/test_multimodal_storage_adapter.py"
       - ".github/workflows/fidelity-governed-storage.yml"
   workflow_dispatch: {}
 
@@ -36,14 +40,14 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Compile validator and tests
-        run: python3 -m compileall -q tools/validate_experience_capsule.py tests/test_experience_capsule.py
+      - name: Compile validator, adapter, and tests
+        run: python3 -m compileall -q multimodal_storage tools/validate_experience_capsule.py tests/test_experience_capsule.py tests/test_multimodal_storage_adapter.py
 
       - name: Validate reference capsules
         run: python3 tools/validate_experience_capsule.py
 
-      - name: Run invariant tests
-        run: python3 -m unittest tests.test_experience_capsule
+      - name: Run invariant and access-boundary tests
+        run: python3 -m unittest tests.test_experience_capsule tests.test_multimodal_storage_adapter
 
       - name: Confirm schema parses
         run: python3 -c 'import json; json.load(open("schemas/experience-capsule.schema.json", encoding="utf-8")); print("schema JSON valid")'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,22 @@ The format is based on [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+- `docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md` defining artifact-class separation, transcription-only voice recall, multimodal fidelity transitions, sparse reconstruction, sensor substitution, and reconstruction-completeness requirements
+- `schemas/experience-capsule.schema.json` as the machine-readable contract for governed multimodal episodes, streams, consent transitions, retention policy, reconstruction rights, missing evidence, and fidelity transitions
+- Four reference capsules covering transcription-only voice, protected audio evidence, sparse video reconstruction, and materially incomplete ambient capture
+- `tools/validate_experience_capsule.py` and `tests/test_experience_capsule.py` to enforce generated-content labeling, ephemeral payload restrictions, voice-recall boundaries, fidelity-loss declarations, and completeness consistency
+- `multimodal_storage/adapter.py` and `tests/test_multimodal_storage_adapter.py` to authorize canonical text and derived recall without granting protected raw-media access by implication
+- `.github/workflows/fidelity-governed-storage.yml` as the dedicated executable validation gate for the multimodal storage contract
+
+### Improved
+- Reconstructive-memory integration now distinguishes ordinary recall, generated reconstruction rights, and protected raw-evidence access
+- Text-to-speech playback is explicitly treated as synthesized presentation rather than replay of an original voice event
+- Fidelity reduction and deletion preserve continuity receipts, information-loss declarations, and recovery limitations
+- Multimodal reconstruction results must disclose missing, protected, deleted, disputed, uncertain, or generated-only evidence states
+
+### Notes
+The multimodal storage layer does not establish surveillance authority, guarantee complete experiential preservation, convert inferred emotion into fact, or make generated reconstruction equivalent to original evidence. Lower compute cost supports selective and explainable fidelity management but does not remove raw-media storage cost.
 
 ---
 

--- a/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -2,8 +2,8 @@
 
 **Repository:** `StegVerse-Labs/continuity-vault-kit`  
 **Module:** KnowledgeVault Kit / Continuity Vault Kit  
-**Status:** Active standalone release with repository-native verification, reconstructive memory, and an in-progress fidelity-governed multimodal storage contract.  
-**Current published version:** `0.1.2`  
+**Status:** Active standalone release with repository-native verification, reconstructive memory, and a validated fidelity-governed multimodal storage activation in PR #20.  
+**Current published version:** `0.1.3`  
 **Last updated:** 2026-07-15
 
 ## 1. Purpose and scope boundary
@@ -18,11 +18,11 @@ Integrity tooling verifies package and copy behavior only. Automation-contract t
 
 ## 2. Release state
 
-- Last verified published release: `v0.1.2`.
-- Release commit: `5e38ca635ed420a3800ca53dd59f236175207edb`.
-- Published assets: ZIP, SHA-256 sidecar, and expanded manifest sidecar.
-- Historical activation issues #7, #8, #9, and #10 are closed and are not reusable release gates.
-- Substantive Unreleased changes justify the next compatible patch release.
+- Last verified published release: `v0.1.3`.
+- The fidelity-governed multimodal storage activation is currently proposed in draft PR #20 from `agent/fidelity-governed-storage-v0-1`.
+- Current validated pre-changelog head: `064e9049679aeeefda5fdfd547eac3fd5ba4e238`.
+- On that head, Fidelity-Governed Storage Validation, KV Guardrails, Repository validation diagnostics, and Release integrity all completed successfully.
+- A substantive Unreleased changelog entry was added after those checks and requires fresh current-head validation before readiness or merge.
 - Do not claim a later release until `VERSION`, `latest_release.json`, and `latest_cycle.json` jointly confirm publication.
 - Durable release evidence is stored under `docs/release_evidence/`.
 
@@ -124,57 +124,57 @@ Determinations and receipts are stored under `evidence/downstream-propagation/`.
 
 ## 7. Fidelity-governed multimodal storage activation
 
-### Active branch
+### Active branch and pull request
 
-`agent/fidelity-governed-storage-v0-1`
+- Branch: `agent/fidelity-governed-storage-v0-1`
+- Pull request: `#20 Add fidelity-governed multimodal storage contract`
+- PR state: draft pending current-head verification after changelog and handoff updates
 
-### Completed in this activation slice
+### Completed implementation
 
-- Added `docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md`.
-- Added `schemas/experience-capsule.schema.json`.
-- Defined separate artifact classes for continuity, derived records, protected raw evidence, ephemeral compute state, and generated reconstructions.
-- Defined transcription-only voice as the default low-storage boundary while preserving the distinction between synthesized playback and original voice evidence.
-- Defined a video fidelity ladder from raw original capture to continuity-receipt-only state.
-- Defined time-varying consent transitions, user recall rights, missing-evidence declarations, and reconstruction completeness states.
-- Defined the initial machine-readable `ExperienceCapsule` contract, including stream artifact class, modality, clock quality, retention class, fidelity class, integrity commitments, consent transitions, reconstruction rights, and fidelity transitions.
+- `docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md`
+- `schemas/experience-capsule.schema.json`
+- `fixtures/multimodal/transcription-only-voice.json`
+- `fixtures/multimodal/protected-audio-evidence.json`
+- `fixtures/multimodal/sparse-video-reconstruction.json`
+- `fixtures/multimodal/incomplete-experience.json`
+- `tools/validate_experience_capsule.py`
+- `tests/test_experience_capsule.py`
+- `multimodal_storage/__init__.py`
+- `multimodal_storage/adapter.py`
+- `tests/test_multimodal_storage_adapter.py`
+- `.github/workflows/fidelity-governed-storage.yml`
+- substantive Unreleased changelog entry
+
+### Enforced boundaries
+
+- Raw evidence, derived records, continuity metadata, ephemeral processing state, and generated reconstruction remain distinct artifact classes.
+- Transcription-only voice does not imply original-audio recall.
+- Text-to-speech output is synthesized presentation, not replay of the original event.
+- Generated reconstruction requires explicit labeling, source links, separate request intent, and authorization.
+- Ordinary recall rights do not grant protected raw-media access.
+- Ephemeral and deleted streams may not expose durable payload references.
+- Fidelity reductions declare information loss, reversibility, integrity commitments, actor, policy, and effective time.
+- Materially missing evidence cannot be reported as complete for the declared scope.
 
 ### Parallel-session boundary
 
-The merged reconstructive-memory v0.1 work in PR #14 owns minimal continuity events, proof boundaries, authorization, protected-object lifecycle, coordinated reconstruction sessions, durable receipts, Master-Records outbox behavior, and external storage/delivery contracts. This branch must not duplicate or redefine those completed state-machine boundaries.
+The merged reconstructive-memory v0.1 work in PR #14 owns minimal continuity events, proof boundaries, authorization, protected-object lifecycle, coordinated reconstruction sessions, durable receipts, Master-Records outbox behavior, and external storage/delivery contracts. PR #20 adds only the multimodal episode, fidelity, recall-rights, and protected-evidence boundary above those completed state machines.
 
-This activation owns only the next layer:
-
-- multimodal episode representation;
-- artifact-class separation;
-- voice retention and recall limits;
-- sparse and scene-state video representation;
-- fidelity transition receipts;
-- reconstruction completeness for multimodal evidence.
-
-### Remaining files and modules
+### Remaining release-stage actions
 
 Destination: `StegVerse-Labs/continuity-vault-kit`
 
-1. `schemas/fidelity-transition.schema.json` or a deliberate decision to keep the transition definition embedded in the capsule schema.
-2. `fixtures/multimodal/transcription-only-voice.json`.
-3. `fixtures/multimodal/protected-audio-evidence.json`.
-4. `fixtures/multimodal/sparse-video-reconstruction.json`.
-5. `fixtures/multimodal/incomplete-experience.json`.
-6. `tools/validate_experience_capsule.py`.
-7. `tests/test_experience_capsule.py`.
-8. `.github/workflows/fidelity-governed-storage.yml`.
-9. Integration adapter connecting an authorized experience capsule to the existing reconstructive-memory session boundary without granting raw-evidence access by implication.
-10. Changelog entry after executable validation exists.
+1. Confirm all workflows succeed on the current head containing the changelog and handoff updates.
+2. Update PR #20 body to reflect the completed executable implementation.
+3. Mark PR #20 ready for review only after current-head checks pass.
+4. Merge PR #20 only after readiness and mergeability are confirmed.
+5. Observe the main-branch release lifecycle and do not claim publication until release receipts confirm it.
+6. Verify downstream determination receipts for Site, Publisher, admissibility-wiki, and stegguardian-wiki after publication.
 
-### Next bounded task
+### Next integration candidate after activation
 
-Implement fixtures and a dependency-light validator that enforces:
-
-- generated reconstructions are explicitly labeled and source-linked;
-- ephemeral streams do not expose durable payload references;
-- transcription-only voice does not imply original-audio recall;
-- fidelity reductions declare information loss and reversibility;
-- incomplete evidence cannot be reported as complete for the declared scope.
+Once PR #20 is merged and its release is durably confirmed, the next bounded candidate is a storage-budget and adaptive-capture policy module. It should define declared reconstruction goals, required material properties, sensor substitution, temporary fidelity elevation triggers, and measurable capacity budgets without expanding this repository into a surveillance authority.
 
 ## 8. Durable decisions
 
@@ -196,6 +196,8 @@ Implement fixtures and a dependency-light validator that enforces:
 16. Generated reconstruction is never original evidence.
 17. Lower compute cost does not eliminate raw-media storage cost; it enables more selective, explainable fidelity management.
 18. Deletion and fidelity reduction preserve continuity receipts and explicit recovery limitations.
+19. Fidelity transitions remain embedded in `experience-capsule.schema.json` for v0.1; a separate schema is not required until independent reuse is demonstrated.
+20. Multimodal access is an adapter above reconstructive memory and does not redefine its authority model.
 
 ## 9. Continuation rule
 
@@ -210,16 +212,16 @@ Implement fixtures and a dependency-light validator that enforces:
 - Implement only the smallest demonstrated fix for a supported candidate.
 - Do not invent onboarding automation without evidence.
 - Implement data sharing only under separately governed scope.
-- Continue multimodal work only from the active branch and the bounded task in section 7.
-- Do not merge the multimodal activation until fixtures, validator, tests, and dedicated CI are green.
+- Do not mark PR #20 ready or merge it without successful current-head workflow evidence.
+- Do not claim a new release before the authoritative receipts confirm publication.
 
 Recommended next activation condition:
 
-> The experience-capsule schema has executable fixtures and validation, dedicated CI is successful, and the integration boundary demonstrates that user recall does not silently authorize protected raw-evidence access.
+> PR #20 is merged from a green current head, `VERSION`, `latest_release.json`, and `latest_cycle.json` confirm the resulting patch publication, and downstream determination receipts exist for all four governed destinations.
 
 ## 10. Archive note
 
-This handoff preserves release state, reconstructive-memory ownership boundaries, the active multimodal branch, installed files, remaining modules, durable design decisions, and the next bounded task. Remaining work can proceed from this file, repository issues, workflow evidence, and committed implementation artifacts without access to the originating conversation.
+This handoff preserves release state, reconstructive-memory ownership boundaries, PR #20 implementation inventory, validated invariants, current remaining actions, and the next integration candidate. Remaining work can proceed from this file, the pull request, workflow evidence, and release receipts without access to the originating conversation.
 
 ---
 

--- a/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -2,7 +2,7 @@
 
 **Repository:** `StegVerse-Labs/continuity-vault-kit`  
 **Module:** KnowledgeVault Kit / Continuity Vault Kit  
-**Status:** Active standalone release with repository-native verification, issue-free publication, bounded recovery, safe initialization, downstream determination, and evidence-governed onboarding corrections.  
+**Status:** Active standalone release with repository-native verification, reconstructive memory, and an in-progress fidelity-governed multimodal storage contract.  
 **Current published version:** `0.1.2`  
 **Last updated:** 2026-07-15
 
@@ -122,7 +122,61 @@ Published releases inspect exactly four destinations:
 
 Determinations and receipts are stored under `evidence/downstream-propagation/`. Propagation never certifies user-authored content and never creates baseline dependencies.
 
-## 7. Durable decisions
+## 7. Fidelity-governed multimodal storage activation
+
+### Active branch
+
+`agent/fidelity-governed-storage-v0-1`
+
+### Completed in this activation slice
+
+- Added `docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md`.
+- Added `schemas/experience-capsule.schema.json`.
+- Defined separate artifact classes for continuity, derived records, protected raw evidence, ephemeral compute state, and generated reconstructions.
+- Defined transcription-only voice as the default low-storage boundary while preserving the distinction between synthesized playback and original voice evidence.
+- Defined a video fidelity ladder from raw original capture to continuity-receipt-only state.
+- Defined time-varying consent transitions, user recall rights, missing-evidence declarations, and reconstruction completeness states.
+- Defined the initial machine-readable `ExperienceCapsule` contract, including stream artifact class, modality, clock quality, retention class, fidelity class, integrity commitments, consent transitions, reconstruction rights, and fidelity transitions.
+
+### Parallel-session boundary
+
+The merged reconstructive-memory v0.1 work in PR #14 owns minimal continuity events, proof boundaries, authorization, protected-object lifecycle, coordinated reconstruction sessions, durable receipts, Master-Records outbox behavior, and external storage/delivery contracts. This branch must not duplicate or redefine those completed state-machine boundaries.
+
+This activation owns only the next layer:
+
+- multimodal episode representation;
+- artifact-class separation;
+- voice retention and recall limits;
+- sparse and scene-state video representation;
+- fidelity transition receipts;
+- reconstruction completeness for multimodal evidence.
+
+### Remaining files and modules
+
+Destination: `StegVerse-Labs/continuity-vault-kit`
+
+1. `schemas/fidelity-transition.schema.json` or a deliberate decision to keep the transition definition embedded in the capsule schema.
+2. `fixtures/multimodal/transcription-only-voice.json`.
+3. `fixtures/multimodal/protected-audio-evidence.json`.
+4. `fixtures/multimodal/sparse-video-reconstruction.json`.
+5. `fixtures/multimodal/incomplete-experience.json`.
+6. `tools/validate_experience_capsule.py`.
+7. `tests/test_experience_capsule.py`.
+8. `.github/workflows/fidelity-governed-storage.yml`.
+9. Integration adapter connecting an authorized experience capsule to the existing reconstructive-memory session boundary without granting raw-evidence access by implication.
+10. Changelog entry after executable validation exists.
+
+### Next bounded task
+
+Implement fixtures and a dependency-light validator that enforces:
+
+- generated reconstructions are explicitly labeled and source-linked;
+- ephemeral streams do not expose durable payload references;
+- transcription-only voice does not imply original-audio recall;
+- fidelity reductions declare information loss and reversibility;
+- incomplete evidence cannot be reported as complete for the declared scope.
+
+## 8. Durable decisions
 
 1. Baseline use remains independent of the wider StegVerse ecosystem.
 2. A newer kit cannot silently replace an owner-accepted vault.
@@ -138,8 +192,12 @@ Determinations and receipts are stored under `evidence/downstream-propagation/`.
 12. Supported merged fixes are recorded in Unreleased state before publication.
 13. Optional ecosystem references do not become baseline dependencies.
 14. This repository must not become an identity authority, surveillance surface, mandatory hosted service, financial product, or broad ecosystem-governance repository.
+15. A transcript may be the canonical recall object without preserving or exposing the original voice recording.
+16. Generated reconstruction is never original evidence.
+17. Lower compute cost does not eliminate raw-media storage cost; it enables more selective, explainable fidelity management.
+18. Deletion and fidelity reduction preserve continuity receipts and explicit recovery limitations.
 
-## 8. Continuation rule
+## 9. Continuation rule
 
 - Treat `latest.json` as the integrity and release-required gate.
 - Treat `latest_release.json` as the latest successful publication receipt.
@@ -152,14 +210,16 @@ Determinations and receipts are stored under `evidence/downstream-propagation/`.
 - Implement only the smallest demonstrated fix for a supported candidate.
 - Do not invent onboarding automation without evidence.
 - Implement data sharing only under separately governed scope.
+- Continue multimodal work only from the active branch and the bounded task in section 7.
+- Do not merge the multimodal activation until fixtures, validator, tests, and dedicated CI are green.
 
 Recommended next activation condition:
 
-> `VERSION`, `latest_release.json`, and `latest_cycle.json` jointly confirm the next verified patch publication, or a new durable failure receipt identifies the next bounded correction.
+> The experience-capsule schema has executable fixtures and validation, dedicated CI is successful, and the integration boundary demonstrates that user recall does not silently authorize protected raw-evidence access.
 
-## 9. Archive note
+## 10. Archive note
 
-This handoff preserves release state, release evidence surfaces, bounded recovery behavior, automation contracts, initialization boundaries, downstream determinations, onboarding-friction governance, durable decisions, and successor rules. Remaining work can proceed from this file, repository issues, workflow evidence, and committed implementation artifacts.
+This handoff preserves release state, reconstructive-memory ownership boundaries, the active multimodal branch, installed files, remaining modules, durable design decisions, and the next bounded task. Remaining work can proceed from this file, repository issues, workflow evidence, and committed implementation artifacts without access to the originating conversation.
 
 ---
 

--- a/docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md
+++ b/docs/FIDELITY_GOVERNED_MULTIMODAL_STORAGE.md
@@ -1,0 +1,251 @@
+# Fidelity-Governed Multimodal Storage
+
+## Status
+
+Version: `0.1-draft`  
+Repository: `StegVerse-Labs/continuity-vault-kit`  
+Activation goal: preserve reconstructable multimodal experience without treating all captured media as permanently recallable evidence.
+
+## 1. Purpose
+
+A compact continuity chain can prove that an event belongs to history, but it cannot by itself reproduce the sensory and semantic context of an experience. This specification defines a bounded storage model for text, transient speech, audio evidence, video, and ambient sensor streams.
+
+The model separates:
+
+1. continuity metadata;
+2. searchable derived representations;
+3. protected raw evidence;
+4. ephemeral processing state;
+5. generated reconstructions.
+
+The separation prevents a transcript, inference, or regenerated scene from silently becoming equivalent to original evidence.
+
+## 2. Required invariants
+
+1. Raw evidence, derived observations, interpretations, and generated reconstructions are distinct artifact classes.
+2. Every durable transformation identifies its source artifacts, algorithm or model version, policy basis, and integrity commitment.
+3. A generated reconstruction is never labeled or returned as original capture.
+4. Deletion or fidelity reduction does not erase the continuity record that the source interval existed.
+5. User recall rights are independent from internal evidentiary retention rights.
+6. Speech-to-text may become the canonical user-recall object while original audio remains unavailable or is deleted.
+7. Text-to-speech creates a new presentation from canonical text and is not a replay of the original voice event.
+8. Consent is represented as a time-varying stream, not a one-time property of the full episode.
+9. A reconstruction response declares completeness, missing evidence, disputed interpretation, and generated content.
+10. Stable or redundant sensor intervals should not be retained at full fidelity unless policy or evidence value requires them.
+
+## 3. Experience capsule
+
+An `ExperienceCapsule` binds independently verifiable streams to one governed episode.
+
+Minimum fields:
+
+- `experience_id`;
+- `participants`;
+- `authorized_devices`;
+- `start_time` and `end_time`;
+- `streams`;
+- `consent_transitions`;
+- `retention_policy`;
+- `provenance_root`;
+- `reconstruction_rights`;
+- `completeness_status`.
+
+The capsule does not require all payloads to be colocated. Payloads may remain in local, protected, distributed, or cold custody while the capsule stores commitments and governed references.
+
+## 4. Artifact classes
+
+### 4.1 Continuity record
+
+Retained durably:
+
+- hashes and predecessor relationships;
+- episode and stream identifiers;
+- timestamps and clock-quality declarations;
+- participant and device declarations;
+- consent changes;
+- transformation receipts;
+- retention, deletion, and fidelity-transition receipts;
+- pointers to protected payloads.
+
+### 4.2 Derived searchable record
+
+Retained according to policy:
+
+- transcripts;
+- speaker segmentation;
+- scene boundaries;
+- keyframes;
+- object and motion tracks;
+- environmental state changes;
+- semantic embeddings;
+- user-confirmed annotations.
+
+Derived records must identify their originating evidence and may not replace the evidence declaration.
+
+### 4.3 Protected raw evidence
+
+Potentially retained:
+
+- original audio;
+- original video;
+- high-frequency sensor streams;
+- synchronized device captures.
+
+Raw evidence is encrypted, separately authorized, and excluded from ordinary recall unless the applicable policy grants access.
+
+### 4.4 Ephemeral compute state
+
+Not retained by default:
+
+- intermediate tensors;
+- candidate object tracks;
+- temporary embeddings;
+- transient frame buffers;
+- model scratch state;
+- rejected reconstruction candidates.
+
+A durable processing receipt may attest that an ephemeral operation occurred without storing the intermediate state.
+
+### 4.5 Generated reconstruction
+
+A generated reconstruction may use retained scene state, timing, transcript, geometry, motion, and approved identity representations. It must contain:
+
+- `generated: true`;
+- source artifact references;
+- reconstruction method and version;
+- missing-source declaration;
+- fidelity class;
+- intended use;
+- prohibition against presentation as original evidence.
+
+## 5. Voice boundary
+
+The default voice mode is `transcription_only`:
+
+1. audio is captured transiently;
+2. speech-to-text produces canonical text;
+3. transcription confidence and timing are recorded;
+4. the user may correct the text;
+5. original audio is deleted after verification or after a bounded buffer;
+6. a deletion receipt remains;
+7. later playback uses text-to-speech and is labeled as synthesized presentation.
+
+Supported modes:
+
+- `transcription_only`;
+- `verification_buffer`;
+- `protected_evidence`;
+- `no_derived_voice`.
+
+Original voice recall is not implied by the existence of a transcript.
+
+## 6. Video fidelity ladder
+
+A video interval may transition through the following classes:
+
+1. `raw_original`;
+2. `high_fidelity_evidence`;
+3. `sparse_reconstruction_package`;
+4. `scene_state_record`;
+5. `semantic_episode_record`;
+6. `continuity_receipt_only`.
+
+A transition requires:
+
+- source and destination fidelity classes;
+- policy authorization;
+- transformation method;
+- integrity commitments before and after;
+- declared information loss;
+- recovery limitations;
+- actor and execution context;
+- effective time.
+
+No transition may claim reversibility after required source data is deleted.
+
+## 7. Sparse video representation
+
+A sparse reconstruction package may contain:
+
+- selected keyframes;
+- camera pose and movement;
+- scene geometry or depth approximation;
+- object identities and trajectories;
+- participant pose and gesture tracks;
+- lighting changes;
+- synchronized transcript and sound events;
+- confidence and missing-interval declarations.
+
+This representation supports experiential recall at lower storage cost but is not forensically equivalent to original footage.
+
+## 8. Sensor substitution
+
+Multiple low-cost sensor streams may substitute for continuous high-resolution capture when they preserve the material properties needed by the declared use case.
+
+Examples include:
+
+- low-frame-rate video plus depth and motion;
+- transcript plus speaker timing and scene changes;
+- object tags plus device position and event-triggered keyframes.
+
+Each substitution policy must declare:
+
+- the reconstruction goal;
+- required material properties;
+- selected sensors;
+- omitted properties;
+- expected uncertainty;
+- conditions that trigger temporary higher-fidelity capture.
+
+## 9. Reconstruction completeness
+
+Every reconstruction result must use one of:
+
+- `complete_for_declared_scope`;
+- `bounded_but_coherent`;
+- `materially_incomplete`;
+- `protected_evidence_unavailable`;
+- `source_deleted_under_policy`;
+- `timing_uncertain`;
+- `interpretation_disputed`;
+- `generated_only`.
+
+A polished presentation must not conceal an incomplete evidence state.
+
+## 10. Capacity consequence
+
+The continuity and provenance layers are small relative to raw media. Storage savings arise from:
+
+- content addressing and deduplication;
+- sparse relationship storage;
+- temporary rather than durable model state;
+- adaptive capture rates;
+- selective raw-evidence retention;
+- fidelity reduction with explicit receipts;
+- avoiding independent canonical copies across search, vector, analytics, and archive systems.
+
+Hashing does not replace payload storage when exact reconstruction remains required.
+
+## 11. Prohibited claims
+
+This specification does not authorize claims that:
+
+- all experiences are fully preserved;
+- generated video is original evidence;
+- inferred emotion is a participant's internal state;
+- a transcript preserves the original voice event;
+- deleted source data remains recoverable;
+- low-cost compute eliminates physical storage cost;
+- continuity integrity establishes semantic truth.
+
+## 12. Initial implementation targets
+
+1. JSON Schema for `ExperienceCapsule` and fidelity transitions.
+2. Validator enforcing artifact-class separation and generated-content labeling.
+3. Fixtures for transcription-only voice, protected evidence, sparse video, and incomplete reconstruction.
+4. CI workflow covering schema and fixture validation.
+5. Integration with reconstructive-memory authorization and receipt boundaries.
+
+---
+
+🔒 Layer: Framework | KV

--- a/fixtures/multimodal/incomplete-experience.json
+++ b/fixtures/multimodal/incomplete-experience.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "0.1",
+  "experience_id": "exp_incomplete_001",
+  "start_time": "2026-07-15T18:20:00Z",
+  "end_time": "2026-07-15T18:22:00Z",
+  "participants": [{"participant_id": "user_001", "role": "observer", "identity_proof_ref": null}],
+  "authorized_devices": [{"device_id": "device_room_001", "authority_state": "authorized", "attestation_ref": "attestation:room:001"}],
+  "streams": [{"stream_id": "stream_ambient_001", "modality": "ambient", "artifact_class": "derived", "capture_start": "2026-07-15T18:20:00Z", "capture_end": "2026-07-15T18:20:45Z", "source_device_id": "device_room_001", "clock_quality": "uncertain", "user_recall_available": true, "retention_class": "searchable_derived", "fidelity_class": "semantic_episode_record", "generated": false, "source_stream_refs": [], "transform_method": "ambient_event_summary", "transform_version": "0.1", "payload_ref": "vault://derived/ambient/stream_ambient_001", "integrity": {"algorithm": "sha256", "digest": "abababababababababababababababababababababababababababababababab"}}],
+  "consent_transitions": [{"participant_id": "user_001", "effective_time": "2026-07-15T18:20:00Z", "scope": ["ambient_summary"], "state": "granted", "authority_ref": "consent:user_001:ambient"}],
+  "retention_policy": {"policy_id": "policy:ambient:summary:v1", "default_voice_mode": "no_derived_voice", "raw_media_default": "prohibited", "fidelity_reduction_allowed": true, "maximum_buffer_seconds": 0},
+  "provenance_root": {"algorithm": "sha256", "digest": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"},
+  "reconstruction_rights": [{"principal_id": "user_001", "scope": ["ambient_summary"], "may_access_raw": false, "may_generate_reconstruction": false, "expires_at": null}],
+  "completeness_status": "materially_incomplete",
+  "missing_evidence": [{"interval_start": "2026-07-15T18:20:45Z", "interval_end": "2026-07-15T18:22:00Z", "reason": "device_unavailable", "materiality": "material"}],
+  "fidelity_transitions": []
+}

--- a/fixtures/multimodal/protected-audio-evidence.json
+++ b/fixtures/multimodal/protected-audio-evidence.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "0.1",
+  "experience_id": "exp_audio_evidence_001",
+  "start_time": "2026-07-15T18:05:00Z",
+  "end_time": "2026-07-15T18:05:30Z",
+  "participants": [{"participant_id": "user_001", "role": "speaker", "identity_proof_ref": null}],
+  "authorized_devices": [{"device_id": "device_phone_001", "authority_state": "authorized", "attestation_ref": "attestation:phone:001"}],
+  "streams": [
+    {
+      "stream_id": "stream_audio_protected_001",
+      "modality": "audio",
+      "artifact_class": "protected_raw",
+      "capture_start": "2026-07-15T18:05:00Z",
+      "capture_end": "2026-07-15T18:05:30Z",
+      "source_device_id": "device_phone_001",
+      "clock_quality": "synchronized",
+      "user_recall_available": false,
+      "retention_class": "protected_evidence",
+      "fidelity_class": "raw_original",
+      "generated": false,
+      "source_stream_refs": [],
+      "transform_method": null,
+      "transform_version": null,
+      "payload_ref": "protected://audio/stream_audio_protected_001",
+      "integrity": {"algorithm": "sha256", "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+    }
+  ],
+  "consent_transitions": [{"participant_id": "user_001", "effective_time": "2026-07-15T18:05:00Z", "scope": ["protected_audio_evidence"], "state": "granted", "authority_ref": "consent:user_001:audio-evidence"}],
+  "retention_policy": {"policy_id": "policy:audio:evidence:v1", "default_voice_mode": "protected_evidence", "raw_media_default": "protected_retention", "fidelity_reduction_allowed": false, "maximum_buffer_seconds": null},
+  "provenance_root": {"algorithm": "sha256", "digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+  "reconstruction_rights": [{"principal_id": "user_001", "scope": ["existence_receipt"], "may_access_raw": false, "may_generate_reconstruction": false, "expires_at": null}],
+  "completeness_status": "protected_evidence_unavailable",
+  "missing_evidence": [{"interval_start": "2026-07-15T18:05:00Z", "interval_end": "2026-07-15T18:05:30Z", "reason": "protected", "materiality": "material"}],
+  "fidelity_transitions": []
+}

--- a/fixtures/multimodal/sparse-video-reconstruction.json
+++ b/fixtures/multimodal/sparse-video-reconstruction.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "0.1",
+  "experience_id": "exp_sparse_video_001",
+  "start_time": "2026-07-15T18:10:00Z",
+  "end_time": "2026-07-15T18:11:00Z",
+  "participants": [{"participant_id": "user_001", "role": "subject", "identity_proof_ref": null}],
+  "authorized_devices": [{"device_id": "device_glasses_001", "authority_state": "authorized", "attestation_ref": "attestation:glasses:001"}],
+  "streams": [
+    {
+      "stream_id": "stream_video_sparse_001",
+      "modality": "video",
+      "artifact_class": "derived",
+      "capture_start": "2026-07-15T18:10:00Z",
+      "capture_end": "2026-07-15T18:11:00Z",
+      "source_device_id": "device_glasses_001",
+      "clock_quality": "bounded_drift",
+      "user_recall_available": true,
+      "retention_class": "searchable_derived",
+      "fidelity_class": "sparse_reconstruction_package",
+      "generated": false,
+      "source_stream_refs": ["stream_video_raw_001"],
+      "transform_method": "keyframe_motion_scene_state_extraction",
+      "transform_version": "sparse-video-0.1",
+      "payload_ref": "vault://derived/video/stream_video_sparse_001",
+      "integrity": {"algorithm": "sha256", "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}
+    },
+    {
+      "stream_id": "stream_video_rendered_001",
+      "modality": "video",
+      "artifact_class": "generated_reconstruction",
+      "capture_start": "2026-07-15T18:10:00Z",
+      "capture_end": "2026-07-15T18:11:00Z",
+      "source_device_id": null,
+      "clock_quality": "bounded_drift",
+      "user_recall_available": true,
+      "retention_class": "searchable_derived",
+      "fidelity_class": "scene_state_record",
+      "generated": true,
+      "source_stream_refs": ["stream_video_sparse_001"],
+      "transform_method": "governed_scene_render",
+      "transform_version": "scene-render-0.1",
+      "payload_ref": "vault://generated/video/stream_video_rendered_001",
+      "integrity": {"algorithm": "sha256", "digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}
+    }
+  ],
+  "consent_transitions": [{"participant_id": "user_001", "effective_time": "2026-07-15T18:10:00Z", "scope": ["video_capture", "sparse_reconstruction", "generated_replay"], "state": "granted", "authority_ref": "consent:user_001:sparse-video"}],
+  "retention_policy": {"policy_id": "policy:video:sparse:v1", "default_voice_mode": "no_derived_voice", "raw_media_default": "bounded_buffer", "fidelity_reduction_allowed": true, "maximum_buffer_seconds": 3600},
+  "provenance_root": {"algorithm": "sha256", "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+  "reconstruction_rights": [{"principal_id": "user_001", "scope": ["sparse_package", "generated_replay"], "may_access_raw": false, "may_generate_reconstruction": true, "expires_at": null}],
+  "completeness_status": "bounded_but_coherent",
+  "missing_evidence": [{"interval_start": "2026-07-15T18:10:00Z", "interval_end": "2026-07-15T18:11:00Z", "reason": "deleted_under_policy", "materiality": "minor"}],
+  "fidelity_transitions": [{"transition_id": "transition_video_sparse_001", "source_stream_id": "stream_video_raw_001", "from_class": "raw_original", "to_class": "sparse_reconstruction_package", "effective_time": "2026-07-15T19:10:00Z", "policy_ref": "policy:video:sparse:v1", "actor_ref": "device_glasses_001", "method": "keyframe_motion_scene_state_extraction", "information_loss": ["intermediate_frames", "fine_texture", "unmodeled_background_motion"], "reversible": false, "source_integrity": {"algorithm": "sha256", "digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}, "destination_integrity": {"algorithm": "sha256", "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}}]
+}

--- a/fixtures/multimodal/transcription-only-voice.json
+++ b/fixtures/multimodal/transcription-only-voice.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "0.1",
+  "experience_id": "exp_voice_20260715_001",
+  "start_time": "2026-07-15T18:00:00Z",
+  "end_time": "2026-07-15T18:00:12Z",
+  "participants": [
+    {"participant_id": "user_001", "role": "speaker", "identity_proof_ref": null},
+    {"participant_id": "auri_001", "role": "system", "identity_proof_ref": "proof:auri:001"}
+  ],
+  "authorized_devices": [
+    {"device_id": "device_phone_001", "authority_state": "authorized", "attestation_ref": "attestation:phone:001"}
+  ],
+  "streams": [
+    {
+      "stream_id": "stream_text_001",
+      "modality": "text",
+      "artifact_class": "derived",
+      "capture_start": "2026-07-15T18:00:00Z",
+      "capture_end": "2026-07-15T18:00:12Z",
+      "source_device_id": "device_phone_001",
+      "clock_quality": "synchronized",
+      "user_recall_available": true,
+      "retention_class": "searchable_derived",
+      "fidelity_class": "semantic_episode_record",
+      "generated": false,
+      "source_stream_refs": ["stream_audio_ephemeral_001"],
+      "transform_method": "speech_to_text",
+      "transform_version": "stt-local-0.1",
+      "payload_ref": "vault://derived/transcripts/stream_text_001",
+      "integrity": {"algorithm": "sha256", "digest": "1111111111111111111111111111111111111111111111111111111111111111"}
+    },
+    {
+      "stream_id": "stream_audio_ephemeral_001",
+      "modality": "audio",
+      "artifact_class": "continuity",
+      "capture_start": "2026-07-15T18:00:00Z",
+      "capture_end": "2026-07-15T18:00:12Z",
+      "source_device_id": "device_phone_001",
+      "clock_quality": "synchronized",
+      "user_recall_available": false,
+      "retention_class": "deleted_with_receipt",
+      "fidelity_class": "continuity_receipt_only",
+      "generated": false,
+      "source_stream_refs": [],
+      "transform_method": null,
+      "transform_version": null,
+      "payload_ref": null,
+      "integrity": {"algorithm": "sha256", "digest": "2222222222222222222222222222222222222222222222222222222222222222"}
+    }
+  ],
+  "consent_transitions": [
+    {
+      "participant_id": "user_001",
+      "effective_time": "2026-07-15T18:00:00Z",
+      "scope": ["transient_audio_capture", "speech_to_text"],
+      "state": "granted",
+      "authority_ref": "consent:user_001:001"
+    }
+  ],
+  "retention_policy": {
+    "policy_id": "policy:voice:transcription-only:v1",
+    "default_voice_mode": "transcription_only",
+    "raw_media_default": "discard_after_processing",
+    "fidelity_reduction_allowed": true,
+    "maximum_buffer_seconds": 30
+  },
+  "provenance_root": {"algorithm": "sha256", "digest": "3333333333333333333333333333333333333333333333333333333333333333"},
+  "reconstruction_rights": [
+    {
+      "principal_id": "user_001",
+      "scope": ["canonical_text", "synthesized_playback"],
+      "may_access_raw": false,
+      "may_generate_reconstruction": true,
+      "expires_at": null
+    }
+  ],
+  "completeness_status": "complete_for_declared_scope",
+  "missing_evidence": [],
+  "fidelity_transitions": [
+    {
+      "transition_id": "transition_audio_delete_001",
+      "source_stream_id": "stream_audio_ephemeral_001",
+      "from_class": "raw_original",
+      "to_class": "continuity_receipt_only",
+      "effective_time": "2026-07-15T18:00:20Z",
+      "policy_ref": "policy:voice:transcription-only:v1",
+      "actor_ref": "device_phone_001",
+      "method": "verified_transcription_then_delete",
+      "information_loss": ["original_voice", "background_audio", "prosody"],
+      "reversible": false,
+      "source_integrity": {"algorithm": "sha256", "digest": "4444444444444444444444444444444444444444444444444444444444444444"},
+      "destination_integrity": {"algorithm": "sha256", "digest": "2222222222222222222222222222222222222222222222222222222222222222"}
+    }
+  ]
+}

--- a/multimodal_storage/__init__.py
+++ b/multimodal_storage/__init__.py
@@ -1,0 +1,5 @@
+"""Fidelity-governed multimodal storage boundaries."""
+
+from .adapter import ExperienceAccessPlan, plan_experience_access
+
+__all__ = ["ExperienceAccessPlan", "plan_experience_access"]

--- a/multimodal_storage/adapter.py
+++ b/multimodal_storage/adapter.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ExperienceAccessPlan:
+    experience_id: str
+    principal_id: str
+    permitted_stream_ids: tuple[str, ...]
+    denied_stream_ids: tuple[str, ...]
+    may_generate_reconstruction: bool
+    completeness_status: str
+    raw_access_granted: bool
+
+
+def plan_experience_access(
+    capsule: Mapping[str, Any],
+    *,
+    principal_id: str,
+    requested_raw_access: bool = False,
+    requested_generation: bool = False,
+) -> ExperienceAccessPlan:
+    """Produce a fail-closed access plan for one validated ExperienceCapsule.
+
+    This adapter does not decrypt content and does not consume a reconstructive-
+    memory capability. It narrows a capsule to the streams permitted by its own
+    reconstruction-right declaration. A caller must still satisfy the existing
+    reconstructive-memory proof, capability, lifecycle, and receipt boundaries.
+    """
+
+    if not principal_id:
+        raise ValueError("principal_id is required")
+
+    rights = [
+        right
+        for right in capsule.get("reconstruction_rights", [])
+        if right.get("principal_id") == principal_id
+    ]
+    if len(rights) != 1:
+        raise PermissionError("exactly one reconstruction-right declaration is required")
+
+    right = rights[0]
+    may_access_raw = bool(right.get("may_access_raw", False))
+    may_generate = bool(right.get("may_generate_reconstruction", False))
+
+    if requested_raw_access and not may_access_raw:
+        raise PermissionError("protected raw-evidence access is not granted")
+    if requested_generation and not may_generate:
+        raise PermissionError("generated reconstruction is not granted")
+
+    permitted: list[str] = []
+    denied: list[str] = []
+    for stream in capsule.get("streams", []):
+        stream_id = stream.get("stream_id")
+        if not isinstance(stream_id, str) or not stream_id:
+            raise ValueError("capsule contains an invalid stream_id")
+
+        is_raw = stream.get("artifact_class") == "protected_raw"
+        is_generated = stream.get("artifact_class") == "generated_reconstruction"
+        recallable = stream.get("user_recall_available") is True
+
+        allowed = recallable
+        if is_raw:
+            allowed = requested_raw_access and may_access_raw
+        if is_generated:
+            allowed = requested_generation and may_generate and recallable
+
+        (permitted if allowed else denied).append(stream_id)
+
+    return ExperienceAccessPlan(
+        experience_id=str(capsule.get("experience_id", "")),
+        principal_id=principal_id,
+        permitted_stream_ids=tuple(permitted),
+        denied_stream_ids=tuple(denied),
+        may_generate_reconstruction=may_generate,
+        completeness_status=str(capsule.get("completeness_status", "materially_incomplete")),
+        raw_access_granted=requested_raw_access and may_access_raw,
+    )

--- a/schemas/experience-capsule.schema.json
+++ b/schemas/experience-capsule.schema.json
@@ -1,0 +1,224 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/experience-capsule.schema.json",
+  "title": "Experience Capsule",
+  "description": "A governed multimodal episode binding continuity, consent, retention, evidence, derived records, and reconstruction limits.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "experience_id",
+    "start_time",
+    "participants",
+    "authorized_devices",
+    "streams",
+    "consent_transitions",
+    "retention_policy",
+    "provenance_root",
+    "reconstruction_rights",
+    "completeness_status"
+  ],
+  "properties": {
+    "schema_version": {"const": "0.1"},
+    "experience_id": {"type": "string", "minLength": 8, "maxLength": 256},
+    "start_time": {"type": "string", "format": "date-time"},
+    "end_time": {"type": ["string", "null"], "format": "date-time"},
+    "participants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/participant"}
+    },
+    "authorized_devices": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/device"}
+    },
+    "streams": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/stream"}
+    },
+    "consent_transitions": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/consentTransition"}
+    },
+    "retention_policy": {"$ref": "#/$defs/retentionPolicy"},
+    "provenance_root": {"$ref": "#/$defs/integrityCommitment"},
+    "reconstruction_rights": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/reconstructionRight"}
+    },
+    "completeness_status": {
+      "enum": [
+        "complete_for_declared_scope",
+        "bounded_but_coherent",
+        "materially_incomplete",
+        "protected_evidence_unavailable",
+        "source_deleted_under_policy",
+        "timing_uncertain",
+        "interpretation_disputed",
+        "generated_only"
+      ]
+    },
+    "missing_evidence": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/missingEvidence"}
+    },
+    "fidelity_transitions": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/fidelityTransition"}
+    }
+  },
+  "$defs": {
+    "integrityCommitment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "digest"],
+      "properties": {
+        "algorithm": {"enum": ["sha256", "sha384", "sha512", "blake3"]},
+        "digest": {"type": "string", "pattern": "^[A-Fa-f0-9]{32,128}$"}
+      }
+    },
+    "participant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["participant_id", "role"],
+      "properties": {
+        "participant_id": {"type": "string", "minLength": 1},
+        "role": {"enum": ["speaker", "observer", "operator", "subject", "system", "unknown"]},
+        "identity_proof_ref": {"type": ["string", "null"]}
+      }
+    },
+    "device": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["device_id", "authority_state"],
+      "properties": {
+        "device_id": {"type": "string", "minLength": 1},
+        "authority_state": {"enum": ["authorized", "revoked", "expired", "unknown"]},
+        "attestation_ref": {"type": ["string", "null"]}
+      }
+    },
+    "stream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stream_id",
+        "modality",
+        "artifact_class",
+        "capture_start",
+        "clock_quality",
+        "user_recall_available",
+        "integrity"
+      ],
+      "properties": {
+        "stream_id": {"type": "string", "minLength": 1},
+        "modality": {"enum": ["text", "audio", "video", "image", "depth", "motion", "location", "biometric", "ambient", "other"]},
+        "artifact_class": {"enum": ["continuity", "derived", "protected_raw", "generated_reconstruction"]},
+        "capture_start": {"type": "string", "format": "date-time"},
+        "capture_end": {"type": ["string", "null"], "format": "date-time"},
+        "source_device_id": {"type": ["string", "null"]},
+        "clock_quality": {"enum": ["synchronized", "bounded_drift", "local_only", "uncertain"]},
+        "user_recall_available": {"type": "boolean"},
+        "retention_class": {"enum": ["permanent_continuity", "searchable_derived", "protected_evidence", "ephemeral", "deleted_with_receipt"]},
+        "fidelity_class": {"enum": ["raw_original", "high_fidelity_evidence", "sparse_reconstruction_package", "scene_state_record", "semantic_episode_record", "continuity_receipt_only", "not_applicable"]},
+        "generated": {"type": "boolean", "default": false},
+        "source_stream_refs": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "transform_method": {"type": ["string", "null"]},
+        "transform_version": {"type": ["string", "null"]},
+        "payload_ref": {"type": ["string", "null"]},
+        "integrity": {"$ref": "#/$defs/integrityCommitment"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"artifact_class": {"const": "generated_reconstruction"}}, "required": ["artifact_class"]},
+          "then": {
+            "required": ["generated", "source_stream_refs", "transform_method", "transform_version"],
+            "properties": {"generated": {"const": true}}
+          }
+        },
+        {
+          "if": {"properties": {"retention_class": {"const": "ephemeral"}}, "required": ["retention_class"]},
+          "then": {"properties": {"payload_ref": {"type": "null"}}}
+        }
+      ]
+    },
+    "consentTransition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["participant_id", "effective_time", "scope", "state", "authority_ref"],
+      "properties": {
+        "participant_id": {"type": "string"},
+        "effective_time": {"type": "string", "format": "date-time"},
+        "scope": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "state": {"enum": ["granted", "restricted", "withdrawn", "expired", "emergency_exception"]},
+        "authority_ref": {"type": "string"}
+      }
+    },
+    "retentionPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_id", "default_voice_mode", "raw_media_default", "fidelity_reduction_allowed"],
+      "properties": {
+        "policy_id": {"type": "string"},
+        "default_voice_mode": {"enum": ["transcription_only", "verification_buffer", "protected_evidence", "no_derived_voice"]},
+        "raw_media_default": {"enum": ["discard_after_processing", "bounded_buffer", "protected_retention", "prohibited"]},
+        "fidelity_reduction_allowed": {"type": "boolean"},
+        "maximum_buffer_seconds": {"type": ["integer", "null"], "minimum": 0}
+      }
+    },
+    "reconstructionRight": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["principal_id", "scope", "may_access_raw", "may_generate_reconstruction"],
+      "properties": {
+        "principal_id": {"type": "string"},
+        "scope": {"type": "array", "items": {"type": "string"}},
+        "may_access_raw": {"type": "boolean"},
+        "may_generate_reconstruction": {"type": "boolean"},
+        "expires_at": {"type": ["string", "null"], "format": "date-time"}
+      }
+    },
+    "missingEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["interval_start", "reason", "materiality"],
+      "properties": {
+        "interval_start": {"type": "string", "format": "date-time"},
+        "interval_end": {"type": ["string", "null"], "format": "date-time"},
+        "reason": {"enum": ["not_captured", "deleted_under_policy", "protected", "corrupt", "timing_uncertain", "device_unavailable", "consent_not_granted"]},
+        "materiality": {"enum": ["none", "minor", "material", "unknown"]}
+      }
+    },
+    "fidelityTransition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "transition_id",
+        "source_stream_id",
+        "from_class",
+        "to_class",
+        "effective_time",
+        "policy_ref",
+        "actor_ref",
+        "information_loss",
+        "reversible",
+        "source_integrity",
+        "destination_integrity"
+      ],
+      "properties": {
+        "transition_id": {"type": "string"},
+        "source_stream_id": {"type": "string"},
+        "from_class": {"enum": ["raw_original", "high_fidelity_evidence", "sparse_reconstruction_package", "scene_state_record", "semantic_episode_record", "continuity_receipt_only"]},
+        "to_class": {"enum": ["high_fidelity_evidence", "sparse_reconstruction_package", "scene_state_record", "semantic_episode_record", "continuity_receipt_only"]},
+        "effective_time": {"type": "string", "format": "date-time"},
+        "policy_ref": {"type": "string"},
+        "actor_ref": {"type": "string"},
+        "method": {"type": ["string", "null"]},
+        "information_loss": {"type": "array", "items": {"type": "string"}},
+        "reversible": {"type": "boolean"},
+        "source_integrity": {"$ref": "#/$defs/integrityCommitment"},
+        "destination_integrity": {"$ref": "#/$defs/integrityCommitment"}
+      }
+    }
+  }
+}

--- a/tests/test_experience_capsule.py
+++ b/tests/test_experience_capsule.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+import unittest
+
+from tools.validate_experience_capsule import CapsuleValidationError, validate_capsule
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "fixtures" / "multimodal"
+
+
+class ExperienceCapsuleTests(unittest.TestCase):
+    def load(self, name: str) -> dict:
+        return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+    def test_all_reference_fixtures_validate(self) -> None:
+        for path in sorted(FIXTURES.glob("*.json")):
+            with self.subTest(path=path.name):
+                validate_capsule(json.loads(path.read_text(encoding="utf-8")))
+
+    def test_generated_reconstruction_requires_label_and_sources(self) -> None:
+        capsule = self.load("sparse-video-reconstruction.json")
+        generated = next(s for s in capsule["streams"] if s["artifact_class"] == "generated_reconstruction")
+        generated["generated"] = False
+        with self.assertRaisesRegex(CapsuleValidationError, "generated=true"):
+            validate_capsule(capsule)
+
+        capsule = self.load("sparse-video-reconstruction.json")
+        generated = next(s for s in capsule["streams"] if s["artifact_class"] == "generated_reconstruction")
+        generated["source_stream_refs"] = []
+        with self.assertRaisesRegex(CapsuleValidationError, "source_stream_refs"):
+            validate_capsule(capsule)
+
+    def test_ephemeral_stream_cannot_have_payload_reference(self) -> None:
+        capsule = self.load("transcription-only-voice.json")
+        audio = next(s for s in capsule["streams"] if s["modality"] == "audio")
+        audio["retention_class"] = "ephemeral"
+        audio["payload_ref"] = "vault://forbidden/raw-audio"
+        with self.assertRaisesRegex(CapsuleValidationError, "ephemeral stream"):
+            validate_capsule(capsule)
+
+    def test_transcription_only_cannot_grant_original_audio_recall(self) -> None:
+        capsule = self.load("transcription-only-voice.json")
+        audio = next(s for s in capsule["streams"] if s["modality"] == "audio")
+        audio["user_recall_available"] = True
+        with self.assertRaisesRegex(CapsuleValidationError, "may not be user recallable"):
+            validate_capsule(capsule)
+
+        capsule = self.load("transcription-only-voice.json")
+        capsule["reconstruction_rights"][0]["may_access_raw"] = True
+        with self.assertRaisesRegex(CapsuleValidationError, "raw-audio access"):
+            validate_capsule(capsule)
+
+    def test_fidelity_transition_requires_loss_and_reversibility(self) -> None:
+        capsule = self.load("sparse-video-reconstruction.json")
+        capsule["fidelity_transitions"][0]["information_loss"] = []
+        with self.assertRaisesRegex(CapsuleValidationError, "information_loss"):
+            validate_capsule(capsule)
+
+        capsule = self.load("transcription-only-voice.json")
+        capsule["fidelity_transitions"][0]["reversible"] = True
+        with self.assertRaisesRegex(CapsuleValidationError, "cannot be reversible"):
+            validate_capsule(capsule)
+
+    def test_material_missing_evidence_cannot_be_complete(self) -> None:
+        capsule = self.load("incomplete-experience.json")
+        capsule["completeness_status"] = "complete_for_declared_scope"
+        with self.assertRaisesRegex(CapsuleValidationError, "material missing evidence"):
+            validate_capsule(capsule)
+
+    def test_duplicate_stream_ids_fail(self) -> None:
+        capsule = self.load("sparse-video-reconstruction.json")
+        duplicate = copy.deepcopy(capsule["streams"][0])
+        capsule["streams"].append(duplicate)
+        with self.assertRaisesRegex(CapsuleValidationError, "duplicate stream_id"):
+            validate_capsule(capsule)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multimodal_storage_adapter.py
+++ b/tests/test_multimodal_storage_adapter.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+from multimodal_storage.adapter import plan_experience_access
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "fixtures" / "multimodal"
+
+
+class MultimodalStorageAdapterTests(unittest.TestCase):
+    def load(self, name: str) -> dict:
+        return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+    def test_transcription_recall_does_not_grant_original_audio(self) -> None:
+        capsule = self.load("transcription-only-voice.json")
+        plan = plan_experience_access(capsule, principal_id="user_001")
+        self.assertEqual(plan.permitted_stream_ids, ("stream_text_001",))
+        self.assertIn("stream_audio_ephemeral_001", plan.denied_stream_ids)
+        self.assertFalse(plan.raw_access_granted)
+
+    def test_raw_request_fails_without_explicit_right(self) -> None:
+        capsule = self.load("protected-audio-evidence.json")
+        with self.assertRaisesRegex(PermissionError, "raw-evidence access"):
+            plan_experience_access(capsule, principal_id="user_001", requested_raw_access=True)
+
+    def test_generated_reconstruction_requires_explicit_request(self) -> None:
+        capsule = self.load("sparse-video-reconstruction.json")
+        default_plan = plan_experience_access(capsule, principal_id="user_001")
+        self.assertIn("stream_video_sparse_001", default_plan.permitted_stream_ids)
+        self.assertIn("stream_video_rendered_001", default_plan.denied_stream_ids)
+
+        generated_plan = plan_experience_access(
+            capsule,
+            principal_id="user_001",
+            requested_generation=True,
+        )
+        self.assertIn("stream_video_rendered_001", generated_plan.permitted_stream_ids)
+
+    def test_unknown_principal_fails_closed(self) -> None:
+        capsule = self.load("transcription-only-voice.json")
+        with self.assertRaisesRegex(PermissionError, "exactly one"):
+            plan_experience_access(capsule, principal_id="unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_experience_capsule.py
+++ b/tools/validate_experience_capsule.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FIXTURES = ROOT / "fixtures" / "multimodal"
+
+ALLOWED_COMPLETENESS = {
+    "complete_for_declared_scope",
+    "bounded_but_coherent",
+    "materially_incomplete",
+    "protected_evidence_unavailable",
+    "source_deleted_under_policy",
+    "timing_uncertain",
+    "interpretation_disputed",
+    "generated_only",
+}
+
+
+class CapsuleValidationError(ValueError):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise CapsuleValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CapsuleValidationError(f"cannot read JSON: {exc}") from exc
+    require(isinstance(data, dict), "capsule root must be an object")
+    return data
+
+
+def validate_capsule(data: dict[str, Any]) -> None:
+    required = {
+        "schema_version",
+        "experience_id",
+        "start_time",
+        "participants",
+        "authorized_devices",
+        "streams",
+        "consent_transitions",
+        "retention_policy",
+        "provenance_root",
+        "reconstruction_rights",
+        "completeness_status",
+    }
+    missing = sorted(required - data.keys())
+    require(not missing, f"missing required fields: {', '.join(missing)}")
+    require(data["schema_version"] == "0.1", "unsupported schema_version")
+    require(isinstance(data["streams"], list) and data["streams"], "streams must be a non-empty list")
+    require(data["completeness_status"] in ALLOWED_COMPLETENESS, "invalid completeness_status")
+
+    stream_ids: set[str] = set()
+    has_material_missing = False
+    for item in data.get("missing_evidence", []):
+        require(isinstance(item, dict), "missing_evidence entries must be objects")
+        if item.get("materiality") in {"material", "unknown"}:
+            has_material_missing = True
+
+    for stream in data["streams"]:
+        require(isinstance(stream, dict), "stream entries must be objects")
+        stream_id = stream.get("stream_id")
+        require(isinstance(stream_id, str) and stream_id, "stream_id is required")
+        require(stream_id not in stream_ids, f"duplicate stream_id: {stream_id}")
+        stream_ids.add(stream_id)
+
+        artifact_class = stream.get("artifact_class")
+        retention_class = stream.get("retention_class")
+        generated = stream.get("generated", False)
+        payload_ref = stream.get("payload_ref")
+
+        if artifact_class == "generated_reconstruction":
+            require(generated is True, f"{stream_id}: generated reconstruction must set generated=true")
+            require(bool(stream.get("source_stream_refs")), f"{stream_id}: generated reconstruction requires source_stream_refs")
+            require(bool(stream.get("transform_method")), f"{stream_id}: generated reconstruction requires transform_method")
+            require(bool(stream.get("transform_version")), f"{stream_id}: generated reconstruction requires transform_version")
+        else:
+            require(generated is not True, f"{stream_id}: only generated_reconstruction may set generated=true")
+
+        if retention_class == "ephemeral":
+            require(payload_ref is None, f"{stream_id}: ephemeral stream may not expose a durable payload_ref")
+
+        if retention_class in {"deleted_with_receipt", "continuity_receipt_only"}:
+            require(payload_ref is None, f"{stream_id}: deleted or receipt-only stream may not retain payload_ref")
+
+    policy = data["retention_policy"]
+    require(isinstance(policy, dict), "retention_policy must be an object")
+    voice_mode = policy.get("default_voice_mode")
+    rights = data["reconstruction_rights"]
+    require(isinstance(rights, list), "reconstruction_rights must be a list")
+
+    if voice_mode == "transcription_only":
+        for stream in data["streams"]:
+            if stream.get("modality") == "audio":
+                require(stream.get("user_recall_available") is False, "transcription_only audio may not be user recallable")
+        for right in rights:
+            require(right.get("may_access_raw") is False, "transcription_only policy may not grant raw-audio access")
+
+    transitions = data.get("fidelity_transitions", [])
+    require(isinstance(transitions, list), "fidelity_transitions must be a list")
+    for transition in transitions:
+        require(isinstance(transition, dict), "fidelity transition must be an object")
+        require(bool(transition.get("information_loss")), "fidelity transition must declare information_loss")
+        require(isinstance(transition.get("reversible"), bool), "fidelity transition must declare reversible")
+        if transition.get("to_class") == "continuity_receipt_only":
+            require(transition.get("reversible") is False, "receipt-only transition cannot be reversible")
+
+    completeness = data["completeness_status"]
+    if has_material_missing:
+        require(completeness != "complete_for_declared_scope", "material missing evidence cannot be complete_for_declared_scope")
+    if completeness == "complete_for_declared_scope":
+        require(not data.get("missing_evidence"), "complete_for_declared_scope cannot declare missing evidence")
+    if completeness == "generated_only":
+        require(all(s.get("artifact_class") == "generated_reconstruction" for s in data["streams"]), "generated_only requires all streams to be generated reconstructions")
+
+
+def validate_path(path: Path) -> None:
+    validate_capsule(load_json(path))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate governed ExperienceCapsule fixtures.")
+    parser.add_argument("paths", nargs="*", type=Path, help="Capsule JSON files. Defaults to fixtures/multimodal/*.json")
+    args = parser.parse_args()
+
+    paths = args.paths or sorted(DEFAULT_FIXTURES.glob("*.json"))
+    if not paths:
+        raise SystemExit("EXPERIENCE CAPSULE VALIDATION FAILED: no capsule files found")
+
+    failures: list[str] = []
+    for path in paths:
+        try:
+            validate_path(path)
+            print(f"PASS {path}")
+        except CapsuleValidationError as exc:
+            failures.append(f"{path}: {exc}")
+            print(f"FAIL {path}: {exc}")
+
+    if failures:
+        raise SystemExit("EXPERIENCE CAPSULE VALIDATION FAILED\n" + "\n".join(failures))
+
+    print("EXPERIENCE CAPSULE VALIDATION PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Add the governed multimodal episode and storage layer above the reconstructive-memory v0.1 state machines merged in PR #14.

## Implemented

- readable fidelity-governed multimodal storage specification;
- machine-readable `ExperienceCapsule` schema;
- transcription-only voice, protected audio, sparse-video, and incomplete-experience fixtures;
- dependency-free capsule validator and invariant tests;
- multimodal access adapter that permits canonical text and authorized derived recall without granting protected raw-media access by implication;
- explicit generated-reconstruction request and authorization boundary;
- dedicated GitHub Actions validation;
- authoritative mirror-handoff and Unreleased changelog updates.

## Enforced boundaries

- Raw evidence, derived records, continuity metadata, ephemeral state, and generated reconstructions remain distinct.
- A transcript does not imply original-audio recall.
- Text-to-speech is synthesized presentation, not replay of the original event.
- Generated reconstruction is never original evidence and requires explicit source links, intent, and rights.
- Ordinary recall rights do not grant protected raw-media access.
- Ephemeral or deleted streams do not expose durable payload references.
- Fidelity reduction declares information loss, reversibility, integrity, policy, actor, and effective time.
- Materially missing evidence cannot be reported as complete.

## Validation

Run:

```bash
python3 tools/validate_experience_capsule.py
python3 -m unittest tests.test_experience_capsule tests.test_multimodal_storage_adapter
```

The dedicated `Fidelity-Governed Storage Validation` workflow compiles and runs those gates. PR readiness remains contingent on every current-head workflow completing successfully.

## Release boundary

This is a backward-compatible optional layer. Publication, tagging, and downstream determination remain owned by the repository's existing verified release lifecycle after merge.