### PR TITLE
Issue #56: populate first provider-documented surface facts

### DIFF
--- a/KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md
+++ b/KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md
@@ -2,7 +2,7 @@
 
 Repository: `StegVerse-Labs/continuity-vault-kit`  
 Issue: #56  
-State: IMPLEMENTED_VALIDATED_MERGED / FACT_POPULATION_OPEN  
+State: IMPLEMENTED_VALIDATED_MERGED / DOCUMENTED_FACT_POPULATION_ON_BRANCH  
 Authority effect: NONE
 
 ## Purpose
@@ -36,9 +36,21 @@ Exact-head validation:
 
 ## Current fact state
 
-The canonical registry is intentionally `INSTALLED_UNVERIFIED` with an empty `observations` list.
+The canonical registry foundation is merged. On branch `feat/provider-surface-documented-facts-56`, the first provider-documentation fact set is populated with state `DOCUMENTED_UNVERIFIED`.
 
-Provider families are enumerated, but no concrete provider/browser/device capability claim is admitted until evidence is gathered. This prevents provider marketing text, generic model memory, or undocumented assumptions from becoming verified capability facts.
+Eight observations are represented across:
+- iCloud Files on iPhone / iOS;
+- iCloud Files on iPad / iPadOS;
+- Google Drive native app on iPhone;
+- Google Drive native app on iPad;
+- Google Drive desktop browser offline posture for Chrome/Edge;
+- OneDrive native app on iPhone;
+- OneDrive native app on iPad;
+- OneDrive Files On-Demand / sync-client posture on Windows.
+
+Every observation is `DOCUMENTED`, not `VERIFIED`. Unsupported capability fields remain `UNKNOWN`; no preferred route or fallback route is inferred where provider documentation does not establish one.
+
+Provider-documentation evidence references are retained directly in each observation. The top-level state `DOCUMENTED_UNVERIFIED` is deliberately distinct from `PARTIALLY_VERIFIED` so documentation evidence cannot be mistaken for StegVerse conformance proof.
 
 ## Required observation dimensions
 
@@ -69,11 +81,11 @@ A `VERIFIED` observation must carry a non-unknown evidence type, source referenc
 
 ## Remaining work
 
-1. Gather provider-documentation and StegVerse-observation evidence for iCloud, Google Drive, OneDrive, AWS/object-storage, self-hosted/private cloud, and future StegCloud.
-2. Populate device/platform/access-surface observations without overgeneralizing across device classes.
-3. Add negative tests proving unsupported VERIFIED claims fail closed.
-4. Feed the canonical registry into LLM-adapter#140.
-5. Project resolved provider-route explanations into Site#239.
+1. Validate and merge the first eight provider-documentation observations.
+2. Continue provider-documentation population for AWS/object storage, self-hosted/private cloud, and future StegCloud only when authoritative public sources exist.
+3. Add StegVerse-observed/conformance-tested records separately; documentation evidence alone never becomes `VERIFIED`.
+4. Merge and release the LLM-adapter#140 canonical-registry consumer.
+5. Project resolved provider-route explanations into Site#239 after Site machine admission.
 6. Keep actual user-specific route selection separate from generic provider capability facts.
 
 ## Boundary
@@ -81,3 +93,17 @@ A `VERIFIED` observation must carry a non-unknown evidence type, source referenc
 This registry describes access-path capabilities only. It grants no provider access, credential authority, KV-content inspection authority, execution authority, or activation effect.
 
 Private user-authored vault contents remain outside repository automation scope.
+
+## Documented-fact evidence semantics
+
+The validator now enforces:
+
+- `DOCUMENTED` requires provider-documentation source type, source reference, and observation date;
+- `OBSERVED` requires StegVerse observation or conformance-test evidence;
+- `VERIFIED` requires evidence and may not be inferred from documentation alone;
+- `INSTALLED_UNVERIFIED` cannot contain observations;
+- `DOCUMENTED_UNVERIFIED` cannot contain verified observations;
+- `PARTIALLY_VERIFIED` requires at least one actually verified observation;
+- `VERIFIED` requires every observation to be verified.
+
+Negative tests exercise documented-without-evidence and partially-verified-without-verified-observation failures.

--- a/schemas/kv-provider-surface-capability-registry.schema.json
+++ b/schemas/kv-provider-surface-capability-registry.schema.json
@@ -6,7 +6,7 @@
   "required": ["schema","state","authority_effect","provider_families","observations"],
   "properties": {
     "schema": {"const":"stegverse.kv.provider-surface-capability-registry/v1"},
-    "state": {"enum":["INSTALLED_UNVERIFIED","PARTIALLY_VERIFIED","VERIFIED"]},
+    "state": {"enum":["INSTALLED_UNVERIFIED","DOCUMENTED_UNVERIFIED","PARTIALLY_VERIFIED","VERIFIED"]},
     "authority_effect": {"const":"NONE"},
     "provider_families": {
       "type":"array","minItems":1,"uniqueItems":true,

--- a/specs/kv-provider-surface-capability-registry.v1.json
+++ b/specs/kv-provider-surface-capability-registry.v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "stegverse.kv.provider-surface-capability-registry/v1",
-  "state": "INSTALLED_UNVERIFIED",
+  "state": "PARTIALLY_VERIFIED",
   "authority_effect": "NONE",
   "provider_families": [
     "icloud",
@@ -10,5 +10,330 @@
     "self_hosted_private_cloud",
     "stegcloud"
   ],
-  "observations": []
+  "observations": [
+    {
+      "provider": "icloud",
+      "device_class": "iphone",
+      "device_model_profile": null,
+      "platform": "ios",
+      "platform_version": "26",
+      "access_surface": "os_file_provider",
+      "browser": null,
+      "knowledge_state": "DOCUMENTED",
+      "capabilities": {
+        "read": "YES",
+        "write": "YES",
+        "background_sync": "UNKNOWN",
+        "offline_access": "YES",
+        "local_cache": "YES",
+        "atomic_update": "UNKNOWN",
+        "conflict_handling": "UNKNOWN",
+        "folder_creation": "UNKNOWN",
+        "metadata_fidelity": "UNKNOWN",
+        "change_notifications": "UNKNOWN",
+        "direct_api": "UNKNOWN",
+        "native_file_provider": "YES",
+        "authentication_persistence": "UNKNOWN",
+        "resumable_upload": "UNKNOWN",
+        "file_size_limits": "UNKNOWN",
+        "latency_performance": "UNKNOWN",
+        "recovery_export": "UNKNOWN"
+      },
+      "preferred_route": null,
+      "fallback_route": null,
+      "limitations": [
+        "Offline access depends on keeping the selected file downloaded; offline changes synchronize after connectivity returns."
+      ],
+      "evidence": {
+        "source_type": "provider_documentation",
+        "source_ref": "https://support.apple.com/en-kg/guide/iphone/iphe9aff429a/ios",
+        "observed_at": "2026-08-26",
+        "version": "apple-support-2026-08-26"
+      }
+    },
+    {
+      "provider": "icloud",
+      "device_class": "ipad",
+      "device_model_profile": null,
+      "platform": "ipados",
+      "platform_version": "26",
+      "access_surface": "os_file_provider",
+      "browser": null,
+      "knowledge_state": "DOCUMENTED",
+      "capabilities": {
+        "read": "YES",
+        "write": "YES",
+        "background_sync": "UNKNOWN",
+        "offline_access": "YES",
+        "local_cache": "YES",
+        "atomic_update": "UNKNOWN",
+        "conflict_handling": "UNKNOWN",
+        "folder_creation": "UNKNOWN",
+        "metadata_fidelity": "UNKNOWN",
+        "change_notifications": "UNKNOWN",
+        "direct_api": "UNKNOWN",
+        "native_file_provider": "YES",
+        "authentication_persistence": "UNKNOWN",
+        "resumable_upload": "UNKNOWN",
+        "file_size_limits": "UNKNOWN",
+        "latency_performance": "UNKNOWN",
+        "recovery_export": "UNKNOWN"
+      },
+      "preferred_route": null,
+      "fallback_route": null,
+      "limitations": [
+        "Files/iCloud Drive is the documented native file surface; selected files can be kept downloaded for offline use."
+      ],
+      "evidence": {
+        "source_type": "provider_documentation",
+        "source_ref": "https://support.apple.com/en-ae/102570",
+        "observed_at": "2026-08-26",
+        "version": "apple-support-2026-04-02"
+      }
+    },
+    {
+      "provider": "google_drive",
+      "device_class": "iphone",
+      "device_model_profile": null,
+      "platform": "ios",
+      "platform_version": null,
+      "access_surface": "native_provider_app",
+      "browser": null,
+      "knowledge_state": "DOCUMENTED",
+      "capabilities": {
+        "read": "YES",
+        "write": "PARTIAL",
+        "background_sync": "UNKNOWN",
+        "offline_access": "YES",
+        "local_cache": "YES",
+        "atomic_update": "UNKNOWN",
+        "conflict_handling": "UNKNOWN",
+        "folder_creation": "UNKNOWN",
+        "metadata_fidelity": "UNKNOWN",
+        "change_notifications": "UNKNOWN",
+        "direct_api": "UNKNOWN",
+        "native_file_provider": "UNKNOWN",
+        "authentication_persistence": "UNKNOWN",
+        "resumable_upload": "UNKNOWN",
+        "file_size_limits": "UNKNOWN",
+        "latency_performance": "UNKNOWN",
+        "recovery_export": "UNKNOWN"
+      },
+      "preferred_route": null,
+      "fallback_route": null,
+      "limitations": [
+        "Offline preview requires marking a file Available offline; editing Docs, Sheets, or Slides offline uses the corresponding Google editor app."
+      ],
+      "evidence": {
+        "source_type": "provider_documentation",
+        "source_ref": "https://support.google.com/drive/answer/2375012?co=GENIE.Platform%3DiOS&hl=en",
+        "observed_at": "2026-08-26",
+        "version": "google-drive-help-2026-08-26"
+      }
+    },
+    {
+      "provider": "google_drive",
+      "device_class": "ipad",
+      "device_model_profile": null,
+      "platform": "ipados",
+      "platform_version": null,
+      "access_surface": "native_provider_app",
+      "browser": null,
+      "knowledge_state": "DOCUMENTED",
+      "capabilities": {
+        "read": "YES",
+        "write": "PARTIAL",
+        "background_sync": "UNKNOWN",
+        "offline_access": "YES",
+        "local_cache": "YES",
+        "atomic_update": "UNKNOWN",
+        "conflict_handling": "UNKNOWN",
+        "folder_creation": "UNKNOWN",
+        "metadata_fidelity": "UNKNOWN",
+        "change_notifications": "UNKNOWN",
+        "direct_api": "UNKNOWN",
+        "native_file_provider": "UNKNOWN",
+        "authentication_persistence": "UNKNOWN",
+        "resumable_upload": "UNKNOWN",
+        "file_size_limits": "UNKNOWN",
+        "latency_performance": "UNKNOWN",
+        "recovery_export": "UNKNOWN"
+      },
+      "preferred_route": null,
+      "fallback_route": null,
+      "limitations": [
+        "Offline preview requires marking a file Available offline; editing Docs, Sheets, or Slides offline uses the corresponding Google editor app."
+      ],
+      "evidence": {
+        "source_type": "provider_documentation",
+        "source_ref": "https://support.google.com/drive/answer/2375012?co=GENIE.Platform%3DiOS&hl=en",
+        "observed_at": "2026-08-26",
+        "version": "google-drive-help-2026-08-26"
+      }
+    },
+    {
+      "provider": "google_drive",
+      "device_class": "desktop_or_laptop",
+      "device_model_profile": null,
+      "platform": "desktop",
+      "platform_version": null,
+      "access_surface": "browser",
+      "browser": {
+        "name": "Chrome_or_Edge",
+        "engine": "Chromium",
+        "version": null
+      },
+      "knowledge_state": "DOCUMENTED",
+      "capabilities": {
+        "read": "YES",
+        "write": "YES",
+        "background_sync": "UNKNOWN",
+        "offline_access": "PARTIAL",
+        "local_cache": "PARTIAL",
+        "atomic_update": "UNKNOWN",
+        "conflict_handling": "UNKNOWN",
+        "folder_creation": "UNKNOWN",
+        "metadata_fidelity": "UNKNOWN",
+        "change_notifications": "UNKNOWN",
+        "direct_api": "UNKNOWN",
+        "native_file_provider": "UNKNOWN",
+        "authentication_persistence": "UNKNOWN",
+        "resumable_upload": "UNKNOWN",
+        "file_size_limits": "UNKNOWN",
+        "latency_performance": "UNKNOWN",
+        "recovery_export": "UNKNOWN"
+      },
+      "preferred_route": null,
+      "fallback_route": null,
+      "limitations": [
+        "Documented browser offline mode is limited to Chrome or Microsoft Edge, requires the Google Docs Offline extension, cannot use private browsing, and applies to supported Google Docs/Sheets/Slides workflows rather than arbitrary Drive objects."
+      ],
+      "evidence": {
+        "source_type": "provider_documentation",
+        "source_ref": "https://support.google.com/a/users/answer/13005112?hl=en",
+        "observed_at": "2026-08-26",
+        "version": "google-workspace-help-2026-08-26"
+      }
+    },
+    {
+      "provider": "microsoft_onedrive",
+      "device_class": "iphone",
+      "device_model_profile": null,
+      "platform": "ios",
+      "platform_version": null,
+      "access_surface": "native_provider_app",
+      "browser": null,
+      "knowledge_state": "DOCUMENTED",
+      "capabilities": {
+        "read": "YES",
+        "write": "PARTIAL",
+        "background_sync": "UNKNOWN",
+        "offline_access": "YES",
+        "local_cache": "YES",
+        "atomic_update": "UNKNOWN",
+        "conflict_handling": "UNKNOWN",
+        "folder_creation": "UNKNOWN",
+        "metadata_fidelity": "UNKNOWN",
+        "change_notifications": "UNKNOWN",
+        "direct_api": "UNKNOWN",
+        "native_file_provider": "UNKNOWN",
+        "authentication_persistence": "UNKNOWN",
+        "resumable_upload": "UNKNOWN",
+        "file_size_limits": "UNKNOWN",
+        "latency_performance": "UNKNOWN",
+        "recovery_export": "UNKNOWN"
+      },
+      "preferred_route": null,
+      "fallback_route": null,
+      "limitations": [
+        "Files or folders must be marked offline; offline edits to Office files occur in associated Office apps and synchronize after reconnection; offline folders require eligible Microsoft 365/Premium capability."
+      ],
+      "evidence": {
+        "source_type": "provider_documentation",
+        "source_ref": "https://support.microsoft.com/en-US/onedrive/read-files-or-folders-offline-in-onedrive-for-ios",
+        "observed_at": "2026-08-26",
+        "version": "microsoft-support-2026-08-26"
+      }
+    },
+    {
+      "provider": "microsoft_onedrive",
+      "device_class": "ipad",
+      "device_model_profile": null,
+      "platform": "ipados",
+      "platform_version": null,
+      "access_surface": "native_provider_app",
+      "browser": null,
+      "knowledge_state": "DOCUMENTED",
+      "capabilities": {
+        "read": "YES",
+        "write": "PARTIAL",
+        "background_sync": "UNKNOWN",
+        "offline_access": "YES",
+        "local_cache": "YES",
+        "atomic_update": "UNKNOWN",
+        "conflict_handling": "UNKNOWN",
+        "folder_creation": "UNKNOWN",
+        "metadata_fidelity": "UNKNOWN",
+        "change_notifications": "UNKNOWN",
+        "direct_api": "UNKNOWN",
+        "native_file_provider": "UNKNOWN",
+        "authentication_persistence": "UNKNOWN",
+        "resumable_upload": "UNKNOWN",
+        "file_size_limits": "UNKNOWN",
+        "latency_performance": "UNKNOWN",
+        "recovery_export": "UNKNOWN"
+      },
+      "preferred_route": null,
+      "fallback_route": null,
+      "limitations": [
+        "Files or folders must be marked offline; offline edits to Office files occur in associated Office apps and synchronize after reconnection; offline folders require eligible Microsoft 365/Premium capability."
+      ],
+      "evidence": {
+        "source_type": "provider_documentation",
+        "source_ref": "https://support.microsoft.com/en-US/onedrive/read-files-or-folders-offline-in-onedrive-for-ios",
+        "observed_at": "2026-08-26",
+        "version": "microsoft-support-2026-08-26"
+      }
+    },
+    {
+      "provider": "microsoft_onedrive",
+      "device_class": "windows_pc",
+      "device_model_profile": null,
+      "platform": "windows",
+      "platform_version": "10_22H2_or_11",
+      "access_surface": "sync_client",
+      "browser": null,
+      "knowledge_state": "DOCUMENTED",
+      "capabilities": {
+        "read": "YES",
+        "write": "YES",
+        "background_sync": "PARTIAL",
+        "offline_access": "PARTIAL",
+        "local_cache": "YES",
+        "atomic_update": "UNKNOWN",
+        "conflict_handling": "UNKNOWN",
+        "folder_creation": "UNKNOWN",
+        "metadata_fidelity": "UNKNOWN",
+        "change_notifications": "UNKNOWN",
+        "direct_api": "UNKNOWN",
+        "native_file_provider": "UNKNOWN",
+        "authentication_persistence": "UNKNOWN",
+        "resumable_upload": "UNKNOWN",
+        "file_size_limits": "UNKNOWN",
+        "latency_performance": "UNKNOWN",
+        "recovery_export": "UNKNOWN"
+      },
+      "preferred_route": null,
+      "fallback_route": null,
+      "limitations": [
+        "Online-only files cannot be opened without internet access; locally available or Always keep on this device files can be opened offline."
+      ],
+      "evidence": {
+        "source_type": "provider_documentation",
+        "source_ref": "https://support.microsoft.com/en-US/onedrive/save-disk-space-with-onedrive-files-on-demand-for-windows",
+        "observed_at": "2026-08-26",
+        "version": "microsoft-support-2026-08-26"
+      }
+    }
+  ]
 }

--- a/specs/kv-provider-surface-capability-registry.v1.json
+++ b/specs/kv-provider-surface-capability-registry.v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "stegverse.kv.provider-surface-capability-registry/v1",
-  "state": "PARTIALLY_VERIFIED",
+  "state": "DOCUMENTED_UNVERIFIED",
   "authority_effect": "NONE",
   "provider_families": [
     "icloud",

--- a/tests/test_provider_surface_capability_registry.py
+++ b/tests/test_provider_surface_capability_registry.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -14,11 +15,34 @@ class ProviderSurfaceCapabilityRegistryTests(unittest.TestCase):
         self.assertEqual(run.returncode, 0, run.stdout + run.stderr)
         self.assertIn("KV_PROVIDER_SURFACE_CAPABILITY_REGISTRY=PASS", run.stdout)
 
-    def test_initial_registry_is_fact_fail_closed(self):
+    def test_documented_registry_is_still_unverified(self):
         data = json.loads(REGISTRY.read_text())
-        self.assertEqual(data["state"], "INSTALLED_UNVERIFIED")
+        self.assertEqual(data["state"], "DOCUMENTED_UNVERIFIED")
         self.assertEqual(data["authority_effect"], "NONE")
-        self.assertEqual(data["observations"], [])
+        self.assertEqual(len(data["observations"]), 8)
+        self.assertTrue(all(item["knowledge_state"] == "DOCUMENTED" for item in data["observations"]))
+        self.assertTrue(all(item["evidence"]["source_type"] == "provider_documentation" for item in data["observations"]))
+        self.assertFalse(any(item["knowledge_state"] == "VERIFIED" for item in data["observations"]))
+
+    def test_documented_claim_without_provider_evidence_fails_closed(self):
+        data = json.loads(REGISTRY.read_text())
+        data["observations"][0]["evidence"]["source_type"] = "unknown"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.json"
+            path.write_text(json.dumps(data), encoding="utf-8")
+            run = subprocess.run([sys.executable, str(CHECKER), str(path)], cwd=ROOT, text=True, capture_output=True)
+        self.assertEqual(run.returncode, 1)
+        self.assertIn("documented_without_provider_evidence", run.stdout)
+
+    def test_partially_verified_state_requires_verified_observation(self):
+        data = json.loads(REGISTRY.read_text())
+        data["state"] = "PARTIALLY_VERIFIED"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad-state.json"
+            path.write_text(json.dumps(data), encoding="utf-8")
+            run = subprocess.run([sys.executable, str(CHECKER), str(path)], cwd=ROOT, text=True, capture_output=True)
+        self.assertEqual(run.returncode, 1)
+        self.assertIn("partially_verified_without_verified_observation", run.stdout)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/check_provider_surface_capability_registry.py
+++ b/tools/check_provider_surface_capability_registry.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-REGISTRY = ROOT / "specs" / "kv-provider-surface-capability-registry.v1.json"
+DEFAULT_REGISTRY = ROOT / "specs" / "kv-provider-surface-capability-registry.v1.json"
 
 PROVIDERS = {
     "icloud","google_drive","microsoft_onedrive","aws_object_storage",
@@ -18,17 +18,22 @@ CAPABILITIES = {
 }
 CAPABILITY_VALUES = {"YES","NO","PARTIAL","UNKNOWN","NOT_APPLICABLE"}
 KNOWLEDGE_STATES = {"UNKNOWN","DOCUMENTED","OBSERVED","VERIFIED","CONTRADICTED"}
+REGISTRY_STATES = {"INSTALLED_UNVERIFIED","DOCUMENTED_UNVERIFIED","PARTIALLY_VERIFIED","VERIFIED"}
+SOURCE_TYPES = {"provider_documentation","stegverse_observation","conformance_test","unknown"}
 
 def fail(msg):
     print(f"KV_PROVIDER_SURFACE_CAPABILITY_REGISTRY=FAIL: {msg}")
     raise SystemExit(1)
 
 def main():
-    data = json.loads(REGISTRY.read_text())
+    registry = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_REGISTRY
+    data = json.loads(registry.read_text())
     if data.get("schema") != "stegverse.kv.provider-surface-capability-registry/v1":
         fail("schema")
     if data.get("authority_effect") != "NONE":
         fail("authority_effect")
+    if data.get("state") not in REGISTRY_STATES:
+        fail("state")
     if set(data.get("provider_families", [])) != PROVIDERS:
         fail("provider_families")
     observations = data.get("observations")
@@ -48,6 +53,14 @@ def main():
         ev = obs["evidence"]
         if not isinstance(ev, dict) or not ev.get("version"):
             fail(f"observation[{i}].evidence")
+        if ev.get("source_type") not in SOURCE_TYPES:
+            fail(f"observation[{i}].source_type")
+        if obs["knowledge_state"] == "DOCUMENTED":
+            if ev.get("source_type") != "provider_documentation" or not ev.get("source_ref") or not ev.get("observed_at"):
+                fail(f"observation[{i}].documented_without_provider_evidence")
+        if obs["knowledge_state"] == "OBSERVED":
+            if ev.get("source_type") not in {"stegverse_observation","conformance_test"} or not ev.get("source_ref") or not ev.get("observed_at"):
+                fail(f"observation[{i}].observed_without_stegverse_evidence")
         if obs["knowledge_state"] == "VERIFIED":
             if ev.get("source_type") in (None, "unknown") or not ev.get("source_ref") or not ev.get("observed_at"):
                 fail(f"observation[{i}].verified_without_evidence")

--- a/tools/check_provider_surface_capability_registry.py
+++ b/tools/check_provider_surface_capability_registry.py
@@ -64,6 +64,16 @@ def main():
         if obs["knowledge_state"] == "VERIFIED":
             if ev.get("source_type") in (None, "unknown") or not ev.get("source_ref") or not ev.get("observed_at"):
                 fail(f"observation[{i}].verified_without_evidence")
+    verified_count = sum(1 for obs in observations if obs.get("knowledge_state") == "VERIFIED")
+    state = data.get("state")
+    if state == "INSTALLED_UNVERIFIED" and observations:
+        fail("installed_unverified_with_observations")
+    if state == "DOCUMENTED_UNVERIFIED" and verified_count:
+        fail("documented_unverified_contains_verified_observation")
+    if state == "PARTIALLY_VERIFIED" and verified_count == 0:
+        fail("partially_verified_without_verified_observation")
+    if state == "VERIFIED" and (not observations or verified_count != len(observations)):
+        fail("verified_registry_contains_nonverified_observation")
     print("KV_PROVIDER_SURFACE_CAPABILITY_REGISTRY=PASS")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Advances the fact-population phase of #56 without upgrading documentation claims into verification.

Adds eight provider-documented observations across iCloud, Google Drive, and OneDrive, separated by device/platform/access surface.

Key evidence semantics:
- top-level state = DOCUMENTED_UNVERIFIED
- every current observation = DOCUMENTED
- unsupported capability fields remain UNKNOWN
- preferred/fallback routes remain null unless established
- DOCUMENTED requires provider-documentation provenance
- PARTIALLY_VERIFIED now requires at least one actual VERIFIED observation
- negative tests fail closed on unsupported state/evidence claims

No private KV content is read or mutated. No provider, credential, execution, or activation authority is created.