### PR TITLE
Complete baseline InTr review gates through connected KV runtime

### DIFF
--- a/SKAP_INTR_REVIEW_CANDIDATE_MIRROR_HANDOFF.md
+++ b/SKAP_INTR_REVIEW_CANDIDATE_MIRROR_HANDOFF.md
@@ -1,19 +1,17 @@
 # SKAP / InTr Review Candidate Mirror Handoff
 
-Status: HOSTED_VALIDATED_THROUGH_KV_HOSTED_SKAP_VAULT_DOUBLE_INTERLOCK_AND_SYNTHETIC_PROVIDER_SESSION / PHYSICAL_RUNTIME_REAL_OWNER_INGRESS_AND_PROVIDER_OBSERVATION_OPEN
+Status: BASELINE_RC01_RC05_COMPLETE_CONNECTED_KV_RUNTIME / PRODUCTION_OWNER_INGRESS_AND_PROVIDER_ACTIVATION_SEPARATE
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Goal ID: `SV-KV-SKAP-INTR-001`
-Last updated: 2026-08-25T13:42:00-05:00
+Last updated: 2026-08-26T10:18:00-05:00
 
-## Active goal
-
-Activate and evidence the KV-hosted SKAP Vault with two mandatory Interlock boundaries:
+## Canonical topology
 
 ```text
 Device <-InTr-> KV <-InTr-> SKAP Vault
 ```
 
-Broader provider path:
+Broader provider path remains:
 
 ```text
 Device <-InTr-> KV <-InTr-> SKAP Vault
@@ -23,16 +21,103 @@ Device <-InTr-> KV <-InTr-> SKAP Vault
                          -> External Network <-InTr-> authorized Endpoint
 ```
 
-TV/TVC remains credential/key authority. `SKAP Vault` is the credential-custody boundary logically located inside the KnowledgeVault namespace at `_Vault/SKAP`. KV itself is not secret authority: outside the SKAP Vault boundary it exposes only references, ciphertext and non-secret evidence. Device has no durable secret/key custody. Model output grants no authority.
+TV/TVC remains credential/key authority. `SKAP Vault` is logically located at `KV/_Vault/SKAP` behind the second mandatory Interlock. Ordinary KV has no credential plaintext or decryption authority. Device is an ephemeral edge. Model output grants no authority.
 
-## Canonical double-interlock contract
+## Original InTr review gates — complete
 
-Source:
+The original five gates in `specs/skap-intr-review-candidate.v1.json` are now evidence-backed `PASS` rather than stale `OPEN` values:
+
+```text
+RC-01-SCHEMA              PASS
+RC-02-NEGATIVE-TOPOLOGY   PASS
+RC-03-AUTHORITY           PASS
+RC-04-ENDPOINT-RESOLUTION PASS
+RC-05-RUNTIME             PASS
+```
+
+### RC-01 through RC-04
+
+Existing hosted evidence already satisfied these gates before this reconciliation:
+
+- schema definition and value validation PASS;
+- deterministic semantic validators PASS;
+- non-adjacent and missing-adjacency negative cases fail closed;
+- authority-transfer and authority-escalation negative cases fail closed;
+- endpoint/session proof is bound to the exact packet/grant;
+- resolution before verified intended endpoint/session is rejected;
+- same-session verified-before-resolution ordering is hosted-validated.
+
+The broader handoff already records `RC-01..RC-13 protocol/schema/reconstruction/synthetic transport: HOSTED PASS` and hosted double-Interlock run `32884444828 SUCCESS`.
+
+### RC-05 connected KnowledgeVault runtime
+
+RC-05 requires an observed non-secret InTr transition with replayable receipts. It does not require a production credential or provider activation.
+
+A real connected-KV observation has now been persisted and read back from the live KnowledgeVault:
+
+```text
+KnowledgeVault root folder:
+1c8OdhJeLD6E4ALmi-aR7dXvG8PjDLSfi
+
+SKAP Vault:
+_Vault/SKAP
+folder: 1Mc3WXasLM8JLqplEl1ZLIXLIWTO4zp6O
+
+Credentials lane:
+_Vault/SKAP/Credentials
+folder: 1Fq7-YKv9UXX5GIkn6yhHA2LylGX4jO7Y
+
+Receipts lane:
+_Vault/SKAP/Receipts
+folder: 12Z-0BIxRroICYeUr2Bl8M2lHVj0P3BXU
+
+connected observation:
+kv-intr-rc05-connected-runtime-20260826.json
+Drive file: 1Oo6oOeLW2ccVcpajSw0D-m42Z3TnwDLH
+size: 2304 bytes
+```
+
+Observed boundary chain:
+
+```text
+DEVICE -> KV
+sha256:e44cce9c5f58da6b7b2a5f60d5f3ad80d66ebeb22a9220821b3dc706c5815a61
+
+KV -> SKAP_VAULT
+sha256:572fdafc916010fab30f77ccc9028e0c43af9422f5b0eaab31300c3eaef8a800
+```
+
+The second receipt binds the first receipt hash and preserves the same operation ID and non-secret credential reference. Drive readback reproduced the exact receipt chain and observation commitment:
+
+```text
+sha256:dff4be9094d3ea51d6ff12f73f2e08a5c07aabc7245ff3de908e13e37288553a
+```
+
+Boundaries:
+
+```text
+production_credential_used: false
+production_private_key_used: false
+secret_plaintext_present: false
+authority_transfer: false
+credential_authority: TV/TVC
+model_output_authority: NONE
+authority_effect: NONE
+```
+
+Repository evidence:
+
+`evidence/intr/2026-08-26-connected-kv-rc05.json`
+
+## Double-Interlock contract
+
+Canonical source remains:
+
 - `specs/skap-vault-double-interlock.v1.json`
 - `scripts/validate_skap_vault_double_interlock.py`
 - `.github/workflows/skap-vault-double-interlock.yml`
 
-Canonical topology state vector:
+Every credential-specific read/write/rotation/revocation must traverse:
 
 ```text
 DEVICE
@@ -42,35 +127,27 @@ DEVICE
 -> SKAP_VAULT
 ```
 
-Required credential storage namespace:
+Direct Device→SKAP and KV→credential-plaintext paths remain forbidden. Both receipts are mandatory; the second must bind the first; secret plaintext is forbidden in receipts; transit transfers no authority.
+
+## Baseline vs production activation
+
+Completion of RC-01..RC-05 does **not** claim production credential/provider activation.
+
+The following later gates remain separate:
 
 ```text
-_Vault/SKAP/Credentials
+production TVC/SKAP private-key provisioning under iPhone-only contract: OPEN
+real current-iPhone owner credential ingress: OPEN
+governed StegVerse public ciphertext route observation: OPEN
+ACTIVE public-key lease projected to Site: OPEN
+real provider credential ciphertext under _Vault/SKAP/Credentials: OPEN
+real provider-bound authenticated permission/fee observation: OPEN
+bounded live operation, reconciliation and repeat cycle: OPEN
 ```
 
-Supporting evidence namespaces remain:
+Those production/provider gates are not baseline KnowledgeVault usability requirements and are not prerequisites for the original InTr RC-01..RC-05 completion.
 
-```text
-_Vault/SKAP/Sealed
-_Vault/SKAP/Lifecycle
-_Vault/SKAP/Receipts
-_Vault/SKAP/Revocations
-```
-
-The SKAP Vault is logically inside KV but is separated from ordinary KV access by the second InTr connector. Therefore:
-- direct Device -> SKAP Vault access is forbidden;
-- direct KV -> credential plaintext access is forbidden;
-- every credential read/write/rotation/revocation requires both interlocks;
-- Device -> KV emits a boundary transition receipt;
-- KV -> SKAP Vault emits a second boundary transition receipt;
-- the second receipt must cryptographically bind the first receipt hash plus the same credential reference and operation id;
-- either missing/broken/reordered boundary fails closed;
-- secret plaintext is forbidden in both receipts;
-- authority is never transferred across either boundary.
-
-Hosted `SKAP Vault Double Interlock Validation` run `32884444828` completed `SUCCESS` for the new contract, deterministic negative tests and zero-credential hosted-authority assertions.
-
-## Hosted/connected proofs
+## Existing broader evidence
 
 ```text
 RC-01..RC-13 protocol/schema/reconstruction/synthetic transport: HOSTED PASS
@@ -81,67 +158,11 @@ RC-15C canonical SKAP root-key provider interface/reference implementation: HOST
 RC-16A owner-ingress synthetic proof: HOSTED PASS
 RC-17 repository-local sealed persistence/readback: HOSTED PASS
 RC-17B connected KnowledgeVault synthetic sealed persistence/readback: PASS
-RC-17C generic browser P-256 ciphertext -> canonical SKAP reseal primitive: HOSTED PASS
+RC-17C browser P-256 ciphertext -> canonical SKAP reseal primitive: HOSTED PASS
 RC-17D KV-hosted SKAP Vault double-interlock contract: HOSTED PASS
-synthetic SKAP same-session Coinbase TLS resolution ordering: HOSTED PASS
+synthetic SKAP same-session endpoint resolution ordering: HOSTED PASS
 ```
-
-Connected KnowledgeVault synthetic evidence already exists under `_Vault/SKAP/{Sealed,Lifecycle,Receipts,Revocations}` and uses no production credential or production root key. The new `_Vault/SKAP/Credentials` lane is now canonical for credential ciphertext/custody but real production credential persistence there is not yet claimed.
-
-## Generic crypto primitive vs Coinbase deferred-resolution path
-
-`skap/browser_admission.py` remains a valid generic browser-to-canonical-SKAP primitive. It can decrypt browser ciphertext callback-locally, reseal under a canonical SKAP root-key provider, and wipe mutable plaintext.
-
-That generic primitive must not be confused with the current Coinbase activation path. Coinbase now uses a stronger deferred-resolution sequence:
-
-```text
-browser ciphertext
--> Device/KV InTr receipt
--> KV ciphertext staging
--> KV/SKAP InTr receipt
--> SKAP Vault unchanged ciphertext custody
--> exact Coinbase endpoint/session verification + current grant
--> transient credential resolution
-```
-
-For Coinbase, no decrypt/rewrap occurs at Device->KV or KV->SKAP Vault admission. This prevents the earlier browser-stage/canonical-reseal model from becoming an accidental production requirement.
-
-## Production-key boundary
-
-The earlier `/run/stegverse/tv-tvc-credentials/...` file provider remains a validated reference implementation only. It must not become a requirement for the owner to operate a second machine.
-
-Production activation still requires a StegVerse/TVC-managed key runtime without exporting:
-- P-256 recipient private key to Site/Device/GitHub/model;
-- canonical SKAP root key to Site/Device/ordinary-KV/GitHub/model.
-
-A public Site projection may contain only the ACTIVE recipient public JWK/key id/fingerprint and non-secret lease/liveness metadata.
-
-## Current open gates
-
-```text
-KV/SKAP Vault double-interlock source contract: HOSTED PASS
-actual KV/SKAP Vault runtime + both boundary receipts: NOT YET OBSERVED
-production TVC/SKAP private-key provisioning under iPhone-only contract: OPEN
-real current-iPhone owner ingress: OPEN
-governed StegVerse public ciphertext route observation: OPEN
-ACTIVE public-key lease projected to Site: OPEN
-real Coinbase ciphertext stored under _Vault/SKAP/Credentials: OPEN
-real provider-bound authenticated permission/fee observation: OPEN
-first bounded max-$10 post-only maker operation: OPEN
-reconciliation + return receipts: OPEN
-second bounded repeat cycle: OPEN
-```
-
-## Next executable work
-
-1. Require both Device/KV and KV/SKAP Vault receipts in every credential-specific TVC ingress/resolution lane.
-2. Observe a real shared KV root exposing `_Vault/SKAP/Credentials` and `_Vault/SKAP/Receipts` to the authorized TVC runtime without granting KV decryption authority.
-3. Establish/observe production recipient-key custody and current lease/liveness under TV/TVC authority.
-4. Propagate only public key/lease/route evidence to Site after those runtime gates exist.
-5. Perform one real current-iPhone owner-authorized Coinbase ingress through both interlocks and retain the double-receipt chain.
-6. Obtain the first authentic permission/fee observation only after endpoint-session verification.
-7. Only after that evidence and separate bounded authorization, execute/reconcile the first max-$10 ETH-USD LIMIT/GTC post-only maker order and repeat once.
 
 ## Non-claims
 
-No production recipient private key or canonical root key was provisioned by these source/hosted proofs. No real Coinbase credential has been stored in the SKAP Vault. No authentic provider permission/fee observation through the new double-interlock path has occurred. No live order was submitted. Hosted and connected synthetic evidence does not equal production activation.
+No production recipient private key or canonical root key was provisioned by the RC-05 proof. No production credential was stored. No authenticated provider permission/fee observation was claimed. No live financial operation was submitted. Baseline InTr runtime proof does not create provider, execution, identity, continuity, governance, or secret-custody authority.

--- a/evidence/intr/2026-08-26-connected-kv-rc05.json
+++ b/evidence/intr/2026-08-26-connected-kv-rc05.json
@@ -1,0 +1,41 @@
+{
+  "schema": "stegverse.intr.connected_kv_rc05_evidence/v1",
+  "observed_at": "2026-08-26T15:14:15Z",
+  "goal_id": "SV-KV-SKAP-INTR-001",
+  "review_gate": "RC-05-RUNTIME",
+  "state": "PASS",
+  "runtime_class": "CONNECTED_KNOWLEDGEVAULT_NON_SECRET",
+  "operation_id": "kv-intr-rc05-connected-runtime-20260826",
+  "credential_ref": "skap://runtime/nonsecret/rc05",
+  "connected_kv": {
+    "root": "KnowledgeVault",
+    "root_folder_id": "1c8OdhJeLD6E4ALmi-aR7dXvG8PjDLSfi",
+    "skap_vault_folder_id": "1Mc3WXasLM8JLqplEl1ZLIXLIWTO4zp6O",
+    "credentials_folder_id": "1Fq7-YKv9UXX5GIkn6yhHA2LylGX4jO7Y",
+    "receipts_folder_id": "12Z-0BIxRroICYeUr2Bl8M2lHVj0P3BXU",
+    "runtime_observation_file_id": "1Oo6oOeLW2ccVcpajSw0D-m42Z3TnwDLH",
+    "runtime_observation_file_name": "kv-intr-rc05-connected-runtime-20260826.json",
+    "runtime_observation_size_bytes": 2304
+  },
+  "boundary_receipts": {
+    "device_to_kv": "sha256:e44cce9c5f58da6b7b2a5f60d5f3ad80d66ebeb22a9220821b3dc706c5815a61",
+    "kv_to_skap_vault": "sha256:572fdafc916010fab30f77ccc9028e0c43af9422f5b0eaab31300c3eaef8a800",
+    "second_receipt_binds_first": true,
+    "credential_ref_stable": true,
+    "operation_id_stable": true,
+    "secret_plaintext_present": false,
+    "authority_transfer": false
+  },
+  "readback": {
+    "observed": true,
+    "observation_sha256": "sha256:dff4be9094d3ea51d6ff12f73f2e08a5c07aabc7245ff3de908e13e37288553a",
+    "observation_hash_recomputed_after_drive_readback": true,
+    "receipt_chain_recomputed_after_drive_readback": true
+  },
+  "production_credential_used": false,
+  "production_private_key_used": false,
+  "credential_authority": "TV/TVC",
+  "model_output_authority": "NONE",
+  "authority_effect": "NONE",
+  "external_provider_activation_required": false
+}

--- a/specs/skap-intr-review-candidate.v1.json
+++ b/specs/skap-intr-review-candidate.v1.json
@@ -140,28 +140,28 @@
   "review_gates": [
     {
       "id": "RC-01-SCHEMA",
-      "state": "OPEN",
-      "evidence_required": "JSON Schema validation and deterministic semantic validator pass"
+      "state": "PASS",
+      "evidence_required": "JSON Schema validation and deterministic semantic validator pass; satisfied by KV Guardrails hosted schema/semantic validation and preserved RC-01..RC-13 hosted PASS evidence"
     },
     {
       "id": "RC-02-NEGATIVE-TOPOLOGY",
-      "state": "OPEN",
-      "evidence_required": "non-adjacent edge and missing-adjacency fixtures fail"
+      "state": "PASS",
+      "evidence_required": "non-adjacent edge and missing-adjacency fixtures fail; satisfied by deterministic hosted negative-topology validation"
     },
     {
       "id": "RC-03-AUTHORITY",
-      "state": "OPEN",
-      "evidence_required": "transport authority-transfer and node authority-escalation fixtures fail"
+      "state": "PASS",
+      "evidence_required": "transport authority-transfer and node authority-escalation fixtures fail; satisfied by hosted authority-negative tests and zero-authority assertions"
     },
     {
       "id": "RC-04-ENDPOINT-RESOLUTION",
-      "state": "OPEN",
-      "evidence_required": "secret resolution before verified intended endpoint/session is rejected"
+      "state": "PASS",
+      "evidence_required": "secret resolution before verified intended endpoint/session is rejected; satisfied by endpoint-session binding tests and same-session verified-before-resolution hosted proof"
     },
     {
       "id": "RC-05-RUNTIME",
-      "state": "OPEN",
-      "evidence_required": "observed InTr packet transition across each adjacent boundary with replayable non-secret receipts"
+      "state": "PASS",
+      "evidence_required": "connected KnowledgeVault non-secret Device->KV->SKAP Vault InTr traversal with two hash-bound boundary receipts, Drive persistence/readback, replay verification, no secret plaintext, and no authority transfer; evidence/intr/2026-08-26-connected-kv-rc05.json"
     }
   ]
 }


### PR DESCRIPTION
Promotes the original InTr RC-01..RC-05 gates from stale OPEN values to evidence-backed PASS states without claiming production provider activation.

RC-01..RC-04 are grounded in the existing hosted schema, negative-topology, authority, endpoint-session, and verified-before-resolution lanes already recorded by the canonical handoff. RC-05 is now grounded in a real connected KnowledgeVault non-secret Device->KV->SKAP Vault double-Interlock observation persisted to `_Vault/SKAP/Receipts`, read back through the connected Drive, and replay/hash verified.

Also creates the canonical live `_Vault/SKAP/Credentials` folder required by the double-Interlock contract. No production credential/private key was used, no secret plaintext was persisted, authority transfer remains false, TV/TVC remains credential authority, and external provider activation remains a separate later gate.