### PR TITLE
Add executable production provider probes

### DIFF
--- a/reconstructive_memory/__init__.py
+++ b/reconstructive_memory/__init__.py
@@ -5,7 +5,8 @@ continuity, pair-bound authorization, authenticated minimized ingestion, bounded
 ephemeral reconstruction, durable replay controls, lifecycle tombstones,
 plaintext-free journals, authoritative commit boundaries, receipt propagation,
 deployment adapter contracts, provider activation receipts, fail-closed provider
-readiness, and live conformance evidence without storing plaintext chat in the chain.
+readiness, live conformance evidence, and concrete provider probes without storing
+plaintext chat in the chain.
 """
 
 from .access import AccessReceipt, CallableKeyUnwrapper, KeyUnwrapper, RelationshipRegistry, RelationshipState, make_access_receipt
@@ -20,6 +21,7 @@ from .master_records_state import DurableMasterRecordsOutbox, InMemoryMasterReco
 from .proofs import CallableProofVerifier, ProofVerifier, require_dual_proof
 from .provider_activation import DeploymentReceipt, ProductionActivationProfile, ProviderSelection, default_aws_profile
 from .provider_conformance import ConformanceReport, ProviderProbe, ProviderProbeResult, assemble_deployment_receipt, run_provider_conformance
+from .provider_probes import AwsCliProbe, CommandRunner, HttpProbeClient, HttpsEndpointProbe, SpiffeWorkloadProbe, UrlLibHttpProbeClient, default_live_probes
 from .readiness import REQUIRED_PROVIDERS, ReadinessReport, load_and_validate, validate_provider_profile
 from .replay import DurableTransportReplayRegistry, InMemoryReplayStateStore, ReplayState, ReplayStateStore
 from .routing import OpaqueRouteEntry, OpaqueRouteIndex, validate_candidate_events

--- a/reconstructive_memory/provider_probes.py
+++ b/reconstructive_memory/provider_probes.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+import os
+from typing import Mapping, Protocol, Sequence
+from urllib.request import Request, urlopen
+
+from .provider_activation import ProductionActivationProfile, ProviderSelection
+from .provider_conformance import ProviderProbeResult
+
+
+def _commit(value: object) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + sha256(payload).hexdigest()
+
+
+class CommandRunner(Protocol):
+    def run_json(self, argv: Sequence[str]) -> Mapping[str, object]: ...
+
+
+class HttpProbeClient(Protocol):
+    def head(self, url: str, headers: Mapping[str, str]) -> tuple[int, Mapping[str, str]]: ...
+
+
+class UrlLibHttpProbeClient:
+    def head(self, url: str, headers: Mapping[str, str]) -> tuple[int, Mapping[str, str]]:
+        request = Request(url, method="HEAD", headers=dict(headers))
+        with urlopen(request, timeout=10) as response:
+            return response.status, dict(response.headers.items())
+
+
+@dataclass(frozen=True)
+class AwsCliProbe:
+    role: str
+    selection_name: str
+    service: str
+    operation: str
+    runner: CommandRunner
+
+    def run(self, profile: ProductionActivationProfile, *, checked_at: int) -> ProviderProbeResult:
+        selection: ProviderSelection = getattr(profile, self.selection_name)
+        argv = ["aws", self.service, self.operation, "--region", selection.region, "--output", "json"]
+        if self.service == "kms":
+            argv += ["--key-id", selection.identity_ref]
+        elif self.service == "dynamodb":
+            argv += ["--table-name", selection.identity_ref]
+        try:
+            observed = self.runner.run_json(argv)
+            identity = str(observed.get("KeyMetadata", observed.get("Table", observed)))
+            success = True
+            failure = None
+        except Exception as exc:  # adapter converts provider errors into bounded evidence
+            identity = selection.identity_ref
+            success = False
+            failure = type(exc).__name__.upper()
+            observed = {"error_type": type(exc).__name__}
+        result = ProviderProbeResult(
+            role=self.role,
+            resource_id=selection.identity_ref,
+            observed_identity=identity,
+            capability=f"{self.service}:{self.operation}",
+            success=success,
+            evidence_commitment=_commit(observed),
+            checked_at=checked_at,
+            failure_code=failure,
+        ).with_hash()
+        result.verify()
+        return result
+
+
+@dataclass(frozen=True)
+class SpiffeWorkloadProbe:
+    socket_env: str = "SPIFFE_ENDPOINT_SOCKET"
+
+    def run(self, profile: ProductionActivationProfile, *, checked_at: int) -> ProviderProbeResult:
+        selection = profile.ai_attestation
+        socket = os.environ.get(self.socket_env, "")
+        success = bool(socket and socket.startswith("unix://") and "UNCONFIGURED" not in selection.identity_ref)
+        observed = {"socket": socket, "spiffe_id": selection.identity_ref}
+        result = ProviderProbeResult(
+            role="ai-entity-attestation",
+            resource_id=selection.identity_ref,
+            observed_identity=selection.identity_ref if success else "SPIFFE_ID_UNOBSERVED",
+            capability="spiffe:workload-api-socket",
+            success=success,
+            evidence_commitment=_commit(observed),
+            checked_at=checked_at,
+            failure_code=None if success else "SPIFFE_WORKLOAD_API_UNAVAILABLE",
+        ).with_hash()
+        result.verify()
+        return result
+
+
+@dataclass(frozen=True)
+class HttpsEndpointProbe:
+    role: str
+    selection_name: str
+    client: HttpProbeClient
+    token_env: str
+
+    def run(self, profile: ProductionActivationProfile, *, checked_at: int) -> ProviderProbeResult:
+        selection: ProviderSelection = getattr(profile, self.selection_name)
+        token = os.environ.get(self.token_env, "")
+        headers = {"Authorization": "Bearer " + token} if token else {}
+        try:
+            status, response_headers = self.client.head(selection.identity_ref, headers)
+            success = 200 <= status < 400 and bool(token)
+            failure = None if success else "ENDPOINT_AUTHENTICATION_FAILED"
+            observed = {"status": status, "headers": dict(sorted(response_headers.items()))}
+        except Exception as exc:
+            success = False
+            failure = type(exc).__name__.upper()
+            observed = {"error_type": type(exc).__name__}
+        result = ProviderProbeResult(
+            role=self.role,
+            resource_id=selection.identity_ref,
+            observed_identity=selection.identity_ref,
+            capability="https:authenticated-head",
+            success=success,
+            evidence_commitment=_commit(observed),
+            checked_at=checked_at,
+            failure_code=failure,
+        ).with_hash()
+        result.verify()
+        return result
+
+
+def default_live_probes(*, runner: CommandRunner, http_client: HttpProbeClient | None = None) -> tuple[object, ...]:
+    client = http_client or UrlLibHttpProbeClient()
+    return (
+        AwsCliProbe("steg-id-signature", "steg_id", "kms", "describe-key", runner),
+        SpiffeWorkloadProbe(),
+        AwsCliProbe("key-custody", "key_custody", "kms", "describe-key", runner),
+        AwsCliProbe("replicated-state", "state_store", "dynamodb", "describe-table", runner),
+        HttpsEndpointProbe("ecosystem-chat", "chat_transport", client, "ECOSYSTEM_CHAT_PROBE_TOKEN"),
+        HttpsEndpointProbe("master-records", "master_records", client, "MASTER_RECORDS_PROBE_TOKEN"),
+    )

--- a/tests/test_reconstructive_memory_provider_probes.py
+++ b/tests/test_reconstructive_memory_provider_probes.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from reconstructive_memory.provider_activation import ProductionActivationProfile, ProviderSelection
+from reconstructive_memory.provider_probes import AwsCliProbe, HttpsEndpointProbe, SpiffeWorkloadProbe, default_live_probes
+
+
+class Runner:
+    def __init__(self, fail: bool = False) -> None:
+        self.fail = fail
+        self.calls: list[list[str]] = []
+
+    def run_json(self, argv):
+        self.calls.append(list(argv))
+        if self.fail:
+            raise RuntimeError("provider unavailable")
+        return {"KeyMetadata": {"Arn": "arn:observed"}}
+
+
+class HttpClient:
+    def __init__(self, status: int = 204) -> None:
+        self.status = status
+        self.headers = None
+
+    def head(self, url, headers):
+        self.headers = dict(headers)
+        return self.status, {"x-provider-id": "observed"}
+
+
+def selection(role: str, identity: str, region: str = "global") -> ProviderSelection:
+    return ProviderSelection(role, "provider", "service", identity, region, "verified")
+
+
+def profile() -> ProductionActivationProfile:
+    return ProductionActivationProfile(
+        profile_id="prod-1",
+        environment="production",
+        steg_id=selection("steg-id-signature", "arn:kms:steg", "us-east-1"),
+        ai_attestation=selection("ai-entity-attestation", "spiffe://stegverse/ai"),
+        key_custody=selection("key-custody", "arn:kms:custody", "us-east-1"),
+        state_store=selection("replicated-state", "table-prod", "us-east-1"),
+        chat_transport=selection("ecosystem-chat", "https://chat.example.test/health"),
+        master_records=selection("master-records", "https://records.example.test/health"),
+        rollback_ref="docs/rollback.md",
+        created_at=1,
+    ).with_hash()
+
+
+class ProviderProbeTests(unittest.TestCase):
+    def test_aws_probe_uses_configured_resource(self) -> None:
+        runner = Runner()
+        result = AwsCliProbe("steg-id-signature", "steg_id", "kms", "describe-key", runner).run(profile(), checked_at=2)
+        self.assertTrue(result.success)
+        self.assertIn("arn:kms:steg", runner.calls[0])
+        result.verify()
+
+    def test_aws_failure_is_bounded(self) -> None:
+        result = AwsCliProbe("key-custody", "key_custody", "kms", "describe-key", Runner(True)).run(profile(), checked_at=2)
+        self.assertFalse(result.success)
+        self.assertEqual(result.failure_code, "RUNTIMEERROR")
+
+    def test_spiffe_requires_workload_socket(self) -> None:
+        with patch.dict(os.environ, {"SPIFFE_ENDPOINT_SOCKET": "unix:///run/spire/sockets/agent.sock"}, clear=False):
+            result = SpiffeWorkloadProbe().run(profile(), checked_at=2)
+        self.assertTrue(result.success)
+
+    def test_https_probe_requires_token(self) -> None:
+        client = HttpClient()
+        with patch.dict(os.environ, {}, clear=True):
+            result = HttpsEndpointProbe("ecosystem-chat", "chat_transport", client, "CHAT_TOKEN").run(profile(), checked_at=2)
+        self.assertFalse(result.success)
+        self.assertNotIn("Authorization", client.headers)
+
+    def test_https_probe_does_not_commit_token(self) -> None:
+        client = HttpClient()
+        with patch.dict(os.environ, {"CHAT_TOKEN": "secret-value"}, clear=True):
+            result = HttpsEndpointProbe("ecosystem-chat", "chat_transport", client, "CHAT_TOKEN").run(profile(), checked_at=2)
+        self.assertTrue(result.success)
+        self.assertNotIn("secret-value", str(result.payload()))
+
+    def test_default_probe_set_covers_six_roles(self) -> None:
+        probes = default_live_probes(runner=Runner(), http_client=HttpClient())
+        self.assertEqual(len(probes), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_reconstructive_memory.py
+++ b/tools/check_reconstructive_memory.py
@@ -26,13 +26,14 @@ REQUIRED = (
     ROOT / "reconstructive_memory" / "provider_activation.py",
     ROOT / "reconstructive_memory" / "readiness.py",
     ROOT / "reconstructive_memory" / "provider_conformance.py",
+    ROOT / "reconstructive_memory" / "provider_probes.py",
     ROOT / "schemas" / "reconstructive-memory-event.v0.1.json",
     ROOT / "schemas" / "reconstructive-memory-access-receipt.v0.1.json",
     ROOT / "docs" / "RECONSTRUCTIVE_AI_MEMORY.md",
     ROOT / "docs" / "PRODUCTION_PROVIDER_ACTIVATION.md",
 )
 
-SCHEMAS = REQUIRED[17:19]
+SCHEMAS = REQUIRED[18:20]
 
 
 def fail(message: str) -> None:
@@ -73,6 +74,7 @@ def main() -> int:
     print("- external CAS store and delivery adapter contracts: present")
     print("- concrete provider selection and readiness gate: present")
     print("- live provider conformance and receipt assembly: present")
+    print("- executable AWS, SPIFFE, and HTTPS provider probes: present")
     print("- external resource identifiers and credentials: UNCONFIGURED")
     return 0
 


### PR DESCRIPTION
## Purpose

Complete the last repository-owned execution layer for issue #16 by adding concrete probe adapters for the selected production providers.

## Added

- AWS CLI metadata probes for KMS key identity and DynamoDB table identity;
- SPIFFE/SPIRE workload API socket probe;
- authenticated HTTPS endpoint probes for Ecosystem Chat and Master-Records;
- environment-only bearer token handling with no token material in evidence;
- bounded provider failure codes and committed metadata-only observations;
- a default six-probe set matching the canonical provider roles;
- tests for configured resource usage, bounded AWS failure, SPIFFE availability, authentication refusal, secret exclusion, and role coverage;
- package exports and reconstructive-memory validator integration.

## Security boundary

The adapters perform metadata and endpoint-identity checks only. They do not provision resources, mutate provider state, expose credentials, or claim successful live conformance without configured resources and environment credentials.

## Validation

`python3 tools/check_reconstructive_memory.py`

Issue #16 remains open until the real resources are configured and these probes execute successfully against them.