### PR TITLE
Reconcile v0.1.7 handoff and downstream state

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,28 +1,25 @@
 state: active
 works_today: yes — use the verified initializer or copy the template directly; no accounts, services, or lock-in
-current_version: 0.1.2
-current_focus: complete the automatic 0.1.3 publication cycle using source-SHA ancestry, durable outcome receipts, and bounded self-recovery
+current_version: 0.1.7
+current_focus: reconcile the published governed-action execution release with durable handoff, downstream review, and integration boundaries
 known_gaps:
   - Some docs may be reorganized as StegVerse expands
   - Data-sharing revenue behavior is documented but not implemented
-  - No real onboarding-friction reports have yet crossed the automation-candidate threshold
-  - The latest observed release-cycle receipt remains INCOMPLETE until the corrected workflow publishes or records a newer outcome
+  - No live social-platform connector or credentials are included
+  - Site and Publisher references require bounded review for v0.1.7
+  - Publisher documentation currently describes an ingestion endpoint, weekly batch workflow, and revenue-distribution behavior that are not implemented by this repository
 completed_recently:
-  - Published automated verified release v0.1.2 at commit 5e38ca635ed420a3800ca53dd59f236175207edb
-  - Added repository-native release, evidence, initializer, downstream-propagation, report-maintenance, and candidate-lifecycle automation
-  - Replaced historical issue gates with changelog-driven release state and durable release_required evidence
-  - Connected supported merged candidate fixes to idempotent Unreleased changelog recording and verified publication
-  - Added release-cycle outcome receipts for PUBLISHED, SKIPPED, FAILED, INCOMPLETE, and RECONCILED states
-  - Moved publication eligibility out of the job-level predicate and into an observable gate step
-  - Replaced unreliable event and pull-request metadata filters with a Git ancestry check requiring the source integrity SHA to be contained in main
-  - Added .github/workflows/release-cycle-recovery.yml for one bounded recovery dispatch per distinct incomplete source run
-  - Added docs/release_evidence/recovery_state.json to suppress duplicate recovery loops
+  - Published automated verified release v0.1.7 at commit 1ebba01cabfb08a77fe137035071e708a566080c
+  - Merged PR #38 and closed issue #37 for governed action execution envelopes and connector receipts
+  - Added ACT-only execution envelopes, PREPARED/EXECUTED/FAILED/INDETERMINATE receipts, exact binding checks, duplicate suppression, validator, tests, and dedicated CI
+  - Confirmed builder/verifier, initializer, and automation contract self-tests in the v0.1.7 publication receipt
+  - Preserved the boundary that connectors execute authority but do not create, broaden, reinterpret, or retain it
 next_steps:
   - Treat docs/release_evidence/latest.json as the machine-readable integrity and release-required gate
   - Treat docs/release_evidence/latest_release.json as the latest successful publication receipt
   - Treat docs/release_evidence/latest_cycle.json as the authoritative latest release-cycle outcome
-  - Treat docs/release_evidence/recovery_state.json as the bounded recovery source of truth
-  - Allow the ancestry-gated workflow chain to publish the substantive Unreleased state as the next verified patch release
-  - Allow three matching reports to create, independently validate, implement, record, and publish the smallest supported correction automatically
-  - Keep first-contact use independent of accounts, hosted services, mandatory SDKs, and vault telemetry
-last_reviewed_utc: 2026-07-14T15:50:00Z
+  - Refresh evidence/downstream-propagation/latest.json for v0.1.7
+  - Complete bounded review of StegVerse-Labs/Site and GCAT-BCAT-Engine/Publisher references
+  - Correct downstream documentation that implies unimplemented ingestion, telemetry, revenue, or live connector behavior
+  - Keep first-contact use independent of accounts, hosted services, mandatory SDKs, vault telemetry, and undeclared outbound transmission
+last_reviewed_utc: 2026-07-16T23:47:00Z

--- a/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -2,9 +2,9 @@
 
 **Repository:** `StegVerse-Labs/continuity-vault-kit`  
 **Module:** KnowledgeVault Kit / Continuity Vault Kit  
-**Status:** Active standalone release with published progressive delegation and active governed-action execution work.  
-**Current published version:** `0.1.6`  
-**Last updated:** 2026-07-15
+**Status:** Active standalone release with published governed-action execution and downstream reconciliation in progress.  
+**Current published version:** `0.1.7`  
+**Last updated:** 2026-07-16
 
 ## 1. Purpose and scope boundary
 
@@ -18,106 +18,93 @@ Repository automation does not certify the truth, safety, completeness, authorit
 
 - Standalone mode permits **no undeclared outbound transmission**.
 - A direct user instruction may authorize the covered action.
-- An **explicit, revocable, scoped delegation** may authorize repeated action through **standing preferences** without a per-item toggle.
+- An **explicit, revocable, scoped delegation** may authorize repeated action through standing preferences without a per-item toggle.
 - Per-action confirmation is required only when user policy, scope, material context, risk, law, or platform rules require it.
 - Repository automation does not independently grant authority.
 - Technical access, credentials, possession, repetition, and AI recommendation do not create authority.
 - A governed entity must not silently expand its own authority.
 - Material delegated actions and authority transitions require receipts.
 
-Example:
-
-> “Auri, post this photo to Facebook with the caption ‘Good times!’”
-
-When the intended account, image, and caption are clear, the instruction supplies current authority. Auri should act through a bounded execution envelope and preserve a receipt rather than request approval for every technical sub-step.
-
-Onboarding-friction automation retains its threshold of three reports before a candidate may be treated as supported. A supported candidate authorizes only the smallest repository-native correction demonstrated by evidence.
-
 ## 2. Published state
 
-- Current verified release: `v0.1.6`.
-- Release commit: `590e234fb66121a5ee72ebe422eed73118e012c5`.
+- Current verified release: `v0.1.7`.
+- Release commit: `1ebba01cabfb08a77fe137035071e708a566080c`.
 - Publication receipt: `docs/release_evidence/latest_release.json`.
 - Release-cycle receipt: `docs/release_evidence/latest_cycle.json`.
-- Issue #32 and PR #33 are completed.
-- Published progressive-delegation work includes ACT/ASK/DENY decisions, proposal-only onboarding, governance profiles, lifecycle transitions, immutable transition receipts, relationship declarations, AI limitations, and renegotiation triggers.
+- Release result: `PUBLISHED`; release-required state after publication: `false`.
+- Builder/verifier self-test: `PASS`.
+- Initializer self-test: `PASS`.
+- Automation contract test: `PASS`.
+- Issue #37 and PR #38 are completed.
 
-### Downstream determination for v0.1.6
+Published governed-action execution includes:
 
-- `StegVerse-Labs/Site`: update required through bounded review.
-- `GCAT-BCAT-Engine/Publisher`: update required through bounded review.
-- `StegVerse-Labs/admissibility-wiki`: no update required.
-- `StegVerse-002/stegguardian-wiki`: no update required.
+- ACT-only action execution envelopes;
+- exact action, resource, destination, payload, connector operation, authority-decision hash, and idempotency binding;
+- PREPARED, EXECUTED, FAILED, and INDETERMINATE receipts;
+- duplicate suppression for prior EXECUTED outcomes;
+- exact-envelope retry boundaries for confirmed FAILED outcomes;
+- automatic-retry prohibition for INDETERMINATE outcomes;
+- connector-neutral adapter, fixtures, validator, tests, and dedicated CI.
 
-Authoritative local receipt: `evidence/downstream-propagation/latest.json`.
+No live Facebook integration, social-platform credentials, or externally asserted side effect is included.
 
-## 3. Active governed-action execution work
-
-- Issue: `#37 Define governed action execution envelopes and connector receipts`.
-- Branch: `agent/governed-action-execution-v0-1`.
-- Pull request: `#38 Define governed action execution envelopes and connector receipts`.
-- PR state: draft pending complete executable validation.
-
-### Implemented artifacts
-
-- `schemas/action-execution-envelope.schema.json`;
-- `schemas/action-execution-receipt.schema.json`;
-- `execution/adapter.py`;
-- Facebook `Good times!` PREPARED reference envelope;
-- PREPARED, EXECUTED, FAILED, and INDETERMINATE result fixtures;
-- `tools/validate_action_execution.py`;
-- `tests/test_action_execution.py`;
-- `.github/workflows/governed-action-execution.yml`.
-
-### Execution invariants
+## 3. Durable execution invariants
 
 1. Only an ACT decision may produce an executable envelope.
-2. The exact action, resource, destination, payload, connector operation, authority-decision hash, and idempotency key are bound before execution.
-3. A connector executes authority; it does not create, broaden, reinterpret, or retain authority beyond the envelope.
-4. PREPARED claims no external side effect.
-5. EXECUTED requires platform identity and confirmation evidence.
-6. FAILED distinguishes confirmed absence of side effect from uncertain failure.
-7. INDETERMINATE blocks blind automatic retry.
-8. An EXECUTED duplicate returns the prior receipt instead of repeating the side effect.
-9. Destination, payload, operation, resource, and idempotency substitution are rejected.
-10. Every external attempt requires a receipt.
+2. A connector executes authority; it does not create, broaden, reinterpret, or retain authority beyond the envelope.
+3. PREPARED claims no external side effect.
+4. EXECUTED requires platform identity and confirmation evidence.
+5. FAILED distinguishes confirmed absence of side effect from uncertain failure.
+6. INDETERMINATE blocks blind automatic retry.
+7. An EXECUTED duplicate returns the prior receipt instead of repeating the side effect.
+8. Destination, payload, operation, resource, and idempotency substitution are rejected.
+9. Every external attempt requires a receipt.
+10. Generated reconstruction remains distinct from original evidence.
 
-No live Facebook integration or credentials are included in this bounded implementation.
+## 4. Current adjacent integration goal
 
-## 4. Durable decisions
+The source implementation is published. Remaining work is bounded downstream reconciliation without redefining the source execution contract.
 
-1. Governance exists to make delegated action safe, attributable, bounded, revocable, and usable—not to eliminate delegated action.
-2. A rule that only prevents action and provides no admissible delegated path is incomplete governance.
-3. Clear direct instructions and valid standing preferences should execute without repetitive confirmation.
-4. User responsibility for granted authority and AI responsibility for remaining within scope are distinct and simultaneous.
-5. Relationship standing may evolve through demonstrated conduct and reciprocal declaration, but authority expansion remains explicit.
-6. Connector capability never substitutes for authority.
-7. Unknown execution outcome is not permission to retry.
-8. Generated reconstruction remains distinct from original evidence.
-9. Storage optimization cannot override consent, authority, protected-evidence boundaries, or required material properties.
+### Destinations requiring review
+
+- `StegVerse-Labs/Site`
+  - Review public paper and mirror references for v0.1.7 compatibility.
+  - Preserve the boundary that Site publication does not certify production readiness or grant authority.
+- `GCAT-BCAT-Engine/Publisher`
+  - Correct documentation that currently describes an ingestion endpoint, weekly batch workflow, anonymized aggregation, licensing, revenue calculation, and payouts as though implemented.
+  - The source repository documents optional data sharing, but the behavior is not implemented.
+
+### Destinations currently requiring no direct update
+
+- `StegVerse-Labs/admissibility-wiki`
+- `StegVerse-002/stegguardian-wiki`
+
+Authoritative local determination: `evidence/downstream-propagation/latest.json`.
 
 ## 5. Remaining work
 
-1. Confirm Governed Action Execution Validation and repository-wide checks on the current head.
-2. Correct any schema, fixture, validator, or test mismatch.
-3. Add a substantive Unreleased changelog entry after executable validation is green.
-4. Update PR #38 body to the completed bounded deliverable.
-5. Mark ready and merge only from the exact green, mergeable head.
-6. Observe publication and downstream receipts before claiming the next release.
+1. Refresh downstream propagation evidence from v0.1.6 to v0.1.7.
+2. Complete the bounded Site review and record whether exact release literals or compatibility statements require correction.
+3. Correct Publisher integration claims so unimplemented endpoints, telemetry, aggregation, licensing, revenue, and payout behavior are clearly proposal-only.
+4. Validate all changed repositories on exact heads.
+5. Merge only green, mergeable bounded corrections.
+6. Record durable downstream receipts and update this handoff after completion.
+7. Evaluate the next adjacent goal only after downstream state is accurate and no source-contract expansion is introduced.
 
 ## 6. Continuation rule
 
-Continue only from issue #37, PR #38, the active branch, this handoff, and the execution schemas and tests.
+Continue from this handoff, the v0.1.7 release receipts, PR #38, and the downstream target handoffs before any mutation.
 
-Do not add live platform credentials or claim a real Facebook side effect. Do not permit ASK or DENY to create an envelope. Do not automatically retry an indeterminate action. Do not let connector output broaden the admitted destination, resource, payload, or operation.
+Do not add live platform credentials or claim real external side effects. Do not permit ASK or DENY to create an envelope. Do not automatically retry an indeterminate action. Do not let connector output broaden the admitted destination, resource, payload, or operation. Do not represent proposed data-sharing or revenue behavior as implemented.
 
 Recommended next activation condition:
 
-> PR #38 is merged from a green exact head, its compatible patch publication is confirmed, and downstream bounded-review ownership is preserved without redefining the source execution contract.
+> v0.1.7 downstream evidence is current, Site and Publisher bounded reviews are durably resolved, all exact-head checks pass, and no remaining adjacent documentation, integration, packaging, release, or propagation task is discoverable.
 
 ## 7. Archive note
 
-This handoff preserves published `v0.1.6`, completed progressive delegation and fair-agency implementation, refreshed downstream determinations, active issue #37 and PR #38, governed execution contracts, duplicate-suppression rules, remaining validation and release actions, and continuation boundaries. Continuation no longer requires access to the originating conversation.
+This handoff preserves the published v0.1.7 state, governed-action execution contract, release evidence, completed issue and PR, downstream destinations, known Publisher mismatch, remaining reconciliation work, and continuation boundaries. Continuation no longer requires access to the originating conversation.
 
 ---
 

--- a/docs/release_evidence/v0.1.7-downstream-reconciliation.md
+++ b/docs/release_evidence/v0.1.7-downstream-reconciliation.md
@@ -1,0 +1,22 @@
+# v0.1.7 Downstream Reconciliation
+
+Source release: `v0.1.7`  
+Release commit: `1ebba01cabfb08a77fe137035071e708a566080c`  
+Publication result: `PUBLISHED`
+
+## Verified source state
+
+- Governed action execution work from issue #37 and PR #38 is merged and published.
+- Builder/verifier, initializer, and automation contract self-tests passed in the publication receipt.
+- No live social-platform connector, credentials, or externally asserted side effect is included.
+
+## Downstream review state
+
+- `StegVerse-Labs/Site`: bounded compatibility review required; preserve the publication-only boundary.
+- `GCAT-BCAT-Engine/Publisher`: correction required because the current integration document presents unimplemented ingestion, aggregation, licensing, revenue, and payout behavior as operational.
+- `StegVerse-Labs/admissibility-wiki`: no direct update required under the current bounded determination.
+- `StegVerse-002/stegguardian-wiki`: no direct update required under the current bounded determination.
+
+## Completion condition
+
+Downstream reconciliation is complete only after the required Site review and Publisher correction are merged from validated exact heads and durable receipts are recorded without expanding the source execution contract.

--- a/evidence/downstream-propagation/latest.json
+++ b/evidence/downstream-propagation/latest.json
@@ -1,14 +1,14 @@
 {
   "schema_version": "1.0",
   "source_repository": "StegVerse-Labs/continuity-vault-kit",
-  "source_release": "v0.1.6",
-  "source_release_commit": "590e234fb66121a5ee72ebe422eed73118e012c5",
-  "checked_utc": "2026-07-15T21:36:00Z",
+  "source_release": "v0.1.7",
+  "source_release_commit": "1ebba01cabfb08a77fe137035071e708a566080c",
+  "checked_utc": "2026-07-16T23:47:00Z",
   "results": [
     {
       "repository": "StegVerse-Labs/Site",
-      "determination": "update required",
-      "rationale": "Existing Continuity Vault Kit publication and mirror references require bounded review for the v0.1.6 progressive-delegation and fair-agency release.",
+      "determination": "bounded review required",
+      "rationale": "The public KnowledgeVault paper and mirror handoff reference continuity-vault-kit. Review is required to confirm v0.1.7 compatibility while preserving the publication boundary that Site does not certify production readiness, grant authority, or claim live connector behavior.",
       "matches": [
         {"path": "scripts/check_site_knowledgevault_paper.py", "terms": ["continuity-vault-kit"]},
         {"path": "docs/KNOWLEDGEVAULT_PAPER_PUBLICATION.md", "terms": ["continuity-vault-kit"]},
@@ -19,22 +19,22 @@
     },
     {
       "repository": "GCAT-BCAT-Engine/Publisher",
-      "determination": "update required",
-      "rationale": "The Publisher integration document directly references Continuity Vault Kit and requires bounded review for v0.1.6.",
+      "determination": "correction required",
+      "rationale": "docs/VAULT_PUBLISHER_INTEGRATION.md describes an ingestion endpoint, weekly batch workflow, anonymized aggregation, licensing, revenue calculation, contribution scoring, and payouts as implemented behavior. continuity-vault-kit documents optional data sharing but does not implement these capabilities; the downstream document must be marked proposal-only or replaced with a verified integration contract.",
       "matches": [
-        {"path": "docs/VAULT_PUBLISHER_INTEGRATION.md", "terms": ["continuity-vault-kit"]}
+        {"path": "docs/VAULT_PUBLISHER_INTEGRATION.md", "terms": ["ingestion endpoint", "weekly batch", "Revenue distribution", "Payout"]}
       ]
     },
     {
       "repository": "StegVerse-Labs/admissibility-wiki",
       "determination": "no update required",
-      "rationale": "No direct Continuity Vault Kit release, install, download, compatibility, or mirror reference was found.",
+      "rationale": "No direct Continuity Vault Kit release, install, download, compatibility, connector-execution, or mirror reference was found in the prior bounded review.",
       "matches": []
     },
     {
       "repository": "StegVerse-002/stegguardian-wiki",
       "determination": "no update required",
-      "rationale": "No direct Continuity Vault Kit release, install, download, compatibility, or mirror reference was found.",
+      "rationale": "No direct Continuity Vault Kit release, install, download, compatibility, connector-execution, or mirror reference was found in the prior bounded review.",
       "matches": []
     }
   ]


### PR DESCRIPTION
## Purpose

Reconcile durable repository state after the published v0.1.7 governed-action execution release.

## Changes

- refresh `STATUS.md` from stale v0.1.2/v0.1.3 state to published v0.1.7;
- update the mirror handoff to record merged issue #37 / PR #38 and the current downstream goal;
- refresh downstream propagation evidence from v0.1.6 to v0.1.7;
- add a durable v0.1.7 downstream reconciliation receipt;
- explicitly identify the Publisher document mismatch where proposal-only ingestion, aggregation, licensing, revenue, and payout behavior is presented as operational.

## Boundaries

- no live connector or credentials;
- no claim of external side effects;
- no expansion of authority;
- no representation of proposed data-sharing or revenue behavior as implemented.

## Validation target

Repository checks must pass on the exact head before merge. Downstream Site and Publisher work remains separately bounded and must preserve each target repository's mirror handoff.