### PR TITLE
Define recoverable execution orchestration and attempt journals

### DIFF
--- a/execution/recovery.py
+++ b/execution/recovery.py
@@ -1,0 +1,135 @@
+"""Recoverable governed execution orchestration.
+
+This module reconstructs connector-attempt state without creating authority,
+changing the authorized envelope, or converting uncertainty into success.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+
+class RecoveryError(ValueError):
+    """Raised when an attempt journal or recovery transition is inadmissible."""
+
+
+@dataclass(frozen=True)
+class RecoveryDecision:
+    decision: str
+    reason: str
+
+
+_ALLOWED_TRANSITIONS = {
+    "STARTED": {"DISPATCHED", "ABANDONED"},
+    "DISPATCHED": {"OBSERVING", "TERMINAL", "ABANDONED"},
+    "OBSERVING": {"TERMINAL", "ABANDONED"},
+    "TERMINAL": set(),
+    "ABANDONED": set(),
+}
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def validate_journal(journal: dict[str, Any]) -> None:
+    required = {
+        "schema_version", "journal_id", "envelope_id", "envelope_sha256",
+        "idempotency_key", "state", "revision", "lease", "events",
+        "authority_note",
+    }
+    missing = sorted(required - journal.keys())
+    if missing:
+        raise RecoveryError(f"missing fields: {missing}")
+    if journal["schema_version"] != "0.1":
+        raise RecoveryError("schema_version must be 0.1")
+    if journal["state"] not in _ALLOWED_TRANSITIONS:
+        raise RecoveryError("invalid journal state")
+    if journal["revision"] < 0:
+        raise RecoveryError("revision must be non-negative")
+    events = journal["events"]
+    if not isinstance(events, list) or not events:
+        raise RecoveryError("events must be non-empty")
+    sequences = [event.get("sequence") for event in events]
+    if sequences != list(range(len(events))):
+        raise RecoveryError("event sequences must be contiguous and monotonic")
+    if journal["authority_note"] != (
+        "Recovery restores execution state only; it does not grant or expand authority."
+    ):
+        raise RecoveryError("authority boundary missing")
+
+
+def acquire_lease(
+    journal: dict[str, Any], *, owner: str, acquired_at: str, expires_at: str,
+    expected_revision: int,
+) -> dict[str, Any]:
+    validate_journal(journal)
+    if journal["revision"] != expected_revision:
+        raise RecoveryError("stale journal revision")
+    current_expiry = _parse_time(journal["lease"]["expires_at"])
+    requested_start = _parse_time(acquired_at)
+    if requested_start < current_expiry and journal["lease"]["owner"] != owner:
+        raise RecoveryError("active lease held by another worker")
+    updated = deepcopy(journal)
+    updated["lease"] = {
+        "owner": owner,
+        "acquired_at": acquired_at,
+        "expires_at": expires_at,
+    }
+    updated["revision"] += 1
+    return updated
+
+
+def transition(
+    journal: dict[str, Any], *, new_state: str, event: str, actor: str,
+    recorded_at: str, receipt_sha256: str, expected_revision: int,
+    terminal_receipt_ref: str | None = None,
+) -> dict[str, Any]:
+    validate_journal(journal)
+    if journal["revision"] != expected_revision:
+        raise RecoveryError("stale journal revision")
+    if new_state not in _ALLOWED_TRANSITIONS[journal["state"]]:
+        raise RecoveryError(f"invalid transition {journal['state']} -> {new_state}")
+    updated = deepcopy(journal)
+    updated["state"] = new_state
+    updated["revision"] += 1
+    updated["events"].append({
+        "sequence": len(updated["events"]),
+        "event": event,
+        "recorded_at": recorded_at,
+        "actor": actor,
+        "receipt_sha256": receipt_sha256,
+    })
+    if new_state == "TERMINAL":
+        if not terminal_receipt_ref:
+            raise RecoveryError("terminal transition requires receipt reference")
+        updated["terminal_receipt_ref"] = terminal_receipt_ref
+    return updated
+
+
+def decide_recovery(
+    journal: dict[str, Any], *, receipt_result: str | None,
+    side_effect_absence_confirmed: bool = False,
+    connector_supports_observation: bool = False,
+    authority_still_current: bool = True,
+) -> RecoveryDecision:
+    validate_journal(journal)
+    if journal["state"] in {"TERMINAL", "ABANDONED"}:
+        return RecoveryDecision("STOP", "attempt is already terminal")
+    if not authority_still_current:
+        return RecoveryDecision("ASK", "current authority must be re-established")
+    if receipt_result == "EXECUTED":
+        return RecoveryDecision("STOP", "executed receipt suppresses duplicate dispatch")
+    if receipt_result == "FAILED" and side_effect_absence_confirmed:
+        return RecoveryDecision("RETRY_EXACT", "confirmed absence permits exact-envelope retry")
+    if receipt_result in {"INDETERMINATE", "FAILED"}:
+        return RecoveryDecision("VERIFY_EXTERNALLY", "side effect remains uncertain")
+    if journal["state"] in {"DISPATCHED", "OBSERVING"} and connector_supports_observation:
+        return RecoveryDecision("RESUME_OBSERVATION", "connector observation can continue")
+    if journal["state"] == "STARTED":
+        return RecoveryDecision("RETRY_EXACT", "no dispatch has been recorded")
+    return RecoveryDecision("ASK", "recovery cannot safely determine the next action")

--- a/fixtures/execution-recovery/facebook-post-interrupted.json
+++ b/fixtures/execution-recovery/facebook-post-interrupted.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "0.1",
+  "journal_id": "journal-facebook-good-times-001",
+  "envelope_id": "exec-facebook-good-times-001",
+  "envelope_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+  "idempotency_key": "facebook-good-times-001",
+  "state": "DISPATCHED",
+  "revision": 1,
+  "lease": {
+    "owner": "auri-worker-01",
+    "acquired_at": "2026-07-15T21:55:00Z",
+    "expires_at": "2026-07-15T21:56:00Z"
+  },
+  "events": [
+    {
+      "sequence": 0,
+      "event": "ATTEMPT_STARTED",
+      "recorded_at": "2026-07-15T21:55:00Z",
+      "actor": "auri:primary",
+      "receipt_sha256": "4444444444444444444444444444444444444444444444444444444444444444"
+    },
+    {
+      "sequence": 1,
+      "event": "DISPATCH_RECORDED",
+      "recorded_at": "2026-07-15T21:55:10Z",
+      "actor": "connector:facebook-neutral-adapter",
+      "receipt_sha256": "5555555555555555555555555555555555555555555555555555555555555555"
+    }
+  ],
+  "terminal_receipt_ref": null,
+  "authority_note": "Recovery restores execution state only; it does not grant or expand authority."
+}

--- a/schemas/execution-attempt-journal.schema.json
+++ b/schemas/execution-attempt-journal.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/execution-attempt-journal.schema.json",
+  "title": "Governed Execution Attempt Journal",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "journal_id",
+    "envelope_id",
+    "envelope_sha256",
+    "idempotency_key",
+    "state",
+    "revision",
+    "lease",
+    "events",
+    "authority_note"
+  ],
+  "properties": {
+    "schema_version": {"const": "0.1"},
+    "journal_id": {"type": "string", "minLength": 1},
+    "envelope_id": {"type": "string", "minLength": 1},
+    "envelope_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "idempotency_key": {"type": "string", "minLength": 1},
+    "state": {"enum": ["STARTED", "DISPATCHED", "OBSERVING", "TERMINAL", "ABANDONED"]},
+    "revision": {"type": "integer", "minimum": 0},
+    "lease": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "acquired_at", "expires_at"],
+      "properties": {
+        "owner": {"type": "string", "minLength": 1},
+        "acquired_at": {"type": "string", "format": "date-time"},
+        "expires_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "events": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["sequence", "event", "recorded_at", "actor", "receipt_sha256"],
+        "properties": {
+          "sequence": {"type": "integer", "minimum": 0},
+          "event": {"enum": ["ATTEMPT_STARTED", "DISPATCH_RECORDED", "OBSERVATION_STARTED", "RESULT_ATTACHED", "RECOVERY_DECIDED", "ATTEMPT_ABANDONED"]},
+          "recorded_at": {"type": "string", "format": "date-time"},
+          "actor": {"type": "string", "minLength": 1},
+          "receipt_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+        }
+      }
+    },
+    "terminal_receipt_ref": {"type": ["string", "null"]},
+    "authority_note": {"const": "Recovery restores execution state only; it does not grant or expand authority."}
+  }
+}

--- a/schemas/execution-recovery-decision.schema.json
+++ b/schemas/execution-recovery-decision.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/execution-recovery-decision.schema.json",
+  "title": "Governed Execution Recovery Decision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "decision_id",
+    "journal_id",
+    "journal_revision",
+    "envelope_sha256",
+    "decision",
+    "reason",
+    "decided_at",
+    "receipt_required"
+  ],
+  "properties": {
+    "schema_version": {"const": "0.1"},
+    "decision_id": {"type": "string", "minLength": 1},
+    "journal_id": {"type": "string", "minLength": 1},
+    "journal_revision": {"type": "integer", "minimum": 0},
+    "envelope_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "decision": {"enum": ["RESUME_OBSERVATION", "VERIFY_EXTERNALLY", "RETRY_EXACT", "ASK", "STOP"]},
+    "reason": {"type": "string", "minLength": 1},
+    "decided_at": {"type": "string", "format": "date-time"},
+    "verification_ref": {"type": ["string", "null"]},
+    "receipt_required": {"const": true},
+    "authority_note": {"const": "Recovery cannot create authority or alter the authorized execution envelope."}
+  }
+}

--- a/tests/test_execution_recovery.py
+++ b/tests/test_execution_recovery.py
@@ -1,0 +1,95 @@
+import json
+import unittest
+from pathlib import Path
+
+from execution.recovery import (
+    RecoveryError,
+    acquire_lease,
+    decide_recovery,
+    transition,
+    validate_journal,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_journal():
+    return json.loads(
+        (ROOT / "fixtures" / "execution-recovery" / "facebook-post-interrupted.json")
+        .read_text(encoding="utf-8")
+    )
+
+
+class ExecutionRecoveryTests(unittest.TestCase):
+    def test_interrupted_dispatch_requires_verification_when_uncertain(self):
+        decision = decide_recovery(load_journal(), receipt_result="INDETERMINATE")
+        self.assertEqual(decision.decision, "VERIFY_EXTERNALLY")
+
+    def test_observation_resumes_when_supported(self):
+        decision = decide_recovery(
+            load_journal(), receipt_result=None, connector_supports_observation=True
+        )
+        self.assertEqual(decision.decision, "RESUME_OBSERVATION")
+
+    def test_executed_receipt_stops_duplicate_dispatch(self):
+        decision = decide_recovery(load_journal(), receipt_result="EXECUTED")
+        self.assertEqual(decision.decision, "STOP")
+
+    def test_confirmed_failure_allows_exact_retry(self):
+        decision = decide_recovery(
+            load_journal(),
+            receipt_result="FAILED",
+            side_effect_absence_confirmed=True,
+        )
+        self.assertEqual(decision.decision, "RETRY_EXACT")
+
+    def test_expired_authority_requires_ask(self):
+        decision = decide_recovery(
+            load_journal(), receipt_result=None, authority_still_current=False
+        )
+        self.assertEqual(decision.decision, "ASK")
+
+    def test_active_lease_blocks_other_worker(self):
+        with self.assertRaises(RecoveryError):
+            acquire_lease(
+                load_journal(),
+                owner="auri-worker-02",
+                acquired_at="2026-07-15T21:55:30Z",
+                expires_at="2026-07-15T21:56:30Z",
+                expected_revision=1,
+            )
+
+    def test_stale_revision_is_rejected(self):
+        with self.assertRaises(RecoveryError):
+            transition(
+                load_journal(),
+                new_state="OBSERVING",
+                event="OBSERVATION_STARTED",
+                actor="auri:primary",
+                recorded_at="2026-07-15T21:56:10Z",
+                receipt_sha256="6" * 64,
+                expected_revision=0,
+            )
+
+    def test_terminal_requires_receipt_reference(self):
+        with self.assertRaises(RecoveryError):
+            transition(
+                load_journal(),
+                new_state="TERMINAL",
+                event="RESULT_ATTACHED",
+                actor="auri:primary",
+                recorded_at="2026-07-15T21:56:10Z",
+                receipt_sha256="6" * 64,
+                expected_revision=1,
+            )
+
+    def test_event_sequence_must_be_monotonic(self):
+        journal = load_journal()
+        journal["events"][1]["sequence"] = 8
+        with self.assertRaises(RecoveryError):
+            validate_journal(journal)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Begin issue #39 by preserving governed connector-execution state across interruption, timeout, restart, and ambiguous outcomes without silently repeating side effects or requiring redundant authorization for an unchanged action.

## Added

- execution-attempt journal schema
- execution-recovery decision schema
- connector-neutral recovery state machine
- interrupted Facebook-post journal fixture
- executable recovery tests

## Recovery contract

- recovery restores state but cannot create or expand authority;
- the original execution envelope hash and idempotency key remain bound;
- journal state transitions are monotonic;
- optimistic revisions reject stale writers;
- active leases block concurrent workers;
- EXECUTED receipts stop duplicate dispatch;
- confirmed side-effect absence may permit RETRY_EXACT;
- INDETERMINATE and uncertain FAILED outcomes require external verification;
- loss of current authority produces ASK rather than automatic replay;
- terminal transitions require receipt references.

## Remaining bounded work

- add dependency-light journal validator;
- add STARTED, OBSERVING, TERMINAL, and ABANDONED fixtures;
- add recovery-decision fixtures and receipt validation;
- add stale-lease takeover rules;
- bind recovery receipts to journal revision and prior-event hash;
- add dedicated CI;
- update handoff from published v0.1.7 to active issue #39;
- activate Unreleased changelog only after executable validation is green.

No live connector calls or credentials are included.

Closes #39 only when the full bounded deliverable is executable and green.