### PR TITLE
Add continuous provider conformance drift detection

### DIFF
--- a/docs/PROVIDER_CONFORMANCE_DRIFT.md
+++ b/docs/PROVIDER_CONFORMANCE_DRIFT.md
@@ -1,0 +1,41 @@
+# Continuous Provider Conformance
+
+Production activation is not permanent authority. It remains valid only while the active provider profile and all required provider observations continue to match the committed activation baseline.
+
+## Baseline
+
+The baseline binds:
+
+- the activated provider-profile commitment;
+- exactly one observation for each required provider role;
+- each provider resource identity;
+- each tested capability;
+- each evidence commitment;
+- the baseline creation time.
+
+## Drift classes
+
+The monitor emits deterministic findings for:
+
+- provider-profile commitment changes;
+- missing or duplicate roles;
+- provider resource-identity changes;
+- capability expansion or contraction;
+- evidence-commitment changes;
+- failed probes;
+- stale or future-dated observations;
+- malformed timestamps and unexpected roles.
+
+Any finding changes the decision to `FAIL_CLOSED`.
+
+## Recovery
+
+A drifted deployment does not regain readiness merely because a later probe succeeds. Recovery requires a new verified conformance report and a new deployment receipt that establishes a successor baseline. Prior activation and drift receipts remain preserved.
+
+## Evidence boundary
+
+Monitoring evidence may contain provider identifiers, capability labels, timestamps, commitments, and bounded failure classifications. It must not contain cloud credentials, bearer tokens, private keys, raw chat, reconstructed plaintext, or protected memory content.
+
+## External execution
+
+The comparison logic and tests are repository-owned. Scheduled live probe execution remains dependent on the protected production activation environment and configured provider identities.

--- a/reconstructive_memory/provider_drift.py
+++ b/reconstructive_memory/provider_drift.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+import hashlib
+import json
+from typing import Iterable
+
+
+class DriftKind(str, Enum):
+    NONE = "none"
+    PROFILE = "profile"
+    MISSING_ROLE = "missing_role"
+    RESOURCE_IDENTITY = "resource_identity"
+    CAPABILITY = "capability"
+    EVIDENCE = "evidence"
+    FAILED_PROBE = "failed_probe"
+    STALE_EVIDENCE = "stale_evidence"
+    TAMPERING = "tampering"
+
+
+@dataclass(frozen=True)
+class ProviderObservation:
+    role: str
+    resource: str
+    capability: str
+    evidence_commitment: str
+    observed_at: str
+    success: bool = True
+
+    def canonical(self) -> dict[str, object]:
+        return {
+            "role": self.role,
+            "resource": self.resource,
+            "capability": self.capability,
+            "evidence_commitment": self.evidence_commitment,
+            "observed_at": self.observed_at,
+            "success": self.success,
+        }
+
+    @property
+    def commitment(self) -> str:
+        raw = json.dumps(self.canonical(), sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(raw).hexdigest()
+
+
+@dataclass(frozen=True)
+class ConformanceBaseline:
+    profile_commitment: str
+    observations: tuple[ProviderObservation, ...]
+    created_at: str
+
+    def by_role(self) -> dict[str, ProviderObservation]:
+        result: dict[str, ProviderObservation] = {}
+        for observation in self.observations:
+            if observation.role in result:
+                raise ValueError(f"duplicate baseline role: {observation.role}")
+            result[observation.role] = observation
+        return result
+
+    @property
+    def commitment(self) -> str:
+        payload = {
+            "profile_commitment": self.profile_commitment,
+            "created_at": self.created_at,
+            "observations": [o.canonical() for o in sorted(self.observations, key=lambda o: o.role)],
+        }
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(raw).hexdigest()
+
+
+@dataclass(frozen=True)
+class DriftFinding:
+    role: str
+    kind: DriftKind
+    detail: str
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    baseline_commitment: str
+    current_profile_commitment: str
+    checked_at: str
+    findings: tuple[DriftFinding, ...]
+
+    @property
+    def ready(self) -> bool:
+        return not self.findings
+
+    @property
+    def decision(self) -> str:
+        return "ALLOW" if self.ready else "FAIL_CLOSED"
+
+    @property
+    def commitment(self) -> str:
+        payload = {
+            "baseline_commitment": self.baseline_commitment,
+            "current_profile_commitment": self.current_profile_commitment,
+            "checked_at": self.checked_at,
+            "decision": self.decision,
+            "findings": [
+                {"role": f.role, "kind": f.kind.value, "detail": f.detail}
+                for f in self.findings
+            ],
+        }
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(raw).hexdigest()
+
+
+def compare_conformance(
+    baseline: ConformanceBaseline,
+    current_profile_commitment: str,
+    current_observations: Iterable[ProviderObservation],
+    *,
+    max_age_seconds: int,
+    now: datetime | None = None,
+) -> DriftReport:
+    now = now or datetime.now(timezone.utc)
+    findings: list[DriftFinding] = []
+    baseline_by_role = baseline.by_role()
+    current_by_role: dict[str, ProviderObservation] = {}
+
+    if current_profile_commitment != baseline.profile_commitment:
+        findings.append(DriftFinding("*", DriftKind.PROFILE, "profile commitment changed"))
+
+    for observation in current_observations:
+        if observation.role in current_by_role:
+            findings.append(DriftFinding(observation.role, DriftKind.TAMPERING, "duplicate current role"))
+            continue
+        current_by_role[observation.role] = observation
+
+    for role, expected in baseline_by_role.items():
+        actual = current_by_role.get(role)
+        if actual is None:
+            findings.append(DriftFinding(role, DriftKind.MISSING_ROLE, "current observation missing"))
+            continue
+        if not actual.success:
+            findings.append(DriftFinding(role, DriftKind.FAILED_PROBE, "provider probe failed"))
+        if actual.resource != expected.resource:
+            findings.append(DriftFinding(role, DriftKind.RESOURCE_IDENTITY, "resource identity changed"))
+        if actual.capability != expected.capability:
+            findings.append(DriftFinding(role, DriftKind.CAPABILITY, "capability changed"))
+        if actual.evidence_commitment != expected.evidence_commitment:
+            findings.append(DriftFinding(role, DriftKind.EVIDENCE, "evidence commitment changed"))
+        try:
+            observed = datetime.fromisoformat(actual.observed_at.replace("Z", "+00:00"))
+            age = (now - observed.astimezone(timezone.utc)).total_seconds()
+            if age < 0 or age > max_age_seconds:
+                findings.append(DriftFinding(role, DriftKind.STALE_EVIDENCE, "observation outside freshness window"))
+        except ValueError:
+            findings.append(DriftFinding(role, DriftKind.TAMPERING, "invalid observation timestamp"))
+
+    for role in sorted(set(current_by_role) - set(baseline_by_role)):
+        findings.append(DriftFinding(role, DriftKind.TAMPERING, "unexpected provider role"))
+
+    return DriftReport(
+        baseline_commitment=baseline.commitment,
+        current_profile_commitment=current_profile_commitment,
+        checked_at=now.isoformat(),
+        findings=tuple(findings),
+    )

--- a/tests/test_reconstructive_memory_provider_drift.py
+++ b/tests/test_reconstructive_memory_provider_drift.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timezone
+import unittest
+
+from reconstructive_memory.provider_drift import (
+    ConformanceBaseline,
+    DriftKind,
+    ProviderObservation,
+    compare_conformance,
+)
+
+
+NOW = datetime(2026, 7, 15, 20, 0, tzinfo=timezone.utc)
+
+
+def observation(role: str, *, resource: str | None = None, capability: str = "verify", evidence: str = "e1", success: bool = True, observed_at: str = "2026-07-15T19:59:30Z") -> ProviderObservation:
+    return ProviderObservation(
+        role=role,
+        resource=resource or f"resource:{role}",
+        capability=capability,
+        evidence_commitment=evidence,
+        observed_at=observed_at,
+        success=success,
+    )
+
+
+class ProviderDriftTests(unittest.TestCase):
+    def baseline(self) -> ConformanceBaseline:
+        return ConformanceBaseline(
+            profile_commitment="profile-v1",
+            observations=(observation("stegid"), observation("custody")),
+            created_at="2026-07-15T19:00:00Z",
+        )
+
+    def test_matching_fresh_observations_allow(self) -> None:
+        report = compare_conformance(
+            self.baseline(),
+            "profile-v1",
+            (observation("stegid"), observation("custody")),
+            max_age_seconds=120,
+            now=NOW,
+        )
+        self.assertTrue(report.ready)
+        self.assertEqual(report.decision, "ALLOW")
+
+    def test_profile_and_resource_drift_fail_closed(self) -> None:
+        report = compare_conformance(
+            self.baseline(),
+            "profile-v2",
+            (observation("stegid", resource="resource:new"), observation("custody")),
+            max_age_seconds=120,
+            now=NOW,
+        )
+        kinds = {finding.kind for finding in report.findings}
+        self.assertIn(DriftKind.PROFILE, kinds)
+        self.assertIn(DriftKind.RESOURCE_IDENTITY, kinds)
+        self.assertEqual(report.decision, "FAIL_CLOSED")
+
+    def test_missing_failed_and_stale_evidence_fail_closed(self) -> None:
+        report = compare_conformance(
+            self.baseline(),
+            "profile-v1",
+            (observation("stegid", success=False, observed_at="2026-07-15T18:00:00Z"),),
+            max_age_seconds=120,
+            now=NOW,
+        )
+        kinds = {finding.kind for finding in report.findings}
+        self.assertIn(DriftKind.FAILED_PROBE, kinds)
+        self.assertIn(DriftKind.STALE_EVIDENCE, kinds)
+        self.assertIn(DriftKind.MISSING_ROLE, kinds)
+
+    def test_duplicate_and_unexpected_roles_are_tampering(self) -> None:
+        report = compare_conformance(
+            self.baseline(),
+            "profile-v1",
+            (observation("stegid"), observation("stegid"), observation("custody"), observation("extra")),
+            max_age_seconds=120,
+            now=NOW,
+        )
+        tampering = [f for f in report.findings if f.kind is DriftKind.TAMPERING]
+        self.assertEqual(len(tampering), 2)
+
+    def test_report_commitment_changes_with_findings(self) -> None:
+        good = compare_conformance(self.baseline(), "profile-v1", (observation("stegid"), observation("custody")), max_age_seconds=120, now=NOW)
+        bad = compare_conformance(self.baseline(), "profile-v2", (observation("stegid"), observation("custody")), max_age_seconds=120, now=NOW)
+        self.assertNotEqual(good.commitment, bad.commitment)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_reconstructive_memory.py
+++ b/tools/check_reconstructive_memory.py
@@ -27,13 +27,15 @@ REQUIRED = (
     ROOT / "reconstructive_memory" / "readiness.py",
     ROOT / "reconstructive_memory" / "provider_conformance.py",
     ROOT / "reconstructive_memory" / "provider_probes.py",
+    ROOT / "reconstructive_memory" / "provider_drift.py",
     ROOT / "schemas" / "reconstructive-memory-event.v0.1.json",
     ROOT / "schemas" / "reconstructive-memory-access-receipt.v0.1.json",
     ROOT / "docs" / "RECONSTRUCTIVE_AI_MEMORY.md",
     ROOT / "docs" / "PRODUCTION_PROVIDER_ACTIVATION.md",
+    ROOT / "docs" / "PROVIDER_CONFORMANCE_DRIFT.md",
 )
 
-SCHEMAS = REQUIRED[18:20]
+SCHEMAS = REQUIRED[19:21]
 
 
 def fail(message: str) -> None:
@@ -75,6 +77,7 @@ def main() -> int:
     print("- concrete provider selection and readiness gate: present")
     print("- live provider conformance and receipt assembly: present")
     print("- executable AWS, SPIFFE, and HTTPS provider probes: present")
+    print("- continuous provider conformance drift detection: present")
     print("- external resource identifiers and credentials: UNCONFIGURED")
     return 0
 


### PR DESCRIPTION
## Purpose

Advance beyond initial activation preparation by making provider readiness continuously evidence-bound.

## Added

- committed conformance baseline for provider profile and observations;
- deterministic comparison of current observations against the baseline;
- drift classifications for profile, missing role, resource identity, capability, evidence, failed probe, stale evidence, and tampering;
- freshness-window enforcement, including future-dated evidence rejection;
- fail-closed decision on any finding;
- tamper-evident baseline and drift-report commitments;
- recovery rule requiring a new conformance report and deployment receipt rather than silent readiness restoration;
- focused tests and validator integration;
- documentation of evidence and secret-exclusion boundaries.

## Boundary

This PR does not touch production resources or claim activation. Scheduled live probe execution remains dependent on the protected external activation environment.

## Validation

`python3 tools/check_reconstructive_memory.py`