### PR TITLE
Add KnowledgeVault communications contact-ledger custody surface

### DIFF
--- a/KNOWLEDGEVAULT_MODULE_INTEGRATIONS_MIRROR_HANDOFF.md
+++ b/KNOWLEDGEVAULT_MODULE_INTEGRATIONS_MIRROR_HANDOFF.md
@@ -204,3 +204,19 @@ The `_Entities` root category folders plus `README.md` and `Entity_File_Template
 `_System/Identity/**`, `_System/Governance/**`, and `_System/Execution/**` remain runtime extension surfaces unless/until their paths are explicitly added to authoritative template source.
 
 Do not count dynamic runtime records as static template parity merely because their directories exist.
+
+
+## Incoming communications / contact-ledger binding
+
+Canonical producer: `StegVerse-Labs/Comms-Gateway`.
+
+Template-backed personal custody surfaces:
+
+- `_Entities/Self/Communications/PersonalInformationDirectory/`;
+- `_Entities/Self/Communications/ContactLedger/`.
+
+Comms-Gateway normalizes inbound events, resolves endpoints against every installed directory communication mode, groups evidence references by attributed subject, and emits hash-bound `COMMIT_CANDIDATE` packages. KnowledgeVault remains the durable custody owner and accepts changes only through the Interlock.
+
+A threshold-qualified composition is a candidate, not filing authority. Sealing requires separate owner authorization. Sealed observation IDs, cutoff, and composition hash are immutable; later events are preserved in an append-only post-filing list, and notice events are separately evidence-bound.
+
+Activation remains unproven until a real provider observation is resolved against the live personal directory, committed and read back through the KV Interlock, and receipt/hash verification succeeds. No synthetic caller evidence may be installed as a live personal record.

--- a/KNOWLEDGEVAULT_MODULE_INTEGRATIONS_MIRROR_HANDOFF.md
+++ b/KNOWLEDGEVAULT_MODULE_INTEGRATIONS_MIRROR_HANDOFF.md
@@ -213,10 +213,11 @@ Canonical producer: `StegVerse-Labs/Comms-Gateway`.
 Template-backed personal custody surfaces:
 
 - `_Entities/Self/Communications/PersonalInformationDirectory/`;
-- `_Entities/Self/Communications/ContactLedger/`.
+- `_Entities/Self/Communications/ContactLedger/`;
+- `_Entities/Self/Communications/contact-ledger.example.json` (schema-aligned empty ledger).
 
 Comms-Gateway normalizes inbound events, resolves endpoints against every installed directory communication mode, groups evidence references by attributed subject, and emits hash-bound `COMMIT_CANDIDATE` packages. KnowledgeVault remains the durable custody owner and accepts changes only through the Interlock.
 
-A threshold-qualified composition is a candidate, not filing authority. Sealing requires separate owner authorization. Sealed observation IDs, cutoff, and composition hash are immutable; later events are preserved in an append-only post-filing list, and notice events are separately evidence-bound.
+A threshold-qualified composition is a candidate, not filing authority. Sealing requires evidence-bound owner authorization scoped to the attribution key, claim type, and filing ID. A candidate containing communications after its filing cutoff fails closed. Sealed observation IDs, cutoff, and composition hash are immutable; later events are preserved in an append-only post-filing list, and notice events are separately evidence-bound.
 
 Activation remains unproven until a real provider observation is resolved against the live personal directory, committed and read back through the KV Interlock, and receipt/hash verification succeeds. No synthetic caller evidence may be installed as a live personal record.

--- a/vault_template/KnowledgeVault/_Entities/Self/Communications/ContactLedger/README.md
+++ b/vault_template/KnowledgeVault/_Entities/Self/Communications/ContactLedger/README.md
@@ -1,0 +1,21 @@
+# Contact Ledger
+
+One ledger record is maintained per attribution key. It contains normalized communication observations and evidence references without embedding call audio or message bodies.
+
+Lifecycle:
+
+1. append idempotent inbound observations;
+2. evaluate a versioned threshold profile over a defined time window;
+3. create a filing candidate when the threshold is met;
+4. seal only after separate owner authorization, freezing included observation IDs, cutoff time, and composition hash;
+5. append later communications to `post_filing_observation_ids`;
+6. append evidence-bound notice events without changing the sealed filing hash.
+
+Required integrity properties:
+
+- source event ID and evidence hash deduplicate ingestion;
+- ambiguous attribution cannot enter automatic filing composition;
+- the sealed filing core is immutable;
+- post-filing and notice histories are append-only;
+- every mutation arrives through the KnowledgeVault Interlock and yields commit/readback receipts;
+- ledger state is evidence organization, not a legal conclusion or permission to file.

--- a/vault_template/KnowledgeVault/_Entities/Self/Communications/PersonalInformationDirectory/README.md
+++ b/vault_template/KnowledgeVault/_Entities/Self/Communications/PersonalInformationDirectory/README.md
@@ -1,0 +1,15 @@
+# Personal Information Directory
+
+The personal directory maps owner-known subjects to any attributed communication modes.
+
+Each subject record should contain:
+
+- stable `subject_id`;
+- `subject_type`: `person` or `organization`;
+- owner-facing display name;
+- zero or more `communication_modes`, each with `mode`, `value`, optional label, verification state, and provenance reference;
+- optional relationship and organization references.
+
+Phone-family modes (`phone`, `voice`, `sms`, `mms`, `rcs`, `imessage_phone`) share a normalized endpoint family. Email and `imessage_email` share another. Other handles remain mode-scoped.
+
+Resolution must fail closed: one match is attributed, no match is unattributed, and multiple matches are ambiguous. Directory contents are private personal information and are not caller-identification authority.

--- a/vault_template/KnowledgeVault/_Entities/Self/Communications/README.md
+++ b/vault_template/KnowledgeVault/_Entities/Self/Communications/README.md
@@ -1,0 +1,10 @@
+# Personal Communications
+
+Canonical owner-controlled custody surface for normalized inbound communication records.
+
+- `PersonalInformationDirectory/` resolves communication endpoints to people or organizations.
+- `ContactLedger/` groups evidence references by attribution and maintains filing lifecycle state.
+- Raw audio, message bodies, credentials, and secrets are never embedded in index records; records reference separately governed evidence by path and hash.
+- Producers submit hash-bound `COMMIT_CANDIDATE` packages through the KnowledgeVault Interlock. This directory grants no provider, filing, governance, or execution authority.
+
+Ambiguous endpoint matches remain ambiguous and must not be composed into a filing automatically. Unknown endpoints use a pseudonymous endpoint key until owner-authorized attribution.

--- a/vault_template/KnowledgeVault/_Entities/Self/Communications/contact-ledger.example.json
+++ b/vault_template/KnowledgeVault/_Entities/Self/Communications/contact-ledger.example.json
@@ -1,19 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "attribution": {
-    "key": "organization:example",
-    "state": "ATTRIBUTED_DIRECTORY_MATCH",
-    "subject_id": "organization:example"
-  },
-  "observations": [],
-  "threshold_profile": {
-    "policy_version": "owner-policy-v1",
-    "claim_type": "owner_defined",
-    "minimum_communications": 3,
-    "window_days": 30
-  },
-  "filing_candidates": [],
-  "sealed_filings": [],
-  "notices": [],
-  "post_filing_observation_ids": []
+  "record_type": "personal_kv_contact_ledger",
+  "owner_ref": "kv://self",
+  "groups": {}
 }

--- a/vault_template/KnowledgeVault/_Entities/Self/Communications/contact-ledger.example.json
+++ b/vault_template/KnowledgeVault/_Entities/Self/Communications/contact-ledger.example.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1.0.0",
+  "attribution": {
+    "key": "organization:example",
+    "state": "ATTRIBUTED_DIRECTORY_MATCH",
+    "subject_id": "organization:example"
+  },
+  "observations": [],
+  "threshold_profile": {
+    "policy_version": "owner-policy-v1",
+    "claim_type": "owner_defined",
+    "minimum_communications": 3,
+    "window_days": 30
+  },
+  "filing_candidates": [],
+  "sealed_filings": [],
+  "notices": [],
+  "post_filing_observation_ids": []
+}


### PR DESCRIPTION
## Outcome

Adds the canonical personal KnowledgeVault paths consumed by the incoming communications reviewer.

### Template surfaces

- `_Entities/Self/Communications/PersonalInformationDirectory/`
- `_Entities/Self/Communications/ContactLedger/`
- schema-aligned empty contact-ledger example

### Integrity boundary

The directory supports any attributed communication mode. Ambiguous matches fail closed. Raw content remains separately governed evidence. Filing candidates do not confer filing authority; sealing requires evidence-bound owner authorization and valid cutoff chronology. Sealed filing cores remain immutable while notices and post-filing communications append separately.

### Validation

- KV Guardrails: PASS
- Security Baseline: PASS
- Repository validation diagnostics: PASS
- Release integrity: PASS

### Activation boundary

This establishes validated source/template custody topology only. Live activation still requires an actual provider event and KV Interlock commit/readback receipts.