### PR TITLE
Reconcile merged KV personal services installation

### DIFF
--- a/KV_PERSONAL_SERVICES_MIRROR_HANDOFF.md
+++ b/KV_PERSONAL_SERVICES_MIRROR_HANDOFF.md
@@ -1,8 +1,11 @@
 # KnowledgeVault Personal Services Mirror Handoff
 
-Status: INSTALLED_INACTIVE_CONNECTED_KV
+Status: INSTALLED_INACTIVE_CONNECTED_KV_MERGED
 Repository: StegVerse-Labs/continuity-vault-kit
 Issue: #55
+Merged PR: #57
+Merge: 7df3e547f092dcb3b849314739b690837f51e126
+CI: KV Guardrails 33014611544 SUCCESS; Repository validation 33014611550 SUCCESS; Security Baseline 33014611612 SUCCESS
 Updated: 2026-08-26
 
 ## Decision
@@ -197,10 +200,10 @@ This installation does not claim:
 ## Completion
 
 ```text
-canonical schema: COMPLETE_ON_BRANCH
-canonical registry: COMPLETE_ON_BRANCH
-validator: COMPLETE_ON_BRANCH
-tests: COMPLETE_ON_BRANCH
+canonical schema: COMPLETE_MERGED
+canonical registry: COMPLETE_MERGED
+validator: COMPLETE_MERGED
+tests: COMPLETE_MERGED
 connected Services surface: COMPLETE
 33 service slots: COMPLETE
 registry projection: COMPLETE


### PR DESCRIPTION
Reconciles the #55 handoff after PR #57 merged and records the successful guardrail, repository-validation, and security runs. No runtime or activation semantics change.