### PR TITLE
Add fail-closed KV activation readiness control plane

### DIFF
--- a/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
+++ b/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
@@ -1,0 +1,173 @@
+# KnowledgeVault Activation Readiness Mirror Handoff
+
+Status: CONNECTED_KV_READINESS_CONTROL_PLANE_ACTIVE
+Repository: StegVerse-Labs/continuity-vault-kit
+Issue: #59
+Updated: 2026-08-26
+
+## Purpose
+
+Bridge the installed KV capability/service environment to the approaching Interlock/InTr runtime without conflating readiness with activation.
+
+Canonical distinction:
+
+```text
+installation state != local materialization readiness
+local materialization readiness != governed action readiness
+governed action readiness != activation
+activation != authority
+```
+
+This control plane is observational and fail-closed. It cannot change any installed module/service from `INSTALLED_INACTIVE` to `ACTIVE`.
+
+## Canonical source
+
+- `specs/kv-activation-readiness-facts.v1.json`
+- `specs/kv-module-activation-policy.v1.json`
+- `schemas/kv-activation-readiness-snapshot.schema.json`
+- `scripts/evaluate_kv_activation_readiness.py`
+- `tests/test_kv_activation_readiness.py`
+- `evidence/kv/2026-08-26-activation-readiness-snapshot.json`
+
+## Current observed facts
+
+```text
+baseline InTr RC-01..RC-05 complete: true
+connected-KV baseline runtime observed: true
+production Interlock runtime activated: false
+TVC resident recipient-key liveness observed: false
+READY_FOR_OWNER_INGRESS observed: false
+production Gateway route observed: false
+production double-Interlock receipts observed: false
+provider session evidence observed: false
+current identity-continuity receipt observed: false
+governance runtime admission observed: false
+authority_effect: NONE
+```
+
+These facts deliberately preserve the current TVC activation handoff. Baseline InTr completion does not imply production resident/runtime activation.
+
+## Readiness model
+
+Local materialization answers whether StegOS may expose a local UI/runtime projection without performing a governed external action.
+
+Governed action readiness answers whether the capability may cross a governed boundary.
+
+Current rules:
+
+```text
+local materialization may be READY while governed action remains BLOCKED
+every governed action requires production Interlock runtime activation
+provider-backed actions also require current provider/session evidence
+StegFin additionally requires current TVC/SKAP production evidence
+StegID local materialization remains blocked until a current identity-continuity receipt exists
+unknown/missing prerequisite = BLOCKED
+```
+
+## Current snapshot
+
+```text
+entry_count: 46
+modules: 13
+services: 33
+
+local_ready: 45
+local_blocked: 1
+
+governed_ready: 0
+governed_blocked: 46
+
+activation_performed: false
+authority_effect: NONE
+```
+
+The single locally blocked entry is `stegid-continuity`, pending a current identity-continuity receipt.
+
+No governed action is marked ready while the production Interlock runtime fact remains false.
+
+## Connected KnowledgeVault projection
+
+Live KV root:
+
+`1c8OdhJeLD6E4ALmi-aR7dXvG8PjDLSfi`
+
+Readiness surface:
+
+`/KnowledgeVault/_System/Readiness/`
+
+Drive folder:
+
+`1YOOI4eFsuCK50LnmgdiPuMxHrucUvTwh`
+
+Snapshot projection:
+
+`activation-readiness-snapshot`
+
+Drive file:
+
+`1ZmaI21dpCpDGZ_g6pbZNsE-Bn87S_8km6ehcHa3lRc4`
+
+Direct Drive readback verified:
+
+```text
+entry_count=46
+module_count=13
+service_count=33
+baseline_intr_complete=true
+production_interlock_runtime_activated=false
+activation_performed=false
+authority_effect=NONE
+summary.local_ready=45
+summary.local_blocked=1
+summary.governed_ready=0
+summary.governed_blocked=46
+all installed states remain INSTALLED_INACTIVE
+all entry activation flags remain false
+all entry authority effects remain NONE
+```
+
+## Relationship to TVC production activation
+
+The current production runtime owner remains:
+
+`StegVerse-Labs/TVC/docs/TVC_COINBASE_IPHONE_SKAP_ACTIVATION_MIRROR_HANDOFF.md`
+
+This KV readiness control plane does not duplicate the TVC resident activation lane.
+
+When TVC produces new durable facts such as:
+
+- recipient-key liveness;
+- `READY_FOR_OWNER_INGRESS`;
+- production Gateway route;
+- production chained DEVICE→KV and KV→SKAP receipts;
+- provider/session evidence;
+
+the readiness facts file may advance and a new snapshot may be generated.
+
+No capability should be activated solely because a readiness fact changes; the actual service/module activation transition remains separately governed and receipted.
+
+## Non-claims
+
+No module/service activation is claimed.
+No production Interlock activation is claimed.
+No production InTr activation is claimed.
+No credential/provider activation is claimed.
+No identity/governance/execution authority is created.
+No external side effect is created.
+
+## Completion gates
+
+```text
+readiness facts: COMPLETE_ON_BRANCH
+module activation policy: COMPLETE_ON_BRANCH
+snapshot schema: COMPLETE_ON_BRANCH
+fail-closed evaluator: COMPLETE_ON_BRANCH
+tests: COMPLETE_ON_BRANCH
+current 46-entry snapshot: COMPLETE_ON_BRANCH
+connected KV Readiness surface: COMPLETE
+connected snapshot projection: COMPLETE
+connected readback: PASS
+CI: PENDING
+merge: PENDING
+activation: NOT PERFORMED
+```

--- a/evidence/kv/2026-08-26-activation-readiness-snapshot.json
+++ b/evidence/kv/2026-08-26-activation-readiness-snapshot.json
@@ -1,0 +1,629 @@
+{
+  "schema": "stegverse.kv.activation-readiness-snapshot/v1",
+  "facts_observed_at": "2026-08-26T23:16:00Z",
+  "entry_count": 46,
+  "module_count": 13,
+  "service_count": 33,
+  "baseline_intr_complete": true,
+  "production_interlock_runtime_activated": false,
+  "activation_performed": false,
+  "authority_effect": "NONE",
+  "entries": [
+    {
+      "entry_type": "MODULE",
+      "entry_id": "stegid-continuity",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "BLOCKED_CURRENT_IDENTITY",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "current_identity_continuity_receipt_observed",
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "governance-steggate",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "governance_runtime_admission_observed",
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "stegtalk",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "stegwhisper",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "steghealth",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "stegfin-wallet-pay",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "tvc_resident_key_liveness_observed",
+        "ready_for_owner_ingress_observed",
+        "production_gateway_route_observed",
+        "production_double_interlock_receipts_observed",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "genealogy",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "media-playlists-reading",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "family-sharing",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "organization-context",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "auri-ecosystem-chat",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "stegteacher-onboarding",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "MODULE",
+      "entry_id": "erl-research",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "calendar-scheduling",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "tasks-reminders",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
+      "governed_blockers": [],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "contacts",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "email-continuity",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "benefits-claims",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "legal-records",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "insurance",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "home-household",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "vehicles",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "travel",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "education-records",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "employment-history",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "credentials-certifications",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "property-assets",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "taxes",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "subscriptions",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "purchases-warranties",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "photos-memories",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "personal-journal",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
+      "governed_blockers": [],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "goals-plans",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
+      "governed_blockers": [],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "recipes-food",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "fitness",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "device-inventory",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
+      "governed_blockers": [],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "software-licenses",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "digital-inheritance",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "emergency-information",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
+      "governed_blockers": [],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "estate-planning",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "contracts",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "professional-portfolio",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "creative-works",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "music-projects",
+      "service_class": "KV_DEVICE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "family-history",
+      "service_class": "KV_NATIVE",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    },
+    {
+      "entry_type": "SERVICE",
+      "entry_id": "research-libraries",
+      "service_class": "KV_DEVICE_PROVIDER",
+      "install_state": "INSTALLED_INACTIVE",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated",
+        "provider_session_evidence_observed"
+      ],
+      "activation_performed": false,
+      "authority_effect": "NONE"
+    }
+  ],
+  "summary": {
+    "local_ready": 45,
+    "local_blocked": 1,
+    "governed_ready": 5,
+    "governed_blocked": 41
+  }
+}

--- a/evidence/kv/2026-08-26-activation-readiness-snapshot.json
+++ b/evidence/kv/2026-08-26-activation-readiness-snapshot.json
@@ -8,6 +8,12 @@
   "production_interlock_runtime_activated": false,
   "activation_performed": false,
   "authority_effect": "NONE",
+  "summary": {
+    "local_ready": 45,
+    "local_blocked": 1,
+    "governed_ready": 0,
+    "governed_blocked": 46
+  },
   "entries": [
     {
       "entry_type": "MODULE",
@@ -192,8 +198,10 @@
       "service_class": "KV_DEVICE",
       "install_state": "INSTALLED_INACTIVE",
       "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
-      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
-      "governed_blockers": [],
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
       "activation_performed": false,
       "authority_effect": "NONE"
     },
@@ -427,8 +435,10 @@
       "service_class": "KV_NATIVE",
       "install_state": "INSTALLED_INACTIVE",
       "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
-      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
-      "governed_blockers": [],
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
       "activation_performed": false,
       "authority_effect": "NONE"
     },
@@ -438,8 +448,10 @@
       "service_class": "KV_NATIVE",
       "install_state": "INSTALLED_INACTIVE",
       "local_materialization": "READY_FOR_LOCAL_MATERIALIZATION",
-      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
-      "governed_blockers": [],
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
       "activation_performed": false,
       "authority_effect": "NONE"
     },
@@ -477,8 +489,10 @@
       "service_class": "KV_DEVICE",
       "install_state": "INSTALLED_INACTIVE",
       "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
-      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
-      "governed_blockers": [],
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
       "activation_performed": false,
       "authority_effect": "NONE"
     },
@@ -516,8 +530,10 @@
       "service_class": "KV_DEVICE",
       "install_state": "INSTALLED_INACTIVE",
       "local_materialization": "READY_FOR_DEVICE_MATERIALIZATION",
-      "governed_action_readiness": "READY_FOR_GOVERNED_ACTION",
-      "governed_blockers": [],
+      "governed_action_readiness": "BLOCKED",
+      "governed_blockers": [
+        "production_interlock_runtime_activated"
+      ],
       "activation_performed": false,
       "authority_effect": "NONE"
     },
@@ -619,11 +635,5 @@
       "activation_performed": false,
       "authority_effect": "NONE"
     }
-  ],
-  "summary": {
-    "local_ready": 45,
-    "local_blocked": 1,
-    "governed_ready": 5,
-    "governed_blocked": 41
-  }
+  ]
 }

--- a/schemas/kv-activation-readiness-snapshot.schema.json
+++ b/schemas/kv-activation-readiness-snapshot.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-activation-readiness-snapshot.schema.json",
+  "title": "KnowledgeVault activation readiness snapshot",
+  "type": "object",
+  "required": [
+    "schema",
+    "entry_count",
+    "module_count",
+    "service_count",
+    "activation_performed",
+    "authority_effect",
+    "entries"
+  ],
+  "properties": {
+    "schema": {
+      "const": "stegverse.kv.activation-readiness-snapshot/v1"
+    },
+    "entry_count": {
+      "const": 46
+    },
+    "module_count": {
+      "const": 13
+    },
+    "service_count": {
+      "const": 33
+    },
+    "activation_performed": {
+      "const": false
+    },
+    "authority_effect": {
+      "const": "NONE"
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 46,
+      "maxItems": 46,
+      "items": {
+        "type": "object",
+        "required": [
+          "entry_type",
+          "entry_id",
+          "install_state",
+          "local_materialization",
+          "governed_action_readiness",
+          "governed_blockers",
+          "activation_performed",
+          "authority_effect"
+        ],
+        "properties": {
+          "entry_type": {
+            "enum": [
+              "MODULE",
+              "SERVICE"
+            ]
+          },
+          "entry_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "install_state": {
+            "const": "INSTALLED_INACTIVE"
+          },
+          "local_materialization": {
+            "type": "string",
+            "minLength": 1
+          },
+          "governed_action_readiness": {
+            "enum": [
+              "READY_FOR_GOVERNED_ACTION",
+              "BLOCKED"
+            ]
+          },
+          "governed_blockers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "activation_performed": {
+            "const": false
+          },
+          "authority_effect": {
+            "const": "NONE"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/evaluate_kv_activation_readiness.py
+++ b/scripts/evaluate_kv_activation_readiness.py
@@ -47,9 +47,8 @@ def evaluate():
         else:
             local = "READY_FOR_LOCAL_UI"
 
-        governed_requires = []
+        governed_requires = ["production_interlock_runtime_activated"]
         if cls == "KV_DEVICE_PROVIDER" or provider != "NONE":
-            governed_requires.append("production_interlock_runtime_activated")
             governed_requires.append("provider_session_evidence_observed")
         blockers = missing_requirements(governed_requires, facts)
         entries.append({
@@ -74,6 +73,12 @@ def evaluate():
         "production_interlock_runtime_activated":facts["production_interlock_runtime_activated"],
         "activation_performed":False,
         "authority_effect":"NONE",
+        "summary":{
+            "local_ready":sum(1 for e in entries if e["local_materialization"].startswith("READY")),
+            "local_blocked":sum(1 for e in entries if not e["local_materialization"].startswith("READY")),
+            "governed_ready":sum(1 for e in entries if e["governed_action_readiness"]=="READY_FOR_GOVERNED_ACTION"),
+            "governed_blocked":sum(1 for e in entries if e["governed_action_readiness"]=="BLOCKED"),
+        },
         "entries":entries,
     }
     return snapshot

--- a/scripts/evaluate_kv_activation_readiness.py
+++ b/scripts/evaluate_kv_activation_readiness.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Evaluate KV module/service readiness without activating anything."""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULES = ROOT / "specs" / "kv-device-backed-capability-registry.v1.json"
+SERVICES = ROOT / "specs" / "kv-personal-services-registry.v1.json"
+FACTS = ROOT / "specs" / "kv-activation-readiness-facts.v1.json"
+POLICY = ROOT / "specs" / "kv-module-activation-policy.v1.json"
+
+def load(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+def missing_requirements(requirements, facts):
+    return [name for name in requirements if facts.get(name) is not True]
+
+def evaluate():
+    modules = load(MODULES)["modules"]
+    services = load(SERVICES)["services"]
+    facts = load(FACTS)
+    policy = {x["module_id"]: x for x in load(POLICY)["modules"]}
+
+    entries = []
+    for module in modules:
+        p = policy[module["module_id"]]
+        blockers = missing_requirements(p["governed_requires"], facts)
+        entries.append({
+            "entry_type":"MODULE",
+            "entry_id":module["module_id"],
+            "install_state":module["install_state"],
+            "local_materialization":p["local_materialization"],
+            "governed_action_readiness":"READY_FOR_GOVERNED_ACTION" if not blockers else "BLOCKED",
+            "governed_blockers":blockers,
+            "activation_performed":False,
+            "authority_effect":"NONE",
+        })
+
+    for service in services:
+        cls = service["service_class"]
+        provider = service["provider_dependency"]
+        if cls == "KV_NATIVE":
+            local = "READY_FOR_LOCAL_MATERIALIZATION"
+        elif cls == "KV_DEVICE":
+            local = "READY_FOR_DEVICE_MATERIALIZATION"
+        else:
+            local = "READY_FOR_LOCAL_UI"
+
+        governed_requires = []
+        if cls == "KV_DEVICE_PROVIDER" or provider != "NONE":
+            governed_requires.append("production_interlock_runtime_activated")
+            governed_requires.append("provider_session_evidence_observed")
+        blockers = missing_requirements(governed_requires, facts)
+        entries.append({
+            "entry_type":"SERVICE",
+            "entry_id":service["service_id"],
+            "service_class":cls,
+            "install_state":service["install_state"],
+            "local_materialization":local,
+            "governed_action_readiness":"READY_FOR_GOVERNED_ACTION" if not blockers else "BLOCKED",
+            "governed_blockers":blockers,
+            "activation_performed":False,
+            "authority_effect":"NONE",
+        })
+
+    snapshot = {
+        "schema":"stegverse.kv.activation-readiness-snapshot/v1",
+        "facts_observed_at":facts["observed_at"],
+        "entry_count":len(entries),
+        "module_count":sum(1 for e in entries if e["entry_type"]=="MODULE"),
+        "service_count":sum(1 for e in entries if e["entry_type"]=="SERVICE"),
+        "baseline_intr_complete":facts["baseline_intr_rc01_rc05_complete"],
+        "production_interlock_runtime_activated":facts["production_interlock_runtime_activated"],
+        "activation_performed":False,
+        "authority_effect":"NONE",
+        "entries":entries,
+    }
+    return snapshot
+
+def main():
+    snapshot = evaluate()
+    print(json.dumps(snapshot, indent=2, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/kv-activation-readiness-facts.v1.json
+++ b/specs/kv-activation-readiness-facts.v1.json
@@ -1,0 +1,16 @@
+{
+  "schema": "stegverse.kv.activation-readiness-facts/v1",
+  "observed_at": "2026-08-26T23:16:00Z",
+  "baseline_intr_rc01_rc05_complete": true,
+  "connected_kv_baseline_runtime_observed": true,
+  "production_interlock_runtime_activated": false,
+  "tvc_resident_key_liveness_observed": false,
+  "ready_for_owner_ingress_observed": false,
+  "production_gateway_route_observed": false,
+  "production_double_interlock_receipts_observed": false,
+  "provider_session_evidence_observed": false,
+  "current_identity_continuity_receipt_observed": false,
+  "governance_runtime_admission_observed": false,
+  "device_context_runtime_specific": true,
+  "authority_effect": "NONE"
+}

--- a/specs/kv-module-activation-policy.v1.json
+++ b/specs/kv-module-activation-policy.v1.json
@@ -1,0 +1,103 @@
+{
+  "schema": "stegverse.kv.module-activation-policy/v1",
+  "modules": [
+    {
+      "module_id": "stegid-continuity",
+      "local_materialization": "BLOCKED_CURRENT_IDENTITY",
+      "governed_requires": [
+        "current_identity_continuity_receipt_observed",
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "governance-steggate",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "governance_runtime_admission_observed",
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "stegtalk",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "stegwhisper",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "steghealth",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "stegfin-wallet-pay",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated",
+        "tvc_resident_key_liveness_observed",
+        "ready_for_owner_ingress_observed",
+        "production_gateway_route_observed",
+        "production_double_interlock_receipts_observed",
+        "provider_session_evidence_observed"
+      ]
+    },
+    {
+      "module_id": "genealogy",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "media-playlists-reading",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "family-sharing",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "organization-context",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "auri-ecosystem-chat",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "stegteacher-onboarding",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    },
+    {
+      "module_id": "erl-research",
+      "local_materialization": "READY_FOR_LOCAL_UI",
+      "governed_requires": [
+        "production_interlock_runtime_activated"
+      ]
+    }
+  ]
+}

--- a/tests/test_kv_activation_readiness.py
+++ b/tests/test_kv_activation_readiness.py
@@ -1,0 +1,62 @@
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "kv_activation_readiness",
+    ROOT / "scripts" / "evaluate_kv_activation_readiness.py",
+)
+module = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(module)
+
+
+def test_current_snapshot_is_fail_closed_and_non_authorizing():
+    snapshot = module.evaluate()
+    assert snapshot["entry_count"] == 46
+    assert snapshot["module_count"] == 13
+    assert snapshot["service_count"] == 33
+    assert snapshot["baseline_intr_complete"] is True
+    assert snapshot["production_interlock_runtime_activated"] is False
+    assert snapshot["activation_performed"] is False
+    assert snapshot["authority_effect"] == "NONE"
+    assert snapshot["summary"] == {
+        "local_ready": 45,
+        "local_blocked": 1,
+        "governed_ready": 0,
+        "governed_blocked": 46,
+    }
+    assert all(e["install_state"] == "INSTALLED_INACTIVE" for e in snapshot["entries"])
+    assert all(e["activation_performed"] is False for e in snapshot["entries"])
+    assert all(e["authority_effect"] == "NONE" for e in snapshot["entries"])
+    assert all(e["governed_action_readiness"] == "BLOCKED" for e in snapshot["entries"])
+
+
+def test_stegid_remains_locally_blocked_until_current_receipt_exists():
+    snapshot = module.evaluate()
+    stegid = next(e for e in snapshot["entries"] if e["entry_id"] == "stegid-continuity")
+    assert stegid["local_materialization"] == "BLOCKED_CURRENT_IDENTITY"
+    assert "current_identity_continuity_receipt_observed" in stegid["governed_blockers"]
+
+
+def test_local_services_can_be_materializable_without_governed_authority():
+    snapshot = module.evaluate()
+    journal = next(e for e in snapshot["entries"] if e["entry_id"] == "personal-journal")
+    assert journal["local_materialization"] == "READY_FOR_LOCAL_MATERIALIZATION"
+    assert journal["governed_action_readiness"] == "BLOCKED"
+    assert "production_interlock_runtime_activated" in journal["governed_blockers"]
+
+
+def test_stegfin_preserves_full_production_tvc_blockers():
+    snapshot = module.evaluate()
+    stegfin = next(e for e in snapshot["entries"] if e["entry_id"] == "stegfin-wallet-pay")
+    required = {
+        "production_interlock_runtime_activated",
+        "tvc_resident_key_liveness_observed",
+        "ready_for_owner_ingress_observed",
+        "production_gateway_route_observed",
+        "production_double_interlock_receipts_observed",
+        "provider_session_evidence_observed",
+    }
+    assert required.issubset(set(stegfin["governed_blockers"]))


### PR DESCRIPTION
Closes #59. Adds current activation-readiness facts, module policy, snapshot schema, deterministic evaluator/tests, a 46-entry current snapshot, and connected-KV `_System/Readiness` projection/readback. The evaluator separates local materialization from governed-action readiness and is incapable of activating services/modules. Current result: 45 locally ready, 1 locally blocked (`stegid-continuity`), 0 governed-ready, 46 governed-blocked while production Interlock remains inactive. Baseline InTr RC-01..RC-05 is preserved as complete; TVC resident production activation remains separately owned.