### PR TITLE
Verify StegTalk communication hash profile at KV boundary

### DIFF
--- a/execution/communication_runtime.py
+++ b/execution/communication_runtime.py
@@ -8,6 +8,8 @@ select a bearer, execute a transport, or create authority.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -28,6 +30,17 @@ class RecoveredCommunicationAttempt:
     recovery_records: list[Dict[str, Any]]
 
 
+def stegtalk_communication_sha256(value: Any) -> str:
+    """Return the hash profile used by StegTalk ST-031/ST-032 receipts.
+
+    This is intentionally separate from the generic KnowledgeVault action-envelope
+    hash profile. Cross-repository evidence must be verified using the producer's
+    declared canonicalization instead of silently re-hashing under a local profile.
+    """
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
 def _require(record: Dict[str, Any], *keys: str) -> None:
     missing = [key for key in keys if record.get(key) in (None, "")]
     if missing:
@@ -45,10 +58,8 @@ def _selection_binding(selection: Dict[str, Any]) -> None:
     claimed = str(selection["selection_sha256"])
     body = dict(selection)
     body.pop("selection_sha256", None)
-    calculated = canonical_sha256(body)
-    raw_calculated = calculated.split("sha256:", 1)[-1]
-    raw_claimed = claimed.split("sha256:", 1)[-1]
-    if raw_claimed != raw_calculated:
+    calculated = stegtalk_communication_sha256(body)
+    if claimed != calculated:
         raise CommunicationRuntimeJournalError("selection receipt hash mismatch")
 
 
@@ -87,7 +98,7 @@ def _execution_binding(selection: Dict[str, Any], lease: Dict[str, Any], receipt
         raise CommunicationRuntimeJournalError("execution lease epoch mismatch")
     body = dict(receipt)
     claimed = str(body.pop("receipt_sha256"))
-    calculated = canonical_sha256(body)
+    calculated = stegtalk_communication_sha256(body)
     if claimed != calculated:
         raise CommunicationRuntimeJournalError("edge execution receipt hash mismatch")
     if receipt["outcome"] in {"INDETERMINATE", "TIMEOUT_AFTER_DISPATCH", "UNKNOWN_AFTER_DISPATCH"} and bool(receipt.get("side_effect_absence_confirmed")):
@@ -102,9 +113,7 @@ class CommunicationRuntimeJournal:
 
     @staticmethod
     def stream_id(attempt_id: str) -> str:
-        # KV stream IDs are path components. Keep a stable reversible-enough form
-        # without allowing attempt IDs to create paths.
-        return "comm-" + canonical_sha256(attempt_id).split("sha256:", 1)[-1][:32]
+        return "comm-" + canonical_sha256(attempt_id)[:32]
 
     def begin(self, *, selection: Dict[str, Any], lease: Dict[str, Any]) -> str:
         _selection_binding(selection)

--- a/tests/test_communication_runtime.py
+++ b/tests/test_communication_runtime.py
@@ -2,10 +2,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from execution.adapter import canonical_sha256
 from execution.communication_runtime import (
     CommunicationRuntimeJournal,
     CommunicationRuntimeJournalError,
+    stegtalk_communication_sha256,
 )
 from execution.vault_store import KnowledgeVaultExecutionStore
 
@@ -28,7 +28,7 @@ def selection():
         "multipath_authorized": False,
         "remote_edge_execution_authorized": True,
     }
-    value["selection_sha256"] = canonical_sha256(value)
+    value["selection_sha256"] = stegtalk_communication_sha256(value)
     return value
 
 
@@ -55,7 +55,7 @@ def execution_receipt(*, key="idem:runtime:1", outcome="DELIVERED", side_effect_
         "side_effect_absence_confirmed": side_effect_absence_confirmed,
         "observed_at": "2026-08-22T22:36:00Z",
     }
-    value["receipt_sha256"] = canonical_sha256(value)
+    value["receipt_sha256"] = stegtalk_communication_sha256(value)
     return value
 
 
@@ -69,6 +69,12 @@ class CommunicationRuntimeJournalTests(unittest.TestCase):
 
     def journal(self):
         return CommunicationRuntimeJournal(KnowledgeVaultExecutionStore(self.root))
+
+    def test_hash_profile_is_prefixed_and_preserves_unicode(self):
+        first = stegtalk_communication_sha256({"text": "mañana"})
+        escaped_text = stegtalk_communication_sha256({"text": "ma\u00f1ana"})
+        self.assertTrue(first.startswith("sha256:"))
+        self.assertEqual(first, escaped_text)
 
     def test_begin_persists_selection_and_lease_and_reconstructs(self):
         j = self.journal()
@@ -116,7 +122,7 @@ class CommunicationRuntimeJournalTests(unittest.TestCase):
         receipt["edge_id"] = "edge:other"
         body = dict(receipt)
         body.pop("receipt_sha256")
-        receipt["receipt_sha256"] = canonical_sha256(body)
+        receipt["receipt_sha256"] = stegtalk_communication_sha256(body)
         with self.assertRaisesRegex(CommunicationRuntimeJournalError, "execution edge does not match"):
             self.journal().record_execution(selection=selection(), lease=lease(), receipt=receipt)
 


### PR DESCRIPTION
Fixes the cross-repo hash-verification mismatch exposed by the ST-031/ST-032 -> KnowledgeVault native runtime-journal proof. StegTalk communication receipts use UTF-8 canonical JSON with ensure_ascii=false and a sha256: prefix, while the generic KV action adapter uses a different local hash representation. CommunicationRuntimeJournal now explicitly verifies the producer-declared StegTalk hash profile instead of rehashing external evidence under KV's generic adapter profile. Adds regression coverage including Unicode canonicalization.