### PR TITLE
Add provider drift incident lifecycle

### DIFF
--- a/docs/PROVIDER_CONFORMANCE_INCIDENT_LIFECYCLE.md
+++ b/docs/PROVIDER_CONFORMANCE_INCIDENT_LIFECYCLE.md
@@ -1,0 +1,45 @@
+# Provider Conformance Incident Lifecycle
+
+A drift finding is not merely informational. Any non-empty provider drift report opens a durable incident and removes activation readiness until a successor baseline is explicitly issued.
+
+## State sequence
+
+`DETECTED -> QUARANTINED -> REVOKED -> REMEDIATING -> REATTESTING -> RESOLVED`
+
+A failed re-attestation returns to `REMEDIATING`. No other backward transition is allowed.
+
+## State meaning
+
+- **DETECTED** — a committed drift report identifies provider identity, capability, evidence, freshness, profile, role-coverage, or probe failure.
+- **QUARANTINED** — new reconstructive-memory activation decisions are blocked while evidence is preserved.
+- **REVOKED** — the prior deployment receipt and baseline no longer confer current readiness.
+- **REMEDIATING** — the operator repairs or replaces the affected provider without mutating the historical incident.
+- **REATTESTING** — all six providers are probed again and a new conformance report is assembled.
+- **RESOLVED** — only a newly committed baseline and deployment receipt may restore readiness.
+
+## Resolution boundary
+
+Resolution requires both:
+
+1. `successor_baseline_commitment`
+2. `successor_receipt_commitment`
+
+A successful probe by itself cannot close the incident. A prior deployment receipt cannot be reused after drift. Failed re-attestation returns the incident to remediation and keeps readiness blocked.
+
+## Evidence discipline
+
+Every transition records:
+
+- incident identifier;
+- actor;
+- transition timestamp;
+- evidence commitment;
+- optional bounded note;
+- full ordered event history;
+- deterministic incident commitment.
+
+Incident evidence must not include credentials, bearer tokens, private keys, raw chat, reconstructed plaintext, or protected memory content.
+
+## Operational rule
+
+Open incidents block readiness. Historical incidents remain immutable after resolution. A successor baseline starts a new continuity period rather than rewriting the previous one.

--- a/reconstructive_memory/provider_incident.py
+++ b/reconstructive_memory/provider_incident.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from enum import Enum
+import hashlib
+import json
+
+from .provider_drift import DriftReport
+
+
+class IncidentState(str, Enum):
+    DETECTED = "detected"
+    QUARANTINED = "quarantined"
+    REVOKED = "revoked"
+    REMEDIATING = "remediating"
+    REATTESTING = "reattesting"
+    RESOLVED = "resolved"
+
+
+_ALLOWED_TRANSITIONS = {
+    IncidentState.DETECTED: {IncidentState.QUARANTINED},
+    IncidentState.QUARANTINED: {IncidentState.REVOKED},
+    IncidentState.REVOKED: {IncidentState.REMEDIATING},
+    IncidentState.REMEDIATING: {IncidentState.REATTESTING},
+    IncidentState.REATTESTING: {IncidentState.RESOLVED, IncidentState.REMEDIATING},
+    IncidentState.RESOLVED: set(),
+}
+
+
+@dataclass(frozen=True)
+class IncidentEvent:
+    state: IncidentState
+    actor: str
+    occurred_at: str
+    evidence_commitment: str
+    note: str = ""
+
+    def canonical(self) -> dict[str, str]:
+        return {
+            "state": self.state.value,
+            "actor": self.actor,
+            "occurred_at": self.occurred_at,
+            "evidence_commitment": self.evidence_commitment,
+            "note": self.note,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderIncident:
+    incident_id: str
+    baseline_commitment: str
+    drift_report_commitment: str
+    opened_at: str
+    events: tuple[IncidentEvent, ...]
+    successor_baseline_commitment: str = ""
+    successor_receipt_commitment: str = ""
+
+    @property
+    def state(self) -> IncidentState:
+        if not self.events:
+            raise ValueError("incident requires at least one event")
+        return self.events[-1].state
+
+    @property
+    def blocks_readiness(self) -> bool:
+        return self.state is not IncidentState.RESOLVED
+
+    @property
+    def commitment(self) -> str:
+        payload = {
+            "incident_id": self.incident_id,
+            "baseline_commitment": self.baseline_commitment,
+            "drift_report_commitment": self.drift_report_commitment,
+            "opened_at": self.opened_at,
+            "events": [event.canonical() for event in self.events],
+            "successor_baseline_commitment": self.successor_baseline_commitment,
+            "successor_receipt_commitment": self.successor_receipt_commitment,
+        }
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(raw).hexdigest()
+
+
+def open_incident(report: DriftReport, *, actor: str, now: datetime | None = None) -> ProviderIncident:
+    if report.ready:
+        raise ValueError("cannot open incident from an ALLOW drift report")
+    now = now or datetime.now(timezone.utc)
+    opened_at = now.isoformat()
+    incident_id = hashlib.sha256(
+        f"{report.baseline_commitment}:{report.commitment}:{opened_at}".encode()
+    ).hexdigest()
+    event = IncidentEvent(
+        state=IncidentState.DETECTED,
+        actor=actor,
+        occurred_at=opened_at,
+        evidence_commitment=report.commitment,
+        note="provider conformance drift detected",
+    )
+    return ProviderIncident(
+        incident_id=incident_id,
+        baseline_commitment=report.baseline_commitment,
+        drift_report_commitment=report.commitment,
+        opened_at=opened_at,
+        events=(event,),
+    )
+
+
+def transition_incident(
+    incident: ProviderIncident,
+    new_state: IncidentState,
+    *,
+    actor: str,
+    evidence_commitment: str,
+    note: str = "",
+    successor_baseline_commitment: str = "",
+    successor_receipt_commitment: str = "",
+    now: datetime | None = None,
+) -> ProviderIncident:
+    if new_state not in _ALLOWED_TRANSITIONS[incident.state]:
+        raise ValueError(f"invalid incident transition: {incident.state.value}->{new_state.value}")
+    if not actor or not evidence_commitment:
+        raise ValueError("actor and evidence commitment are required")
+    if new_state is IncidentState.RESOLVED:
+        if incident.state is not IncidentState.REATTESTING:
+            raise ValueError("incident can resolve only after re-attestation")
+        if not successor_baseline_commitment or not successor_receipt_commitment:
+            raise ValueError("resolution requires successor baseline and deployment receipt")
+    else:
+        if successor_baseline_commitment or successor_receipt_commitment:
+            raise ValueError("successor commitments are valid only on resolution")
+
+    now = now or datetime.now(timezone.utc)
+    event = IncidentEvent(
+        state=new_state,
+        actor=actor,
+        occurred_at=now.isoformat(),
+        evidence_commitment=evidence_commitment,
+        note=note,
+    )
+    return replace(
+        incident,
+        events=incident.events + (event,),
+        successor_baseline_commitment=successor_baseline_commitment,
+        successor_receipt_commitment=successor_receipt_commitment,
+    )

--- a/tests/test_reconstructive_memory_provider_incident.py
+++ b/tests/test_reconstructive_memory_provider_incident.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timezone
+import unittest
+
+from reconstructive_memory.provider_drift import DriftFinding, DriftKind, DriftReport
+from reconstructive_memory.provider_incident import (
+    IncidentState,
+    open_incident,
+    transition_incident,
+)
+
+
+NOW = datetime(2026, 7, 15, 21, 30, tzinfo=timezone.utc)
+
+
+def drift_report(*, ready: bool = False) -> DriftReport:
+    findings = () if ready else (DriftFinding("key-custody", DriftKind.RESOURCE_IDENTITY, "resource changed"),)
+    return DriftReport(
+        baseline_commitment="b" * 64,
+        current_profile_commitment="p" * 64,
+        checked_at=NOW.isoformat(),
+        findings=findings,
+    )
+
+
+class ProviderIncidentTests(unittest.TestCase):
+    def test_incident_opens_only_from_failed_conformance(self) -> None:
+        incident = open_incident(drift_report(), actor="monitor", now=NOW)
+        self.assertEqual(IncidentState.DETECTED, incident.state)
+        self.assertTrue(incident.blocks_readiness)
+        with self.assertRaises(ValueError):
+            open_incident(drift_report(ready=True), actor="monitor", now=NOW)
+
+    def test_incident_requires_ordered_fail_closed_transitions(self) -> None:
+        incident = open_incident(drift_report(), actor="monitor", now=NOW)
+        with self.assertRaises(ValueError):
+            transition_incident(
+                incident,
+                IncidentState.RESOLVED,
+                actor="operator",
+                evidence_commitment="e" * 64,
+                now=NOW,
+            )
+        for state in (
+            IncidentState.QUARANTINED,
+            IncidentState.REVOKED,
+            IncidentState.REMEDIATING,
+            IncidentState.REATTESTING,
+        ):
+            incident = transition_incident(
+                incident,
+                state,
+                actor="operator",
+                evidence_commitment=state.value * 8,
+                now=NOW,
+            )
+        self.assertTrue(incident.blocks_readiness)
+
+    def test_resolution_requires_successor_baseline_and_receipt(self) -> None:
+        incident = open_incident(drift_report(), actor="monitor", now=NOW)
+        for state in (
+            IncidentState.QUARANTINED,
+            IncidentState.REVOKED,
+            IncidentState.REMEDIATING,
+            IncidentState.REATTESTING,
+        ):
+            incident = transition_incident(
+                incident,
+                state,
+                actor="operator",
+                evidence_commitment="e" * 64,
+                now=NOW,
+            )
+        with self.assertRaises(ValueError):
+            transition_incident(
+                incident,
+                IncidentState.RESOLVED,
+                actor="operator",
+                evidence_commitment="r" * 64,
+                now=NOW,
+            )
+        resolved = transition_incident(
+            incident,
+            IncidentState.RESOLVED,
+            actor="operator",
+            evidence_commitment="r" * 64,
+            successor_baseline_commitment="n" * 64,
+            successor_receipt_commitment="s" * 64,
+            now=NOW,
+        )
+        self.assertFalse(resolved.blocks_readiness)
+        self.assertEqual("n" * 64, resolved.successor_baseline_commitment)
+        self.assertEqual("s" * 64, resolved.successor_receipt_commitment)
+
+    def test_failed_reattest_returns_to_remediation(self) -> None:
+        incident = open_incident(drift_report(), actor="monitor", now=NOW)
+        for state in (
+            IncidentState.QUARANTINED,
+            IncidentState.REVOKED,
+            IncidentState.REMEDIATING,
+            IncidentState.REATTESTING,
+            IncidentState.REMEDIATING,
+        ):
+            incident = transition_incident(
+                incident,
+                state,
+                actor="operator",
+                evidence_commitment="e" * 64,
+                now=NOW,
+            )
+        self.assertEqual(IncidentState.REMEDIATING, incident.state)
+        self.assertTrue(incident.blocks_readiness)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_reconstructive_memory.py
+++ b/tools/check_reconstructive_memory.py
@@ -28,14 +28,16 @@ REQUIRED = (
     ROOT / "reconstructive_memory" / "provider_conformance.py",
     ROOT / "reconstructive_memory" / "provider_probes.py",
     ROOT / "reconstructive_memory" / "provider_drift.py",
+    ROOT / "reconstructive_memory" / "provider_incident.py",
     ROOT / "schemas" / "reconstructive-memory-event.v0.1.json",
     ROOT / "schemas" / "reconstructive-memory-access-receipt.v0.1.json",
     ROOT / "docs" / "RECONSTRUCTIVE_AI_MEMORY.md",
     ROOT / "docs" / "PRODUCTION_PROVIDER_ACTIVATION.md",
     ROOT / "docs" / "PROVIDER_CONFORMANCE_DRIFT.md",
+    ROOT / "docs" / "PROVIDER_CONFORMANCE_INCIDENT_LIFECYCLE.md",
 )
 
-SCHEMAS = REQUIRED[19:21]
+SCHEMAS = REQUIRED[20:22]
 
 
 def fail(message: str) -> None:
@@ -78,6 +80,7 @@ def main() -> int:
     print("- live provider conformance and receipt assembly: present")
     print("- executable AWS, SPIFFE, and HTTPS provider probes: present")
     print("- continuous provider conformance drift detection: present")
+    print("- provider incident quarantine, revocation, and re-attestation lifecycle: present")
     print("- external resource identifiers and credentials: UNCONFIGURED")
     return 0
 


### PR DESCRIPTION
## Purpose

Turn provider drift from a passive report into a durable fail-closed incident lifecycle.

## Added

- incident opening only from non-ALLOW drift reports;
- ordered DETECTED -> QUARANTINED -> REVOKED -> REMEDIATING -> REATTESTING -> RESOLVED state machine;
- readiness blocking for every unresolved state;
- failed re-attestation path back to remediation;
- mandatory actor and evidence commitment for every transition;
- resolution only with both a successor conformance baseline and successor deployment receipt;
- deterministic incident commitment and immutable ordered event history;
- focused tests and validator integration;
- documentation of evidence and secret-exclusion boundaries.

## Boundary

This PR does not touch production providers or claim activation. It governs the response after continuous conformance monitoring detects drift.

## Validation

`python3 tools/check_reconstructive_memory.py`