### PR TITLE
Add provider containment evidence contracts

### DIFF
--- a/docs/PROVIDER_CONTAINMENT_ACTIONS.md
+++ b/docs/PROVIDER_CONTAINMENT_ACTIONS.md
@@ -1,0 +1,20 @@
+# Provider Containment Actions
+
+Continuous conformance drift must produce enforceable containment, not only a diagnostic report.
+
+## Canonical actions
+
+- disable StegID signing KMS key;
+- disable reconstructive-memory custody KMS key;
+- freeze authoritative replicated-state writes;
+- suspend the affected SPIFFE workload identity;
+- quarantine Ecosystem Chat endpoint access;
+- quarantine Master-Records endpoint access.
+
+Each command binds the incident commitment, canonical provider role, resource identity, action, and reason commitment. Each receipt binds the command commitment, actor, evidence commitment, timestamp, and bounded status.
+
+A containment plan reports `CONTAINED` only when exactly one successful receipt exists for every command and no unknown receipt is supplied. Missing, duplicated, failed, pending, rolled-back, or unknown receipts produce `FAIL_CLOSED`.
+
+Rollback is not readiness restoration. A rolled-back containment action remains fail-closed until the incident lifecycle reaches successful re-attestation and issues both a successor conformance baseline and successor deployment receipt.
+
+Commands and receipts must not contain private keys, bearer tokens, AWS credentials, raw chat, reconstructed plaintext, or protected memory content. Evidence is represented only by commitments and bounded provider metadata.

--- a/reconstructive_memory/provider_containment.py
+++ b/reconstructive_memory/provider_containment.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import json
+from typing import Iterable
+
+
+class ContainmentAction(str, Enum):
+    DISABLE_KMS_KEY = "disable_kms_key"
+    FREEZE_STATE_WRITES = "freeze_state_writes"
+    SUSPEND_SPIFFE_IDENTITY = "suspend_spiffe_identity"
+    QUARANTINE_CHAT_ENDPOINT = "quarantine_chat_endpoint"
+    QUARANTINE_MASTER_RECORDS_ENDPOINT = "quarantine_master_records_endpoint"
+
+
+class ActionStatus(str, Enum):
+    PENDING = "pending"
+    APPLIED = "applied"
+    FAILED = "failed"
+    ROLLED_BACK = "rolled_back"
+
+
+@dataclass(frozen=True)
+class ContainmentCommand:
+    incident_commitment: str
+    role: str
+    action: ContainmentAction
+    resource: str
+    reason_commitment: str
+
+    def canonical(self) -> dict[str, str]:
+        return {
+            "incident_commitment": self.incident_commitment,
+            "role": self.role,
+            "action": self.action.value,
+            "resource": self.resource,
+            "reason_commitment": self.reason_commitment,
+        }
+
+    @property
+    def commitment(self) -> str:
+        raw = json.dumps(self.canonical(), sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(raw).hexdigest()
+
+
+@dataclass(frozen=True)
+class ContainmentReceipt:
+    command_commitment: str
+    status: ActionStatus
+    actor: str
+    evidence_commitment: str
+    observed_at: str
+
+    def __post_init__(self) -> None:
+        if not self.actor:
+            raise ValueError("actor is required")
+        if not self.evidence_commitment:
+            raise ValueError("evidence commitment is required")
+
+    def canonical(self) -> dict[str, str]:
+        return {
+            "command_commitment": self.command_commitment,
+            "status": self.status.value,
+            "actor": self.actor,
+            "evidence_commitment": self.evidence_commitment,
+            "observed_at": self.observed_at,
+        }
+
+    @property
+    def commitment(self) -> str:
+        raw = json.dumps(self.canonical(), sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(raw).hexdigest()
+
+
+@dataclass(frozen=True)
+class ContainmentPlan:
+    incident_commitment: str
+    commands: tuple[ContainmentCommand, ...]
+
+    def __post_init__(self) -> None:
+        seen: set[tuple[str, ContainmentAction]] = set()
+        for command in self.commands:
+            if command.incident_commitment != self.incident_commitment:
+                raise ValueError("command incident commitment mismatch")
+            key = (command.role, command.action)
+            if key in seen:
+                raise ValueError(f"duplicate containment command: {command.role}/{command.action.value}")
+            seen.add(key)
+
+    @property
+    def commitment(self) -> str:
+        payload = {
+            "incident_commitment": self.incident_commitment,
+            "commands": [c.canonical() for c in sorted(self.commands, key=lambda c: (c.role, c.action.value))],
+        }
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(raw).hexdigest()
+
+    def evaluate(self, receipts: Iterable[ContainmentReceipt]) -> str:
+        by_command: dict[str, ContainmentReceipt] = {}
+        for receipt in receipts:
+            if receipt.command_commitment in by_command:
+                return "FAIL_CLOSED"
+            by_command[receipt.command_commitment] = receipt
+        for command in self.commands:
+            receipt = by_command.get(command.commitment)
+            if receipt is None or receipt.status is not ActionStatus.APPLIED:
+                return "FAIL_CLOSED"
+        if set(by_command) != {c.commitment for c in self.commands}:
+            return "FAIL_CLOSED"
+        return "CONTAINED"
+
+
+def build_default_plan(incident_commitment: str, role_resources: dict[str, str], reason_commitment: str) -> ContainmentPlan:
+    action_by_role = {
+        "stegid-signature": ContainmentAction.DISABLE_KMS_KEY,
+        "key-custody": ContainmentAction.DISABLE_KMS_KEY,
+        "replicated-state": ContainmentAction.FREEZE_STATE_WRITES,
+        "ai-entity-attestation": ContainmentAction.SUSPEND_SPIFFE_IDENTITY,
+        "ecosystem-chat": ContainmentAction.QUARANTINE_CHAT_ENDPOINT,
+        "master-records": ContainmentAction.QUARANTINE_MASTER_RECORDS_ENDPOINT,
+    }
+    commands: list[ContainmentCommand] = []
+    for role, action in action_by_role.items():
+        resource = role_resources.get(role)
+        if not resource:
+            raise ValueError(f"missing resource for role: {role}")
+        commands.append(
+            ContainmentCommand(
+                incident_commitment=incident_commitment,
+                role=role,
+                action=action,
+                resource=resource,
+                reason_commitment=reason_commitment,
+            )
+        )
+    return ContainmentPlan(incident_commitment=incident_commitment, commands=tuple(commands))

--- a/tests/test_reconstructive_memory_provider_containment.py
+++ b/tests/test_reconstructive_memory_provider_containment.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import unittest
+
+from reconstructive_memory.provider_containment import ActionStatus, ContainmentReceipt, build_default_plan
+
+
+class ProviderContainmentTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.resources = {
+            "stegid-signature": "arn:kms:sign",
+            "key-custody": "arn:kms:custody",
+            "replicated-state": "table:state",
+            "ai-entity-attestation": "spiffe://example/agent",
+            "ecosystem-chat": "https://chat.example/probe",
+            "master-records": "https://records.example/probe",
+        }
+        self.plan = build_default_plan("incident-1", self.resources, "reason-1")
+
+    def receipt(self, command, status=ActionStatus.APPLIED):
+        return ContainmentReceipt(command.commitment, status, "operator-1", f"evidence-{command.role}", "2026-07-15T21:00:00Z")
+
+    def test_all_actions_applied_is_contained(self) -> None:
+        self.assertEqual(self.plan.evaluate(self.receipt(c) for c in self.plan.commands), "CONTAINED")
+
+    def test_missing_failed_duplicate_and_unknown_fail_closed(self) -> None:
+        self.assertEqual(self.plan.evaluate(self.receipt(c) for c in self.plan.commands[:-1]), "FAIL_CLOSED")
+        receipts = [self.receipt(c) for c in self.plan.commands]
+        receipts[0] = self.receipt(self.plan.commands[0], ActionStatus.FAILED)
+        self.assertEqual(self.plan.evaluate(receipts), "FAIL_CLOSED")
+        receipts = [self.receipt(c) for c in self.plan.commands]
+        self.assertEqual(self.plan.evaluate(receipts + [receipts[0]]), "FAIL_CLOSED")
+        receipts.append(ContainmentReceipt("unknown", ActionStatus.APPLIED, "operator", "evidence", "2026-07-15T21:00:00Z"))
+        self.assertEqual(self.plan.evaluate(receipts), "FAIL_CLOSED")
+
+    def test_missing_role_resource_rejected(self) -> None:
+        resources = dict(self.resources)
+        del resources["key-custody"]
+        with self.assertRaises(ValueError):
+            build_default_plan("incident", resources, "reason")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_reconstructive_memory.py
+++ b/tools/check_reconstructive_memory.py
@@ -29,15 +29,17 @@ REQUIRED = (
     ROOT / "reconstructive_memory" / "provider_probes.py",
     ROOT / "reconstructive_memory" / "provider_drift.py",
     ROOT / "reconstructive_memory" / "provider_incident.py",
+    ROOT / "reconstructive_memory" / "provider_containment.py",
     ROOT / "schemas" / "reconstructive-memory-event.v0.1.json",
     ROOT / "schemas" / "reconstructive-memory-access-receipt.v0.1.json",
     ROOT / "docs" / "RECONSTRUCTIVE_AI_MEMORY.md",
     ROOT / "docs" / "PRODUCTION_PROVIDER_ACTIVATION.md",
     ROOT / "docs" / "PROVIDER_CONFORMANCE_DRIFT.md",
     ROOT / "docs" / "PROVIDER_CONFORMANCE_INCIDENT_LIFECYCLE.md",
+    ROOT / "docs" / "PROVIDER_CONTAINMENT_ACTIONS.md",
 )
 
-SCHEMAS = REQUIRED[20:22]
+SCHEMAS = REQUIRED[21:23]
 
 
 def fail(message: str) -> None:
@@ -81,6 +83,7 @@ def main() -> int:
     print("- executable AWS, SPIFFE, and HTTPS provider probes: present")
     print("- continuous provider conformance drift detection: present")
     print("- provider incident quarantine, revocation, and re-attestation lifecycle: present")
+    print("- receipt-backed provider containment actions: present")
     print("- external resource identifiers and credentials: UNCONFIGURED")
     return 0
 


### PR DESCRIPTION
## Purpose

Add a deterministic evidence contract connecting provider incidents to bounded containment records.

## Added

- canonical commands for each provider role;
- commitments binding incident, role, resource, requested state, and reason;
- receipts binding actor, bounded result, timestamp, and evidence commitment;
- deterministic plan commitment;
- success only when exactly one successful receipt exists for every command;
- fail-closed handling for missing, duplicate, unsuccessful, incomplete, reversed, and unknown receipts;
- tests, documentation, and validator integration.

## Boundary

This change defines and validates records only. It does not call live provider APIs or claim changes to external resources.

## Validation

`python3 tools/check_reconstructive_memory.py`