### PR TITLE
Install device-backed KV capability registry

### DIFF
--- a/KV_DEVICE_BACKED_CAPABILITIES_MIRROR_HANDOFF.md
+++ b/KV_DEVICE_BACKED_CAPABILITIES_MIRROR_HANDOFF.md
@@ -1,0 +1,42 @@
+# KV Device-Backed Capability Installation Mirror Handoff
+
+Status: ACTIVE_INSTALLATION
+Repository: StegVerse-Labs/continuity-vault-kit
+Issue: #53
+Updated: 2026-08-26
+
+## Decision
+
+Device-backed capability state MAY be installed into KnowledgeVault before Interlock/InTr activation.
+
+Installation means durable KV surfaces and a capability registry are present. It does not activate execution, identity, governance, credentials, providers, network access, or external side effects.
+
+Canonical invariant:
+
+```text
+KV holds what persists.
+Device/StegOS supplies what happens.
+Interlock/InTr governs transitions when activated.
+Installation != activation.
+```
+
+## Canonical registry
+
+- `specs/kv-device-backed-capability-registry.v1.json`
+- `schemas/kv-device-backed-capability-registry.schema.json`
+
+All registry entries are `INSTALLED_INACTIVE`, `authority_effect=NONE`, and reuse existing KV surfaces instead of creating duplicate domain stores.
+
+## Initial modules
+
+StegID/Continuity; Governance/StegGate; StegTalk; StegWhisper; StegHealth; StegFin/StegWallet/StegPay; Genealogy; Media/Playlists/Reading; Family Sharing; Organization Context; Auri/Ecosystem Chat; StegTeacher/Onboarding; ERL/Research.
+
+## Activation boundary
+
+A module may become active only after its listed Interlock/authority/provider prerequisites are actually observed. Folder presence or registry installation cannot satisfy those predicates.
+
+## Live Drive target
+
+`/KnowledgeVault/_System/Modules/`
+
+The live Drive copy must contain the registry plus per-module directories or equivalent durable slots, and readback must preserve the canonical inactive/no-authority state.

--- a/KV_DEVICE_BACKED_CAPABILITIES_MIRROR_HANDOFF.md
+++ b/KV_DEVICE_BACKED_CAPABILITIES_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Device-Backed Capability Installation Mirror Handoff
 
-Status: ACTIVE_INSTALLATION
+Status: INSTALLED_INACTIVE_CONNECTED_KV
 Repository: StegVerse-Labs/continuity-vault-kit
 Issue: #53
 Updated: 2026-08-26
@@ -27,16 +27,77 @@ Installation != activation.
 
 All registry entries are `INSTALLED_INACTIVE`, `authority_effect=NONE`, and reuse existing KV surfaces instead of creating duplicate domain stores.
 
-## Initial modules
+## Installed modules
 
-StegID/Continuity; Governance/StegGate; StegTalk; StegWhisper; StegHealth; StegFin/StegWallet/StegPay; Genealogy; Media/Playlists/Reading; Family Sharing; Organization Context; Auri/Ecosystem Chat; StegTeacher/Onboarding; ERL/Research.
+```text
+stegid-continuity
+governance-steggate
+stegtalk
+stegwhisper
+steghealth
+stegfin-wallet-pay
+genealogy
+media-playlists-reading
+family-sharing
+organization-context
+auri-ecosystem-chat
+stegteacher-onboarding
+erl-research
+```
+
+## Live connected-KV installation
+
+Connected KnowledgeVault root:
+
+`1c8OdhJeLD6E4ALmi-aR7dXvG8PjDLSfi`
+
+Installed runtime registry surface:
+
+`/KnowledgeVault/_System/Modules/`
+
+Drive folder:
+
+`1v7qTxizuaN385fD-GZHr_HMmgJpgTJxM`
+
+Registry projection:
+
+`module-registry`
+Drive file id: `1afD641cUGtQK7Bco2b9YL9ZXT77bLB9VAQFJeYz4SHI`
+
+Direct Drive enumeration observed the registry plus all 13 module folders.
+
+Direct registry readback observed:
+
+```text
+schema=stegverse.kv.device-backed-capability-registry/v1
+state=INSTALLED_INACTIVE
+interlock_activation_required_for_install=false
+runtime_activation_claimed=false
+network_activation_claimed=false
+credential_activation_claimed=false
+provider_activation_claimed=false
+authority_effect=NONE
+device_role=EPHEMERAL_ACTIVITY_EDGE
+kv_role=DURABLE_STATE_CONTINUITY_AND_RECONSTRUCTION
+```
+
+The Drive registry document is a connected-KV projection/index. The canonical portable machine-readable registry remains the repository JSON source.
 
 ## Activation boundary
 
 A module may become active only after its listed Interlock/authority/provider prerequisites are actually observed. Folder presence or registry installation cannot satisfy those predicates.
 
-## Live Drive target
+No Interlock activation, InTr activation, execution authority, identity authority, governance authority, credential authority transfer, provider activation, network activation, or external side effect is claimed by this installation.
 
-`/KnowledgeVault/_System/Modules/`
+## Completion
 
-The live Drive copy must contain the registry plus per-module directories or equivalent durable slots, and readback must preserve the canonical inactive/no-authority state.
+```text
+canonical registry source: COMPLETE_ON_BRANCH
+schema: COMPLETE_ON_BRANCH
+connected KV Modules surface: COMPLETE
+13 module slots: COMPLETE
+connected registry projection: COMPLETE
+connected registry readback: PASS
+Interlock/InTr activation: NOT CLAIMED / SEPARATE
+module runtime activation: NOT CLAIMED / SEPARATE
+```

--- a/schemas/kv-device-backed-capability-registry.schema.json
+++ b/schemas/kv-device-backed-capability-registry.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-device-backed-capability-registry.schema.json",
+  "title": "KnowledgeVault device-backed capability registry",
+  "type": "object",
+  "required": ["schema","state","interlock_activation_required_for_install","authority_effect","modules"],
+  "properties": {
+    "schema": {"const":"stegverse.kv.device-backed-capability-registry/v1"},
+    "state": {"enum":["INSTALLED_INACTIVE","ACTIVE"]},
+    "interlock_activation_required_for_install": {"const":false},
+    "authority_effect": {"const":"NONE"},
+    "modules": {
+      "type":"array",
+      "minItems":1,
+      "items":{
+        "type":"object",
+        "required":["module_id","install_state","kv_surfaces","device_activity","activation_requires","authority_effect"],
+        "properties":{
+          "module_id":{"type":"string","minLength":1},
+          "install_state":{"const":"INSTALLED_INACTIVE"},
+          "kv_surfaces":{"type":"array","minItems":1,"items":{"type":"string"}},
+          "device_activity":{"type":"array","minItems":1,"items":{"type":"string"}},
+          "activation_requires":{"type":"array","items":{"type":"string"}},
+          "authority_effect":{"const":"NONE"}
+        },
+        "additionalProperties":true
+      }
+    }
+  },
+  "additionalProperties":false
+}

--- a/specs/kv-device-backed-capability-registry.v1.json
+++ b/specs/kv-device-backed-capability-registry.v1.json
@@ -1,0 +1,288 @@
+{
+  "schema": "stegverse.kv.device-backed-capability-registry/v1",
+  "state": "INSTALLED_INACTIVE",
+  "installed_at": "2026-08-26T20:35:00Z",
+  "interlock_activation_required_for_install": false,
+  "runtime_activation_claimed": false,
+  "network_activation_claimed": false,
+  "credential_activation_claimed": false,
+  "provider_activation_claimed": false,
+  "authority_effect": "NONE",
+  "device_role": "EPHEMERAL_ACTIVITY_EDGE",
+  "kv_role": "DURABLE_STATE_CONTINUITY_AND_RECONSTRUCTION",
+  "modules": [
+    {
+      "module_id": "stegid-continuity",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_System/Identity/Continuity",
+        "_Entities/Self/StegID/Continuity"
+      ],
+      "device_activity": [
+        "user_presence",
+        "device_local_key_use",
+        "attestation_when_available",
+        "challenge_response"
+      ],
+      "activation_requires": [
+        "verified_current_identity_continuity_receipt",
+        "Interlock policy evaluation"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "governance-steggate",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_System/Governance/Decisions",
+        "_Policy"
+      ],
+      "device_activity": [
+        "intent_capture",
+        "approval_ui",
+        "bounded_action_handoff"
+      ],
+      "activation_requires": [
+        "current governance validator PASS",
+        "Interlock admission"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "stegtalk",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_System/Execution/Extensions",
+        "_System/Execution/Attempts",
+        "_System/Execution/Receipts",
+        "_System/Execution/Recovery",
+        "_Entities/People"
+      ],
+      "device_activity": [
+        "text_input",
+        "display",
+        "notifications",
+        "network_transport",
+        "local_crypto"
+      ],
+      "activation_requires": [
+        "Interlock transport admission",
+        "recipient/session resolution when required"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "stegwhisper",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_System/Execution/Extensions",
+        "_System/Execution/Attempts",
+        "_System/Execution/Receipts",
+        "_System/Execution/Recovery",
+        "04_Media"
+      ],
+      "device_activity": [
+        "microphone",
+        "speaker",
+        "audio_route",
+        "capture",
+        "playback",
+        "network_transport"
+      ],
+      "activation_requires": [
+        "Interlock transport admission",
+        "recipient/session resolution when required"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "steghealth",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "03_Records",
+        "_Entities/Self",
+        "_Entities/Organizations",
+        "_System/Execution/Receipts"
+      ],
+      "device_activity": [
+        "health_sensor_ingest",
+        "document_capture",
+        "portal_interaction",
+        "notifications",
+        "user_confirmation"
+      ],
+      "activation_requires": [
+        "KV-INTERLOCK-v1 bounded disclosure",
+        "minimum-necessary policy decision"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "stegfin-wallet-pay",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_Entities/Self",
+        "03_Records",
+        "_System/Execution",
+        "_Vault/SKAP"
+      ],
+      "device_activity": [
+        "biometric_authorization",
+        "provider_session",
+        "payment_presentation",
+        "network_transport",
+        "transaction_confirmation"
+      ],
+      "activation_requires": [
+        "Interlock admission",
+        "SKAP credential resolution",
+        "provider/session verification"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "genealogy",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_Entities/People",
+        "_Entities/Places",
+        "_Entities/Organizations",
+        "_Index/Relationships",
+        "04_Media"
+      ],
+      "device_activity": [
+        "photo_capture",
+        "document_scan",
+        "relative_interaction",
+        "location_observation",
+        "peer_sharing"
+      ],
+      "activation_requires": [
+        "sharing policy when data leaves owner KV"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "media-playlists-reading",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "04_Media",
+        "_Entities/People",
+        "_Entities/Projects"
+      ],
+      "device_activity": [
+        "provider_playback",
+        "media_capture",
+        "provider_sync",
+        "share_ui"
+      ],
+      "activation_requires": [
+        "provider/session admission when external playback or sync is used"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "family-sharing",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_Entities/People",
+        "_Index/Relationships",
+        "04_Media",
+        "05_Projects"
+      ],
+      "device_activity": [
+        "recipient_selection",
+        "share_ui",
+        "local_projection",
+        "transport"
+      ],
+      "activation_requires": [
+        "explicit disclosure policy",
+        "Interlock recipient/scope admission"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "organization-context",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_Entities/Organizations",
+        "_Entities/People",
+        "_Entities/Projects",
+        "_System/Governance"
+      ],
+      "device_activity": [
+        "context_selection",
+        "role_ui",
+        "bounded_projection",
+        "external_interaction"
+      ],
+      "activation_requires": [
+        "organizational authority reference",
+        "Interlock minimum projection"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "auri-ecosystem-chat",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_AI",
+        "_System/Execution",
+        "_Entities",
+        "_Index"
+      ],
+      "device_activity": [
+        "conversation_ui",
+        "local_or_admitted_inference",
+        "network_transport_when_needed",
+        "user_confirmation"
+      ],
+      "activation_requires": [
+        "actionable-handoff-first policy",
+        "minimum-necessary record admission"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "stegteacher-onboarding",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "_Index/Onboarding",
+        "_Entities/Self",
+        "_Entities/Organizations",
+        "05_Projects"
+      ],
+      "device_activity": [
+        "lesson_ui",
+        "assessment_input",
+        "camera_microphone_when_needed",
+        "user_confirmation"
+      ],
+      "activation_requires": [
+        "training/onboarding policy when capability changes"
+      ],
+      "authority_effect": "NONE"
+    },
+    {
+      "module_id": "erl-research",
+      "install_state": "INSTALLED_INACTIVE",
+      "kv_surfaces": [
+        "02_Research",
+        "_Index",
+        "_AI",
+        "05_Projects"
+      ],
+      "device_activity": [
+        "browser_research",
+        "source_capture",
+        "report_ui",
+        "user_review"
+      ],
+      "activation_requires": [
+        "source/disclosure policy for external sharing or governed action"
+      ],
+      "authority_effect": "NONE"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #53. Adds the canonical device-backed KnowledgeVault capability registry and schema, records the direct connected-KV installation under `/KnowledgeVault/_System/Modules/`, and preserves the boundary that installation does not activate Interlock/InTr, execution, identity, governance, credential, provider, or network authority. All 13 module slots are installed as `INSTALLED_INACTIVE`; the connected registry readback confirms all activation claims false and `authority_effect=NONE`.