### PR TITLE
Reconcile v0.1.4 release evidence and downstream determinations

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Commit final release receipt
         if: steps.gate.outputs.enabled == 'true'
         run: |
-          git pull --rebase origin main
           git add docs/release_evidence/latest_release.md docs/release_evidence/latest_release.json
           git commit -m "evidence: record published release v${{ steps.version.outputs.value }} [skip ci]"
+          git pull --rebase origin main
           git push origin HEAD:main


### PR DESCRIPTION
## Durable state

- PR #20 merged the fidelity-governed multimodal storage activation.
- The release workflow created version `0.1.4`, tag `v0.1.4`, and published assets.
- Workflow run `29442255246` failed only at the final receipt commit step after publication.
- PR #22 fixed the receipt commit ordering for future releases.
- `docs/release_evidence/latest_release.json` still identifies `v0.1.3`, so `v0.1.4` must not be considered fully reconciled yet.

## Required reconciliation

1. Verify the existing `v0.1.4` GitHub release and its three assets.
2. Reconstruct and commit `latest_release.md` and `latest_release.json` from the published artifact, SHA-256 sidecar, manifest, release commit `eed058820fc63a5d7cbf554b29ac65f4baa93516`, and workflow run `29442255246`.
3. Record a reconciled release-cycle outcome without creating a duplicate tag or release.
4. Verify or generate downstream determination receipts for:
   - `StegVerse-Labs/Site`
   - `GCAT-BCAT-Engine/Publisher`
   - `StegVerse-Labs/admissibility-wiki`
   - `StegVerse-002/stegguardian-wiki`
5. Update `docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md` only after authoritative receipts agree.

## Safety boundary

Do not rerun version selection or create `v0.1.5` merely to repair evidence for the already-published `v0.1.4`. Reconciliation must be idempotent and must not certify user-authored content.