### PR TITLE
Admit TVC Interlock/InTr readiness evidence into KV facts

### DIFF
--- a/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
+++ b/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
@@ -1,8 +1,11 @@
 # KnowledgeVault Activation Readiness Mirror Handoff
 
-Status: CONNECTED_KV_READINESS_CONTROL_PLANE_ACTIVE
+Status: CONNECTED_KV_READINESS_CONTROL_PLANE_MERGED
 Repository: StegVerse-Labs/continuity-vault-kit
 Issue: #59
+Merged PR: #60
+Merge: a749c8b844b11299004990610a1b5506b2eb3ed8
+CI: KV Guardrails 33022950257 SUCCESS; Repository validation 33022950268 SUCCESS; Security Baseline 33022950263 SUCCESS
 Updated: 2026-08-26
 
 ## Purpose
@@ -158,16 +161,16 @@ No external side effect is created.
 ## Completion gates
 
 ```text
-readiness facts: COMPLETE_ON_BRANCH
-module activation policy: COMPLETE_ON_BRANCH
-snapshot schema: COMPLETE_ON_BRANCH
-fail-closed evaluator: COMPLETE_ON_BRANCH
-tests: COMPLETE_ON_BRANCH
-current 46-entry snapshot: COMPLETE_ON_BRANCH
+readiness facts: COMPLETE_MERGED
+module activation policy: COMPLETE_MERGED
+snapshot schema: COMPLETE_MERGED
+fail-closed evaluator: COMPLETE_MERGED
+tests: COMPLETE_MERGED
+current 46-entry snapshot: COMPLETE_MERGED
 connected KV Readiness surface: COMPLETE
 connected snapshot projection: COMPLETE
 connected readback: PASS
-CI: PENDING
-merge: PENDING
+CI: PASS
+merge: COMPLETE
 activation: NOT PERFORMED
 ```

--- a/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
+++ b/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
@@ -42,6 +42,7 @@ TVC resident recipient-key liveness observed: false
 READY_FOR_OWNER_INGRESS observed: false
 production Gateway route observed: false
 production double-Interlock receipts observed: false
+SKAP Vault runtime boundary observed: false
 provider session evidence observed: false
 current identity-continuity receipt observed: false
 governance runtime admission observed: false
@@ -108,7 +109,7 @@ Snapshot projection:
 
 Drive file:
 
-`1ZmaI21dpCpDGZ_g6pbZNsE-Bn87S_8km6ehcHa3lRc4`
+`1xn5eD2NSgB9n9AKIHxP_ggp81cipa-U666bMUdIWgwQ`
 
 Direct Drive readback verified:
 
@@ -174,3 +175,72 @@ CI: PASS
 merge: COMPLETE
 activation: NOT PERFORMED
 ```
+
+
+## TVC runtime evidence admission — issue #61
+
+Canonical TVC evidence producers already exist in `StegVerse-Labs/TVC`:
+
+- `scripts/observe_coinbase_intr_resident_readiness.py`
+  - schema `stegverse.tvc.coinbase_intr_resident_readiness/v3`;
+- `scripts/observe_skap_vault_runtime_boundary.py`
+  - schema `stegverse.tvc.skap_vault_runtime_boundary_observation/v1`.
+
+KnowledgeVault now has a bounded adapter on the #61 branch:
+
+- `scripts/admit_tvc_readiness_evidence.py`;
+- `schemas/kv-tvc-readiness-evidence-admission.schema.json`;
+- `tests/test_admit_tvc_readiness_evidence.py`.
+
+The adapter may emit only the following evidence-derived facts:
+
+```text
+tvc_resident_key_liveness_observed
+ready_for_owner_ingress_observed
+production_gateway_route_observed
+production_double_interlock_receipts_observed
+skap_vault_runtime_boundary_observed
+```
+
+It explicitly may not set:
+
+```text
+production_interlock_runtime_activated
+provider_session_evidence_observed
+module/service activation
+provider-operation authority
+execution authority
+```
+
+The broader production-Interlock fact remains owned by the appropriate cross-module/runtime admission, not by one Coinbase-specific TVC observation.
+
+Evidence fails closed if any of the following are violated:
+
+```text
+credential_authority != TV/TVC
+credential_custody_target mismatch
+transport_protocol != InTr
+authority_transfer != false
+provider_operation_authorized != false
+provider_operation_started != false
+credential_plaintext_observed != false
+SKAP storage connector != KV_SKAP_INTR_ONLY
+KV decryption authority != false
+execution_authority != NONE
+secret/private-key/plaintext-bearing material present
+```
+
+A legitimate blocked TVC observation is admissible as evidence but produces false readiness facts. A ready observation advances only the exact booleans it proves.
+
+Current connected-KV snapshot remains fail-closed:
+
+```text
+local_ready=45
+local_blocked=1
+governed_ready=0
+governed_blocked=46
+activation_performed=false
+authority_effect=NONE
+```
+
+StegFin now additionally requires `skap_vault_runtime_boundary_observed=true` before governed readiness can ever be considered.

--- a/evidence/kv/2026-08-26-activation-readiness-snapshot.json
+++ b/evidence/kv/2026-08-26-activation-readiness-snapshot.json
@@ -85,6 +85,7 @@
       "governed_action_readiness": "BLOCKED",
       "governed_blockers": [
         "production_interlock_runtime_activated",
+        "skap_vault_runtime_boundary_observed",
         "tvc_resident_key_liveness_observed",
         "ready_for_owner_ingress_observed",
         "production_gateway_route_observed",

--- a/schemas/kv-tvc-readiness-evidence-admission.schema.json
+++ b/schemas/kv-tvc-readiness-evidence-admission.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-tvc-readiness-evidence-admission.schema.json",
+  "title": "KnowledgeVault TVC readiness evidence admission",
+  "type": "object",
+  "required": [
+    "schema",
+    "decision",
+    "facts_delta",
+    "production_interlock_runtime_activated_set_by_adapter",
+    "provider_session_evidence_set_by_adapter",
+    "activation_performed",
+    "provider_operation_authorized",
+    "execution_authority",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema": {
+      "const": "stegverse.kv.tvc-readiness-evidence-admission/v1"
+    },
+    "decision": {
+      "const": "ADMIT_FACTS_DELTA"
+    },
+    "resident_state": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "boundary_state": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "facts_delta": {
+      "type": "object",
+      "required": [
+        "tvc_resident_key_liveness_observed",
+        "ready_for_owner_ingress_observed",
+        "production_gateway_route_observed",
+        "production_double_interlock_receipts_observed",
+        "skap_vault_runtime_boundary_observed"
+      ],
+      "properties": {
+        "tvc_resident_key_liveness_observed": {
+          "type": "boolean"
+        },
+        "ready_for_owner_ingress_observed": {
+          "type": "boolean"
+        },
+        "production_gateway_route_observed": {
+          "type": "boolean"
+        },
+        "production_double_interlock_receipts_observed": {
+          "type": "boolean"
+        },
+        "skap_vault_runtime_boundary_observed": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "production_interlock_runtime_activated_set_by_adapter": {
+      "const": false
+    },
+    "provider_session_evidence_set_by_adapter": {
+      "const": false
+    },
+    "activation_performed": {
+      "const": false
+    },
+    "provider_operation_authorized": {
+      "const": false
+    },
+    "execution_authority": {
+      "const": "NONE"
+    },
+    "authority_effect": {
+      "const": "NONE"
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/admit_tvc_readiness_evidence.py
+++ b/scripts/admit_tvc_readiness_evidence.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Admit canonical TVC runtime-readiness evidence into KV readiness facts.
+
+This adapter is evidence-only. It never activates a module/service and never
+grants provider, execution, identity, governance, or credential authority.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+RESIDENT_SCHEMA = "stegverse.tvc.coinbase_intr_resident_readiness/v3"
+BOUNDARY_SCHEMA = "stegverse.tvc.skap_vault_runtime_boundary_observation/v1"
+ADMISSION_SCHEMA = "stegverse.kv.tvc-readiness-evidence-admission/v1"
+
+FORBIDDEN_KEYS = {
+    "private_key",
+    "recipient_private_key",
+    "credential_plaintext",
+    "credential_value",
+    "api_secret",
+    "secret",
+    "access_token",
+    "authorization",
+    "bearer_token",
+    "jwt",
+}
+FORBIDDEN_STRING_MARKERS = (
+    "-----BEGIN PRIVATE KEY-----",
+    "-----BEGIN EC PRIVATE KEY-----",
+    "Authorization: Bearer ",
+)
+
+
+class AdmissionError(ValueError):
+    pass
+
+
+def _walk_for_secrets(value: Any, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in FORBIDDEN_KEYS:
+                raise AdmissionError(f"forbidden secret-bearing key at {path}.{key}")
+            _walk_for_secrets(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _walk_for_secrets(child, f"{path}[{index}]")
+    elif isinstance(value, str):
+        if any(marker in value for marker in FORBIDDEN_STRING_MARKERS):
+            raise AdmissionError(f"forbidden secret-bearing string at {path}")
+
+
+def _require_resident_authority_boundary(resident: dict[str, Any]) -> None:
+    if resident.get("schema") != RESIDENT_SCHEMA:
+        raise AdmissionError("unexpected resident readiness schema")
+    if resident.get("credential_authority") != "TV/TVC":
+        raise AdmissionError("credential authority mismatch")
+    if resident.get("credential_custody_target") != "SKAP_VAULT":
+        raise AdmissionError("credential custody target mismatch")
+    if resident.get("transport_protocol") != "InTr":
+        raise AdmissionError("transport protocol mismatch")
+    if resident.get("authority_transfer") is not False:
+        raise AdmissionError("authority transfer must be false")
+    if resident.get("provider_operation_authorized") is not False:
+        raise AdmissionError("provider operation authority must be false")
+    if resident.get("provider_operation_started") is not False:
+        raise AdmissionError("provider operation must not be started")
+    if resident.get("credential_plaintext_observed") is not False:
+        raise AdmissionError("credential plaintext must not be observed")
+
+
+def _require_boundary_authority_boundary(boundary: dict[str, Any]) -> None:
+    if boundary.get("schema") != BOUNDARY_SCHEMA:
+        raise AdmissionError("unexpected SKAP Vault boundary schema")
+    if boundary.get("credential_authority") != "TV/TVC":
+        raise AdmissionError("SKAP boundary credential authority mismatch")
+    if boundary.get("credential_custody_target") != "KV_HOSTED_SKAP_VAULT":
+        raise AdmissionError("SKAP boundary custody target mismatch")
+    if boundary.get("storage_connector") != "KV_SKAP_INTR_ONLY":
+        raise AdmissionError("SKAP boundary storage connector mismatch")
+    if boundary.get("device_durable_secret_custody") is not False:
+        raise AdmissionError("device durable secret custody must be false")
+    if boundary.get("kv_decryption_authority") is not False:
+        raise AdmissionError("KV decryption authority must be false")
+    if boundary.get("provider_operation_authorized") is not False:
+        raise AdmissionError("SKAP boundary provider authority must be false")
+    if boundary.get("execution_authority") != "NONE":
+        raise AdmissionError("SKAP boundary execution authority must be NONE")
+    if boundary.get("authority_transfer") is not False:
+        raise AdmissionError("SKAP boundary authority transfer must be false")
+
+
+def admit(
+    resident: dict[str, Any],
+    boundary: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(resident, dict):
+        raise AdmissionError("resident readiness object required")
+    if boundary is not None and not isinstance(boundary, dict):
+        raise AdmissionError("boundary observation must be an object")
+
+    _walk_for_secrets(resident)
+    if boundary is not None:
+        _walk_for_secrets(boundary)
+
+    _require_resident_authority_boundary(resident)
+    if boundary is not None:
+        _require_boundary_authority_boundary(boundary)
+
+    ready = resident.get("ready_for_owner_ingress") is True
+    liveness = (
+        ready
+        and resident.get("private_key_liveness_verified") is True
+        and resident.get("public_projection_verified") is True
+        and resident.get("successor_service_installed") is True
+        and resident.get("browser_ingress_service_installed") is True
+        and resident.get("browser_ingress_health_verified") is True
+    )
+    double_interlock = (
+        resident.get("double_interlock_receipt_chain_observed") is True
+        and resident.get("device_kv_receipt_observed") is True
+        and resident.get("kv_skap_receipt_observed") is True
+        and bool(resident.get("device_kv_receipt_hash"))
+        and bool(resident.get("kv_skap_receipt_hash"))
+        and bool(resident.get("double_interlock_chain_digest"))
+    )
+    skap_boundary_ready = bool(
+        boundary is not None
+        and boundary.get("ready_for_skap_vault_ingress") is True
+        and boundary.get("state") == "READY_FOR_SKAP_VAULT_INGRESS"
+    )
+    gateway_route = resident.get("public_intr_route_verified") is True
+
+    facts_delta = {
+        "tvc_resident_key_liveness_observed": liveness,
+        "ready_for_owner_ingress_observed": ready,
+        "production_gateway_route_observed": gateway_route,
+        "production_double_interlock_receipts_observed": double_interlock,
+        "skap_vault_runtime_boundary_observed": skap_boundary_ready,
+    }
+
+    return {
+        "schema": ADMISSION_SCHEMA,
+        "decision": "ADMIT_FACTS_DELTA",
+        "resident_state": resident.get("state"),
+        "boundary_state": None if boundary is None else boundary.get("state"),
+        "facts_delta": facts_delta,
+        "production_interlock_runtime_activated_set_by_adapter": False,
+        "provider_session_evidence_set_by_adapter": False,
+        "activation_performed": False,
+        "provider_operation_authorized": False,
+        "execution_authority": "NONE",
+        "authority_effect": "NONE",
+    }
+
+
+def main() -> int:
+    raise SystemExit(
+        "library adapter only; call admit() from a governed evidence-ingestion path"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/kv-activation-readiness-facts.v1.json
+++ b/specs/kv-activation-readiness-facts.v1.json
@@ -12,5 +12,6 @@
   "current_identity_continuity_receipt_observed": false,
   "governance_runtime_admission_observed": false,
   "device_context_runtime_specific": true,
-  "authority_effect": "NONE"
+  "authority_effect": "NONE",
+  "skap_vault_runtime_boundary_observed": false
 }

--- a/specs/kv-module-activation-policy.v1.json
+++ b/specs/kv-module-activation-policy.v1.json
@@ -43,6 +43,7 @@
       "local_materialization": "READY_FOR_LOCAL_UI",
       "governed_requires": [
         "production_interlock_runtime_activated",
+        "skap_vault_runtime_boundary_observed",
         "tvc_resident_key_liveness_observed",
         "ready_for_owner_ingress_observed",
         "production_gateway_route_observed",

--- a/tests/test_admit_tvc_readiness_evidence.py
+++ b/tests/test_admit_tvc_readiness_evidence.py
@@ -1,0 +1,122 @@
+import importlib.util
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "tvc_readiness_admission",
+    ROOT / "scripts" / "admit_tvc_readiness_evidence.py",
+)
+module = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(module)
+
+
+def resident_base(**overrides):
+    value = {
+        "schema": "stegverse.tvc.coinbase_intr_resident_readiness/v3",
+        "state": "BLOCKED_RECIPIENT_KEY_NOT_PROVISIONED",
+        "ready_for_owner_ingress": False,
+        "provider_operation_authorized": False,
+        "provider_operation_started": False,
+        "credential_plaintext_observed": False,
+        "credential_authority": "TV/TVC",
+        "credential_custody_target": "SKAP_VAULT",
+        "transport_protocol": "InTr",
+        "authority_transfer": False,
+    }
+    value.update(overrides)
+    return value
+
+
+def boundary_ready(**overrides):
+    value = {
+        "schema": "stegverse.tvc.skap_vault_runtime_boundary_observation/v1",
+        "state": "READY_FOR_SKAP_VAULT_INGRESS",
+        "ready_for_skap_vault_ingress": True,
+        "credential_authority": "TV/TVC",
+        "credential_custody_target": "KV_HOSTED_SKAP_VAULT",
+        "storage_connector": "KV_SKAP_INTR_ONLY",
+        "device_durable_secret_custody": False,
+        "kv_decryption_authority": False,
+        "provider_operation_authorized": False,
+        "execution_authority": "NONE",
+        "authority_transfer": False,
+    }
+    value.update(overrides)
+    return value
+
+
+def test_blocked_observation_is_admitted_as_false_facts_only():
+    result = module.admit(resident_base())
+    assert result["decision"] == "ADMIT_FACTS_DELTA"
+    assert all(value is False for value in result["facts_delta"].values())
+    assert result["activation_performed"] is False
+    assert result["authority_effect"] == "NONE"
+
+
+def test_ready_owner_ingress_advances_only_proven_liveness_facts():
+    resident = resident_base(
+        state="READY_FOR_OWNER_INGRESS",
+        ready_for_owner_ingress=True,
+        private_key_liveness_verified=True,
+        public_projection_verified=True,
+        successor_service_installed=True,
+        browser_ingress_service_installed=True,
+        browser_ingress_health_verified=True,
+        public_intr_route_verified=False,
+        double_interlock_receipt_chain_observed=False,
+        device_kv_receipt_observed=False,
+        kv_skap_receipt_observed=False,
+    )
+    result = module.admit(resident)
+    facts = result["facts_delta"]
+    assert facts["tvc_resident_key_liveness_observed"] is True
+    assert facts["ready_for_owner_ingress_observed"] is True
+    assert facts["production_gateway_route_observed"] is False
+    assert facts["production_double_interlock_receipts_observed"] is False
+    assert facts["skap_vault_runtime_boundary_observed"] is False
+    assert result["production_interlock_runtime_activated_set_by_adapter"] is False
+
+
+def test_ready_double_interlock_plus_boundary_advances_exact_runtime_facts():
+    resident = resident_base(
+        state="READY_WITH_DOUBLE_INTERLOCK_RECEIPTS",
+        ready_for_owner_ingress=True,
+        private_key_liveness_verified=True,
+        public_projection_verified=True,
+        successor_service_installed=True,
+        browser_ingress_service_installed=True,
+        browser_ingress_health_verified=True,
+        public_intr_route_verified=True,
+        double_interlock_receipt_chain_observed=True,
+        device_kv_receipt_observed=True,
+        kv_skap_receipt_observed=True,
+        device_kv_receipt_hash="sha256:first",
+        kv_skap_receipt_hash="sha256:second",
+        double_interlock_chain_digest="sha256:chain",
+    )
+    result = module.admit(resident, boundary_ready())
+    assert result["facts_delta"] == {
+        "tvc_resident_key_liveness_observed": True,
+        "ready_for_owner_ingress_observed": True,
+        "production_gateway_route_observed": True,
+        "production_double_interlock_receipts_observed": True,
+        "skap_vault_runtime_boundary_observed": True,
+    }
+    assert result["provider_session_evidence_set_by_adapter"] is False
+    assert result["activation_performed"] is False
+
+
+def test_authority_escalation_is_rejected():
+    with pytest.raises(module.AdmissionError):
+        module.admit(resident_base(provider_operation_authorized=True))
+    with pytest.raises(module.AdmissionError):
+        module.admit(resident_base(), boundary_ready(execution_authority="ALLOW"))
+
+
+def test_secret_bearing_evidence_is_rejected():
+    with pytest.raises(module.AdmissionError):
+        module.admit(resident_base(recipient_private_key="-----BEGIN PRIVATE KEY-----abc"))
+    with pytest.raises(module.AdmissionError):
+        module.admit(resident_base(credential_plaintext_observed=True))


### PR DESCRIPTION
Closes #61. Adds a fail-closed adapter from the canonical TVC resident-readiness and SKAP Vault boundary observation schemas into KnowledgeVault readiness facts. It rejects secret-bearing evidence, authority transfer, provider/execution authority, plaintext observation, invalid custody/transport/storage boundaries, and never activates modules/services. It may advance only exact proven TVC/SKAP readiness booleans; it explicitly cannot set the broader production Interlock fact or provider-session evidence. StegFin now also requires SKAP Vault runtime-boundary observation. The current connected KV snapshot was refreshed and remains 45 local-ready / 1 local-blocked / 0 governed-ready / 46 governed-blocked.