### PR TITLE
Issue #56: add KV provider/access-surface capability registry

### DIFF
--- a/.github/workflows/provider-surface-capability-registry.yml
+++ b/.github/workflows/provider-surface-capability-registry.yml
@@ -1,0 +1,38 @@
+name: KV Provider Surface Capability Registry
+
+on:
+  pull_request:
+    paths:
+      - "schemas/kv-provider-surface-capability-registry.schema.json"
+      - "specs/kv-provider-surface-capability-registry.v1.json"
+      - "tools/check_provider_surface_capability_registry.py"
+      - "tests/test_provider_surface_capability_registry.py"
+      - "KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md"
+      - ".github/workflows/provider-surface-capability-registry.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "schemas/kv-provider-surface-capability-registry.schema.json"
+      - "specs/kv-provider-surface-capability-registry.v1.json"
+      - "tools/check_provider_surface_capability_registry.py"
+      - "tests/test_provider_surface_capability_registry.py"
+      - "KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md"
+      - ".github/workflows/provider-surface-capability-registry.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Compile validator and tests
+        run: python3 -m compileall -q tools/check_provider_surface_capability_registry.py tests/test_provider_surface_capability_registry.py
+      - name: Validate canonical provider/surface registry
+        run: python3 tools/check_provider_surface_capability_registry.py
+      - name: Run provider/surface registry tests
+        run: python3 -m unittest tests.test_provider_surface_capability_registry

--- a/KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md
+++ b/KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md
@@ -1,0 +1,59 @@
+# KV Provider / Access-Surface Capability Registry Mirror Handoff
+
+Repository: `StegVerse-Labs/continuity-vault-kit`  
+Issue: #56  
+State: IMPLEMENTED_ON_BRANCH_UNVERIFIED_FACT_SET  
+Authority effect: NONE
+
+## Purpose
+
+Provide one canonical, provider-neutral registry that describes KnowledgeVault access behavior by:
+
+`provider × device × platform × access surface × browser/runtime`
+
+This extends the existing device-backed capability model. It does not replace it.
+
+## Canonical files
+
+- `specs/kv-provider-surface-capability-registry.v1.json`
+- `schemas/kv-provider-surface-capability-registry.schema.json`
+- `tools/check_provider_surface_capability_registry.py`
+
+## Current implementation state
+
+The schema, empty canonical registry, and fail-closed validator are installed on branch `feat/provider-surface-capability-56`.
+
+The initial registry deliberately contains no provider capability claims. Provider families are enumerated, but observations remain empty until evidence is gathered. This prevents provider marketing text or model memory from becoming a verified capability claim.
+
+## Required observation dimensions
+
+- provider
+- device class
+- optional device model/capability profile
+- platform / OS
+- platform version when relevant
+- access surface
+- browser name / engine / version where applicable
+- capability values
+- limitations
+- preferred route
+- fallback route
+- provenance and observation/version date
+
+## Downstream contract
+
+`StegVerse-org/LLM-adapter#140` consumes this registry for Ecosystem Chat public-knowledge resolution.
+
+`StegVerse-Labs/Site#239` projects resolved facts into My KV, My Node / StegOS, and progressive troubleshooting UI.
+
+Downstream consumers must not create independent provider-fact registries.
+
+## Validation rule
+
+A `VERIFIED` observation must carry a non-unknown evidence type, source reference, observation date, and version. Missing evidence fails closed.
+
+## Boundary
+
+This registry describes access-path capabilities only. It grants no provider access, credential authority, KV-content inspection authority, execution authority, or activation effect.
+
+Private user-authored vault contents remain outside repository automation scope.

--- a/schemas/kv-provider-surface-capability-registry.schema.json
+++ b/schemas/kv-provider-surface-capability-registry.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-provider-surface-capability-registry.schema.json",
+  "title": "KnowledgeVault provider/access-surface capability registry",
+  "type": "object",
+  "required": ["schema","state","authority_effect","provider_families","observations"],
+  "properties": {
+    "schema": {"const":"stegverse.kv.provider-surface-capability-registry/v1"},
+    "state": {"enum":["INSTALLED_UNVERIFIED","PARTIALLY_VERIFIED","VERIFIED"]},
+    "authority_effect": {"const":"NONE"},
+    "provider_families": {
+      "type":"array","minItems":1,"uniqueItems":true,
+      "items":{"enum":["icloud","google_drive","microsoft_onedrive","aws_object_storage","self_hosted_private_cloud","stegcloud"]}
+    },
+    "observations": {
+      "type":"array",
+      "items":{
+        "type":"object",
+        "required":["provider","device_class","platform","access_surface","knowledge_state","capabilities","preferred_route","fallback_route","evidence"],
+        "properties":{
+          "provider":{"type":"string","minLength":1},
+          "device_class":{"type":"string","minLength":1},
+          "device_model_profile":{"type":["string","null"]},
+          "platform":{"type":"string","minLength":1},
+          "platform_version":{"type":["string","null"]},
+          "access_surface":{"enum":["native_provider_app","os_file_provider","browser","direct_api","sync_client","self_hosted_endpoint","stegverse_native"]},
+          "browser":{"type":["object","null"],"properties":{"name":{"type":"string"},"engine":{"type":"string"},"version":{"type":["string","null"]}},"additionalProperties":false},
+          "knowledge_state":{"enum":["UNKNOWN","DOCUMENTED","OBSERVED","VERIFIED","CONTRADICTED"]},
+          "capabilities":{
+            "type":"object",
+            "required":["read","write","background_sync","offline_access","local_cache","atomic_update","conflict_handling","folder_creation","metadata_fidelity","change_notifications","direct_api","native_file_provider","authentication_persistence","resumable_upload","file_size_limits","latency_performance","recovery_export"],
+            "additionalProperties":false,
+            "properties":{
+              "read":{"$ref":"#/$defs/capability"},
+              "write":{"$ref":"#/$defs/capability"},
+              "background_sync":{"$ref":"#/$defs/capability"},
+              "offline_access":{"$ref":"#/$defs/capability"},
+              "local_cache":{"$ref":"#/$defs/capability"},
+              "atomic_update":{"$ref":"#/$defs/capability"},
+              "conflict_handling":{"$ref":"#/$defs/capability"},
+              "folder_creation":{"$ref":"#/$defs/capability"},
+              "metadata_fidelity":{"$ref":"#/$defs/capability"},
+              "change_notifications":{"$ref":"#/$defs/capability"},
+              "direct_api":{"$ref":"#/$defs/capability"},
+              "native_file_provider":{"$ref":"#/$defs/capability"},
+              "authentication_persistence":{"$ref":"#/$defs/capability"},
+              "resumable_upload":{"$ref":"#/$defs/capability"},
+              "file_size_limits":{"$ref":"#/$defs/capability"},
+              "latency_performance":{"$ref":"#/$defs/capability"},
+              "recovery_export":{"$ref":"#/$defs/capability"}
+            }
+          },
+          "preferred_route":{"type":["string","null"]},
+          "fallback_route":{"type":["string","null"]},
+          "limitations":{"type":"array","items":{"type":"string"}},
+          "evidence":{
+            "type":"object",
+            "required":["source_type","source_ref","observed_at","version"],
+            "properties":{
+              "source_type":{"enum":["provider_documentation","stegverse_observation","conformance_test","unknown"]},
+              "source_ref":{"type":["string","null"]},
+              "observed_at":{"type":["string","null"]},
+              "version":{"type":"string","minLength":1}
+            },
+            "additionalProperties":false
+          }
+        },
+        "additionalProperties":false
+      }
+    }
+  },
+  "$defs":{
+    "capability":{"enum":["YES","NO","PARTIAL","UNKNOWN","NOT_APPLICABLE"]}
+  },
+  "additionalProperties":false
+}

--- a/specs/kv-provider-surface-capability-registry.v1.json
+++ b/specs/kv-provider-surface-capability-registry.v1.json
@@ -1,0 +1,14 @@
+{
+  "schema": "stegverse.kv.provider-surface-capability-registry/v1",
+  "state": "INSTALLED_UNVERIFIED",
+  "authority_effect": "NONE",
+  "provider_families": [
+    "icloud",
+    "google_drive",
+    "microsoft_onedrive",
+    "aws_object_storage",
+    "self_hosted_private_cloud",
+    "stegcloud"
+  ],
+  "observations": []
+}

--- a/tests/test_provider_surface_capability_registry.py
+++ b/tests/test_provider_surface_capability_registry.py
@@ -1,0 +1,24 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "specs" / "kv-provider-surface-capability-registry.v1.json"
+CHECKER = ROOT / "tools" / "check_provider_surface_capability_registry.py"
+
+class ProviderSurfaceCapabilityRegistryTests(unittest.TestCase):
+    def test_canonical_registry_passes(self):
+        run = subprocess.run([sys.executable, str(CHECKER)], cwd=ROOT, text=True, capture_output=True)
+        self.assertEqual(run.returncode, 0, run.stdout + run.stderr)
+        self.assertIn("KV_PROVIDER_SURFACE_CAPABILITY_REGISTRY=PASS", run.stdout)
+
+    def test_initial_registry_is_fact_fail_closed(self):
+        data = json.loads(REGISTRY.read_text())
+        self.assertEqual(data["state"], "INSTALLED_UNVERIFIED")
+        self.assertEqual(data["authority_effect"], "NONE")
+        self.assertEqual(data["observations"], [])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_provider_surface_capability_registry.py
+++ b/tools/check_provider_surface_capability_registry.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "specs" / "kv-provider-surface-capability-registry.v1.json"
+
+PROVIDERS = {
+    "icloud","google_drive","microsoft_onedrive","aws_object_storage",
+    "self_hosted_private_cloud","stegcloud"
+}
+CAPABILITIES = {
+    "read","write","background_sync","offline_access","local_cache","atomic_update",
+    "conflict_handling","folder_creation","metadata_fidelity","change_notifications",
+    "direct_api","native_file_provider","authentication_persistence","resumable_upload",
+    "file_size_limits","latency_performance","recovery_export"
+}
+CAPABILITY_VALUES = {"YES","NO","PARTIAL","UNKNOWN","NOT_APPLICABLE"}
+KNOWLEDGE_STATES = {"UNKNOWN","DOCUMENTED","OBSERVED","VERIFIED","CONTRADICTED"}
+
+def fail(msg):
+    print(f"KV_PROVIDER_SURFACE_CAPABILITY_REGISTRY=FAIL: {msg}")
+    raise SystemExit(1)
+
+def main():
+    data = json.loads(REGISTRY.read_text())
+    if data.get("schema") != "stegverse.kv.provider-surface-capability-registry/v1":
+        fail("schema")
+    if data.get("authority_effect") != "NONE":
+        fail("authority_effect")
+    if set(data.get("provider_families", [])) != PROVIDERS:
+        fail("provider_families")
+    observations = data.get("observations")
+    if not isinstance(observations, list):
+        fail("observations")
+    for i, obs in enumerate(observations):
+        for key in ("provider","device_class","platform","access_surface","knowledge_state","capabilities","preferred_route","fallback_route","evidence"):
+            if key not in obs:
+                fail(f"observation[{i}].{key}")
+        if obs["knowledge_state"] not in KNOWLEDGE_STATES:
+            fail(f"observation[{i}].knowledge_state")
+        caps = obs["capabilities"]
+        if set(caps) != CAPABILITIES:
+            fail(f"observation[{i}].capabilities")
+        if any(v not in CAPABILITY_VALUES for v in caps.values()):
+            fail(f"observation[{i}].capability_value")
+        ev = obs["evidence"]
+        if not isinstance(ev, dict) or not ev.get("version"):
+            fail(f"observation[{i}].evidence")
+        if obs["knowledge_state"] == "VERIFIED":
+            if ev.get("source_type") in (None, "unknown") or not ev.get("source_ref") or not ev.get("observed_at"):
+                fail(f"observation[{i}].verified_without_evidence")
+    print("KV_PROVIDER_SURFACE_CAPABILITY_REGISTRY=PASS")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements the first bounded machine-executable slice for #56.

Includes:
- provider/access-surface capability schema;
- canonical registry enumerating provider families with no unsupported capability claims;
- fail-closed validator;
- unit tests;
- dedicated GitHub Actions validation;
- mirror handoff documenting downstream Site/Ecosystem Chat consumption.

Important boundary:
- observations are intentionally empty;
- no provider capability is claimed VERIFIED without evidence;
- no private KV content is read or mutated;
- authority_effect remains NONE.

This extends, rather than duplicates, the existing device-backed capability registry.