### PR TITLE
Add deployable production provider infrastructure

### DIFF
--- a/docs/PRODUCTION_PROVIDER_PROVISIONING.md
+++ b/docs/PRODUCTION_PROVIDER_PROVISIONING.md
@@ -1,0 +1,64 @@
+# Production Provider Provisioning
+
+This document reduces issue #16's remaining infrastructure work to an apply-and-record sequence. It does not authorize production activation by itself.
+
+## 1. Provision AWS resources
+
+From `infra/production-providers`:
+
+```bash
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+terraform output -json > provider-outputs.json
+```
+
+The module creates:
+
+- an asymmetric AWS KMS key for StegID signing and verification;
+- a rotating symmetric AWS KMS key for memory wrapping and custody;
+- a deletion-protected, point-in-time-recoverable DynamoDB table encrypted with the custody key.
+
+Do not commit Terraform state, credentials, plans, or provider tokens.
+
+## 2. Populate the activation profile
+
+Map Terraform outputs into the configured provider profile:
+
+- `stegid_kms_key_arn` -> StegID verification resource identifier;
+- `custody_kms_key_arn` -> key-custody resource identifier;
+- `authoritative_state_table_arn` -> replicated-state resource identifier;
+- `aws_region` -> the region for all three AWS providers.
+
+Keep each provider status below `verified` until its executable probe succeeds.
+
+## 3. Register the SPIFFE workload
+
+Copy `spire-entry.template.json` outside the repository, replace all `UNCONFIGURED` values, and create the entry through the authorized SPIRE server.
+
+The resulting workload identity must exactly match the AI-attestation resource identifier in the activation profile. The runtime must receive `SPIFFE_ENDPOINT_SOCKET` through its deployment environment.
+
+## 4. Configure service endpoints
+
+Supply absolute HTTPS endpoints and environment-only probe tokens for Ecosystem Chat and Master-Records. Tokens and endpoint credentials must not be written into repository files, workflow logs, conformance reports, or deployment receipts.
+
+## 5. Execute readiness and conformance
+
+Run the merged readiness validator, followed by the canonical six-provider probe set. Retain only committed metadata evidence and bounded failure codes.
+
+Activation remains denied unless:
+
+1. the configured profile passes readiness validation;
+2. all six provider probes succeed;
+3. the conformance report matches the exact profile commitment;
+4. the signed deployment receipt is retained;
+5. rollback and revocation evidence is present;
+6. repository validation remains green.
+
+## 6. Rollback
+
+A failed activation attempt must not destroy evidence or silently weaken custody. Disable endpoint access, revoke workload identity, stop new writes, preserve unresolved Master-Records exports, and follow the governed KMS deletion window only after recovery and evidence-retention requirements are satisfied.
+
+---
+
+🔒 Layer: Framework | KV

--- a/infra/production-providers/main.tf
+++ b/infra/production-providers/main.tf
@@ -1,0 +1,132 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      System      = "reconstructive-ai-memory"
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+resource "aws_kms_key" "stegid_verification" {
+  description              = "StegID asymmetric signing and verification key"
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P256"
+  enable_key_rotation      = false
+  deletion_window_in_days  = var.kms_deletion_window_days
+}
+
+resource "aws_kms_alias" "stegid_verification" {
+  name          = "alias/${var.name_prefix}-stegid-verification"
+  target_key_id = aws_kms_key.stegid_verification.key_id
+}
+
+resource "aws_kms_key" "memory_custody" {
+  description              = "Reconstructive memory wrapping and custody key"
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  deletion_window_in_days  = var.kms_deletion_window_days
+}
+
+resource "aws_kms_alias" "memory_custody" {
+  name          = "alias/${var.name_prefix}-memory-custody"
+  target_key_id = aws_kms_key.memory_custody.key_id
+}
+
+resource "aws_dynamodb_table" "authoritative_state" {
+  name         = "${var.name_prefix}-authoritative-state"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "state_key"
+
+  attribute {
+    name = "state_key"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.memory_custody.arn
+  }
+
+  deletion_protection_enabled = var.deletion_protection_enabled
+}
+
+variable "aws_region" {
+  description = "AWS region for KMS and DynamoDB resources."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment."
+  type        = string
+  default     = "staging"
+  validation {
+    condition     = contains(["staging", "production"], var.environment)
+    error_message = "environment must be staging or production"
+  }
+}
+
+variable "name_prefix" {
+  description = "Resource naming prefix."
+  type        = string
+  default     = "stegverse-reconstructive-memory"
+}
+
+variable "kms_deletion_window_days" {
+  description = "Governed delay before a scheduled KMS deletion completes."
+  type        = number
+  default     = 30
+  validation {
+    condition     = var.kms_deletion_window_days >= 7 && var.kms_deletion_window_days <= 30
+    error_message = "KMS deletion window must be between 7 and 30 days"
+  }
+}
+
+variable "deletion_protection_enabled" {
+  description = "Protect the authoritative table from accidental deletion."
+  type        = bool
+  default     = true
+}
+
+output "stegid_kms_key_arn" {
+  value       = aws_kms_key.stegid_verification.arn
+  description = "Populate providers.stegid_verification.resource_id with this ARN."
+}
+
+output "custody_kms_key_arn" {
+  value       = aws_kms_key.memory_custody.arn
+  description = "Populate providers.key_custody.resource_id with this ARN."
+}
+
+output "authoritative_state_table_arn" {
+  value       = aws_dynamodb_table.authoritative_state.arn
+  description = "Populate providers.replicated_state.resource_id with this ARN."
+}
+
+output "activation_profile_fragment" {
+  description = "Non-secret resource mapping for the production activation profile."
+  value = {
+    aws_region                    = var.aws_region
+    stegid_verification_resource = aws_kms_key.stegid_verification.arn
+    key_custody_resource         = aws_kms_key.memory_custody.arn
+    replicated_state_resource    = aws_dynamodb_table.authoritative_state.arn
+  }
+}

--- a/infra/production-providers/spire-entry.template.json
+++ b/infra/production-providers/spire-entry.template.json
@@ -1,0 +1,16 @@
+{
+  "parent_id": "spiffe://UNCONFIGURED/spire/agent/UNCONFIGURED",
+  "spiffe_id": "spiffe://UNCONFIGURED/reconstructive-memory/service",
+  "selectors": [
+    "unix:uid:UNCONFIGURED",
+    "unix:path:/opt/stegverse/reconstructive-memory/bin/service"
+  ],
+  "ttl_seconds": 3600,
+  "federates_with": [],
+  "activation_profile_mapping": {
+    "provider_role": "ai-entity-attestation",
+    "resource_id": "spiffe://UNCONFIGURED/reconstructive-memory/service",
+    "required_environment": "SPIFFE_ENDPOINT_SOCKET"
+  },
+  "status": "FAIL_CLOSED"
+}

--- a/tests/test_reconstructive_memory_infrastructure.py
+++ b/tests/test_reconstructive_memory_infrastructure.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import json
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ProviderInfrastructureTests(unittest.TestCase):
+    def test_terraform_defines_required_resources_and_outputs(self) -> None:
+        text = (ROOT / "infra/production-providers/main.tf").read_text(encoding="utf-8")
+        for token in (
+            'resource "aws_kms_key" "stegid_verification"',
+            'key_usage                = "SIGN_VERIFY"',
+            'resource "aws_kms_key" "memory_custody"',
+            'enable_key_rotation      = true',
+            'resource "aws_dynamodb_table" "authoritative_state"',
+            'point_in_time_recovery',
+            'deletion_protection_enabled',
+            'output "activation_profile_fragment"',
+        ):
+            self.assertIn(token, text)
+
+    def test_infrastructure_files_do_not_contain_secret_values(self) -> None:
+        combined = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in (ROOT / "infra/production-providers").iterdir()
+            if path.is_file()
+        )
+        for forbidden in ("AKIA", "BEGIN PRIVATE KEY", "Bearer ", "aws_secret_access_key"):
+            self.assertNotIn(forbidden, combined)
+
+    def test_spire_template_remains_fail_closed(self) -> None:
+        data = json.loads((ROOT / "infra/production-providers/spire-entry.template.json").read_text(encoding="utf-8"))
+        self.assertEqual(data["status"], "FAIL_CLOSED")
+        self.assertIn("UNCONFIGURED", data["spiffe_id"])
+        self.assertEqual(data["activation_profile_mapping"]["provider_role"], "ai-entity-attestation")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Reduce issue #16's remaining operator-controlled work by providing deployable infrastructure definitions for the selected AWS and SPIFFE providers.

## Added

- Terraform for the StegID asymmetric KMS key;
- Terraform for the rotating memory-custody KMS key;
- Terraform for the encrypted, deletion-protected DynamoDB authoritative-state table;
- activation-profile output mapping;
- fail-closed SPIRE workload-registration template;
- provisioning and rollback runbook;
- static tests for required controls and secret exclusion.

## Security boundary

This PR does not apply Terraform, create cloud resources, register a workload, or claim activation. Terraform state, credentials, plans, and endpoint tokens remain outside the repository.

## Validation

`python3 tools/check_reconstructive_memory.py`

Issue #16 remains open until an authorized operator applies the infrastructure, configures endpoints, executes all six probes, and retains the signed deployment evidence.