### PR TITLE
Fix final release receipt commit ordering

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Commit final release receipt
         if: steps.gate.outputs.enabled == 'true'
         run: |
-          git pull --rebase origin main
           git add docs/release_evidence/latest_release.md docs/release_evidence/latest_release.json
           git commit -m "evidence: record published release v${{ steps.version.outputs.value }} [skip ci]"
+          git pull --rebase origin main
           git push origin HEAD:main


### PR DESCRIPTION
## Root cause

The `v0.1.4` release workflow completed candidate verification, version commit, tag push, asset publication, and receipt generation, then failed in `Commit final release receipt`.

The step attempted `git pull --rebase origin main` while the newly generated receipt files were still unstaged. Git refuses a rebase pull with unstaged changes, so the release existed but its final receipt was not committed.

## Fix

Commit the generated receipt first, then rebase that clean commit onto the latest `main`, and push.

## Scope

This changes only the ordering of the final receipt persistence step. It does not modify release eligibility, version selection, verification, tagging, asset publication, or receipt content.