### PR TITLE
Admit Universal Interlock adoption readiness into KV

### DIFF
--- a/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
+++ b/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
@@ -46,6 +46,9 @@ SKAP Vault runtime boundary observed: false
 provider session evidence observed: false
 current identity-continuity receipt observed: false
 governance runtime admission observed: false
+Universal Interlock adoption review ready: false
+Universal Interlock adoption review state: BLOCKED
+Universal Interlock blockers: AUTHENTIC_RUNTIME_BINDING_MISSING; MASTER_RECORDS_CUSTODY_RECEIPT_MISSING; MASTER_RECORDS_RECONSTRUCTION_NOT_VERIFIED
 authority_effect: NONE
 ```
 
@@ -109,7 +112,7 @@ Snapshot projection:
 
 Drive file:
 
-`1xn5eD2NSgB9n9AKIHxP_ggp81cipa-U666bMUdIWgwQ`
+`1F-kXN_KaPZpTzP1RpK7QzpeAs46IOFq7MWIZD9-s_M4`
 
 Direct Drive readback verified:
 
@@ -267,3 +270,61 @@ output schema: stegos.kv_capability_shell_projection.v1
 ```
 
 StegOS validates the 46-entry KV snapshot and separates local-ready, local-blocked, and governed-action states. It has no KV mutation or activation surface. KV readiness therefore propagates to the device shell without transferring authority.
+
+
+## Universal Interlock adoption-readiness admission — issue #74
+
+StegOS now owns a separate non-authorizing adoption-eligibility assessment for
+`SV-INTERLOCK-v0.4-candidate`:
+
+`stegos.universal_interlock_adoption_readiness.v1`
+
+KnowledgeVault issue #74 adds a bounded explanatory adapter:
+
+- `scripts/admit_interlock_adoption_readiness.py`;
+- `tests/test_interlock_adoption_readiness_admission.py`.
+
+It may set only:
+
+```text
+universal_interlock_adoption_review_ready
+universal_interlock_adoption_review_state
+universal_interlock_adoption_review_blockers
+```
+
+It explicitly cannot set:
+
+```text
+production_interlock_runtime_activated
+canonical protocol adoption
+module/service activation
+provider/session evidence
+authority
+```
+
+Current admitted state:
+
+```text
+universal_interlock_adoption_review_ready=false
+universal_interlock_adoption_review_state=BLOCKED
+blockers:
+  AUTHENTIC_RUNTIME_BINDING_MISSING
+  MASTER_RECORDS_CUSTODY_RECEIPT_MISSING
+  MASTER_RECORDS_RECONSTRUCTION_NOT_VERIFIED
+production_interlock_runtime_activated=false
+```
+
+The connected readiness projection was replaced and directly read back at:
+
+`/KnowledgeVault/_System/Readiness/activation-readiness-snapshot`
+
+Drive file:
+
+`1F-kXN_KaPZpTzP1RpK7QzpeAs46IOFq7MWIZD9-s_M4`
+
+The prior snapshot file was deleted after successful readback so the connected
+Readiness surface retains one current projection.
+
+This does not reduce the Universal Interlock runtime/adoption gates. It gives the
+device shell a machine-readable explanation for why all governed controls remain
+disabled.

--- a/evidence/kv/2026-08-26-activation-readiness-snapshot.json
+++ b/evidence/kv/2026-08-26-activation-readiness-snapshot.json
@@ -1,6 +1,6 @@
 {
   "schema": "stegverse.kv.activation-readiness-snapshot/v1",
-  "facts_observed_at": "2026-08-26T23:16:00Z",
+  "facts_observed_at": "2026-08-27T04:08:00Z",
   "entry_count": 46,
   "module_count": 13,
   "service_count": 33,
@@ -636,5 +636,17 @@
       "activation_performed": false,
       "authority_effect": "NONE"
     }
-  ]
+  ],
+  "interlock_adoption_review": {
+    "ready": false,
+    "state": "BLOCKED",
+    "blockers": [
+      "AUTHENTIC_RUNTIME_BINDING_MISSING",
+      "MASTER_RECORDS_CUSTODY_RECEIPT_MISSING",
+      "MASTER_RECORDS_RECONSTRUCTION_NOT_VERIFIED"
+    ],
+    "canonical_protocol_adopted": false,
+    "runtime_activation": false,
+    "authority_effect": "NONE"
+  }
 }

--- a/schemas/kv-interlock-adoption-readiness-admission.schema.json
+++ b/schemas/kv-interlock-adoption-readiness-admission.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-interlock-adoption-readiness-admission.schema.json",
+  "title": "KnowledgeVault Universal Interlock Adoption Readiness Admission",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "protocol_id",
+    "decision",
+    "facts_delta",
+    "production_interlock_runtime_activated_set_by_adapter",
+    "canonical_protocol_adopted_set_by_adapter",
+    "activation_performed",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema": {
+      "const": "stegverse.kv.interlock-adoption-readiness-admission/v1"
+    },
+    "protocol_id": {
+      "const": "SV-INTERLOCK-v0.4-candidate"
+    },
+    "decision": {
+      "const": "ADMIT_EXPLANATORY_FACTS"
+    },
+    "facts_delta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "universal_interlock_adoption_review_ready",
+        "universal_interlock_adoption_review_state",
+        "universal_interlock_adoption_review_blockers"
+      ],
+      "properties": {
+        "universal_interlock_adoption_review_ready": {
+          "type": "boolean"
+        },
+        "universal_interlock_adoption_review_state": {
+          "enum": [
+            "BLOCKED",
+            "READY_FOR_ADOPTION_REVIEW"
+          ]
+        },
+        "universal_interlock_adoption_review_blockers": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "production_interlock_runtime_activated_set_by_adapter": {
+      "const": false
+    },
+    "canonical_protocol_adopted_set_by_adapter": {
+      "const": false
+    },
+    "activation_performed": {
+      "const": false
+    },
+    "authority_effect": {
+      "const": "NONE"
+    }
+  }
+}

--- a/scripts/admit_interlock_adoption_readiness.py
+++ b/scripts/admit_interlock_adoption_readiness.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Admit StegOS Universal Interlock adoption-readiness as explanatory KV facts."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+SOURCE_SCHEMA = "stegos.universal_interlock_adoption_readiness.v1"
+ADMISSION_SCHEMA = "stegverse.kv.interlock-adoption-readiness-admission/v1"
+PROTOCOL_ID = "SV-INTERLOCK-v0.4-candidate"
+
+
+class AdmissionError(ValueError):
+    pass
+
+
+def admit_interlock_adoption_readiness(
+    assessment: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(assessment, Mapping):
+        raise AdmissionError("Interlock adoption-readiness assessment object required")
+    if assessment.get("schema") != SOURCE_SCHEMA:
+        raise AdmissionError("unexpected Interlock adoption-readiness schema")
+    if assessment.get("protocol_id") != PROTOCOL_ID:
+        raise AdmissionError("Interlock protocol id mismatch")
+    state = assessment.get("state")
+    blockers = assessment.get("blockers")
+    if state not in {"BLOCKED", "READY_FOR_ADOPTION_REVIEW"}:
+        raise AdmissionError("invalid Interlock adoption-readiness state")
+    if not isinstance(blockers, list) or any(
+        not isinstance(item, str) or not item for item in blockers
+    ):
+        raise AdmissionError("Interlock adoption-readiness blockers invalid")
+    if state == "BLOCKED" and not blockers:
+        raise AdmissionError("blocked Interlock assessment must expose blockers")
+    if state == "READY_FOR_ADOPTION_REVIEW" and blockers:
+        raise AdmissionError("ready Interlock assessment cannot retain blockers")
+
+    forbidden_true = (
+        "canonical_protocol_adopted",
+        "runtime_activation",
+        "production_interlock_runtime_activated",
+        "adoption_decision_created",
+        "execute_consequence",
+        "canonical_result_committed",
+    )
+    for field in forbidden_true:
+        if assessment.get(field) is not False:
+            raise AdmissionError(f"{field} must remain false")
+
+    if assessment.get("credential_authority") != "TV/TVC":
+        raise AdmissionError("credential authority must remain TV/TVC")
+    if assessment.get("master_records_authority_effect") != "NONE":
+        raise AdmissionError("Master Records authority effect must remain NONE")
+    if assessment.get("authority_effect") != "NONE":
+        raise AdmissionError("Interlock adoption-readiness authority effect must remain NONE")
+
+    ready = state == "READY_FOR_ADOPTION_REVIEW"
+    return {
+        "schema": ADMISSION_SCHEMA,
+        "protocol_id": PROTOCOL_ID,
+        "decision": "ADMIT_EXPLANATORY_FACTS",
+        "facts_delta": {
+            "universal_interlock_adoption_review_ready": ready,
+            "universal_interlock_adoption_review_state": state,
+            "universal_interlock_adoption_review_blockers": list(blockers),
+        },
+        "production_interlock_runtime_activated_set_by_adapter": False,
+        "canonical_protocol_adopted_set_by_adapter": False,
+        "activation_performed": False,
+        "authority_effect": "NONE",
+    }

--- a/scripts/evaluate_kv_activation_readiness.py
+++ b/scripts/evaluate_kv_activation_readiness.py
@@ -71,6 +71,14 @@ def evaluate():
         "service_count":sum(1 for e in entries if e["entry_type"]=="SERVICE"),
         "baseline_intr_complete":facts["baseline_intr_rc01_rc05_complete"],
         "production_interlock_runtime_activated":facts["production_interlock_runtime_activated"],
+        "interlock_adoption_review":{
+            "ready":facts.get("universal_interlock_adoption_review_ready") is True,
+            "state":facts.get("universal_interlock_adoption_review_state","BLOCKED"),
+            "blockers":list(facts.get("universal_interlock_adoption_review_blockers",[])),
+            "canonical_protocol_adopted":False,
+            "runtime_activation":False,
+            "authority_effect":"NONE",
+        },
         "activation_performed":False,
         "authority_effect":"NONE",
         "summary":{

--- a/specs/kv-activation-readiness-facts.v1.json
+++ b/specs/kv-activation-readiness-facts.v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "stegverse.kv.activation-readiness-facts/v1",
-  "observed_at": "2026-08-26T23:16:00Z",
+  "observed_at": "2026-08-27T04:08:00Z",
   "baseline_intr_rc01_rc05_complete": true,
   "connected_kv_baseline_runtime_observed": true,
   "production_interlock_runtime_activated": false,
@@ -13,5 +13,12 @@
   "governance_runtime_admission_observed": false,
   "device_context_runtime_specific": true,
   "authority_effect": "NONE",
-  "skap_vault_runtime_boundary_observed": false
+  "skap_vault_runtime_boundary_observed": false,
+  "universal_interlock_adoption_review_ready": false,
+  "universal_interlock_adoption_review_state": "BLOCKED",
+  "universal_interlock_adoption_review_blockers": [
+    "AUTHENTIC_RUNTIME_BINDING_MISSING",
+    "MASTER_RECORDS_CUSTODY_RECEIPT_MISSING",
+    "MASTER_RECORDS_RECONSTRUCTION_NOT_VERIFIED"
+  ]
 }

--- a/tests/test_interlock_adoption_readiness_admission.py
+++ b/tests/test_interlock_adoption_readiness_admission.py
@@ -1,0 +1,111 @@
+import copy
+import importlib.util
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ADMIT_SPEC = importlib.util.spec_from_file_location(
+    "interlock_adoption_admission",
+    ROOT / "scripts" / "admit_interlock_adoption_readiness.py",
+)
+admit_module = importlib.util.module_from_spec(ADMIT_SPEC)
+assert ADMIT_SPEC.loader is not None
+ADMIT_SPEC.loader.exec_module(admit_module)
+
+EVAL_SPEC = importlib.util.spec_from_file_location(
+    "kv_activation_readiness",
+    ROOT / "scripts" / "evaluate_kv_activation_readiness.py",
+)
+eval_module = importlib.util.module_from_spec(EVAL_SPEC)
+assert EVAL_SPEC.loader is not None
+EVAL_SPEC.loader.exec_module(eval_module)
+
+
+def blocked_assessment():
+    return {
+        "schema": "stegos.universal_interlock_adoption_readiness.v1",
+        "protocol_id": "SV-INTERLOCK-v0.4-candidate",
+        "state": "BLOCKED",
+        "blockers": [
+            "AUTHENTIC_RUNTIME_BINDING_MISSING",
+            "MASTER_RECORDS_CUSTODY_RECEIPT_MISSING",
+            "MASTER_RECORDS_RECONSTRUCTION_NOT_VERIFIED",
+        ],
+        "runtime_binding_id": None,
+        "master_records_custody_receipt_id": None,
+        "runtime_conformance_evidenced": False,
+        "master_records_custody_evidenced": False,
+        "master_records_reconstruction_verified": False,
+        "canonical_protocol_adopted": False,
+        "runtime_activation": False,
+        "production_interlock_runtime_activated": False,
+        "adoption_decision_created": False,
+        "execute_consequence": False,
+        "canonical_result_committed": False,
+        "credential_authority": "TV/TVC",
+        "master_records_authority_effect": "NONE",
+        "authority_effect": "NONE",
+    }
+
+
+def test_blocked_interlock_assessment_admits_only_explanatory_facts():
+    result = admit_module.admit_interlock_adoption_readiness(blocked_assessment())
+    assert result["decision"] == "ADMIT_EXPLANATORY_FACTS"
+    assert result["facts_delta"]["universal_interlock_adoption_review_ready"] is False
+    assert result["facts_delta"]["universal_interlock_adoption_review_state"] == "BLOCKED"
+    assert result["facts_delta"]["universal_interlock_adoption_review_blockers"]
+    assert result["production_interlock_runtime_activated_set_by_adapter"] is False
+    assert result["canonical_protocol_adopted_set_by_adapter"] is False
+    assert result["activation_performed"] is False
+    assert result["authority_effect"] == "NONE"
+
+
+def test_ready_for_review_still_cannot_activate_interlock():
+    assessment = blocked_assessment()
+    assessment["state"] = "READY_FOR_ADOPTION_REVIEW"
+    assessment["blockers"] = []
+    assessment["runtime_binding_id"] = "runtime-binding-1"
+    assessment["master_records_custody_receipt_id"] = "custody-receipt-1"
+    assessment["runtime_conformance_evidenced"] = True
+    assessment["master_records_custody_evidenced"] = True
+    assessment["master_records_reconstruction_verified"] = True
+    result = admit_module.admit_interlock_adoption_readiness(assessment)
+    assert result["facts_delta"]["universal_interlock_adoption_review_ready"] is True
+    assert result["production_interlock_runtime_activated_set_by_adapter"] is False
+    assert result["canonical_protocol_adopted_set_by_adapter"] is False
+
+
+def test_adopted_or_active_source_claim_is_rejected():
+    assessment = blocked_assessment()
+    assessment["canonical_protocol_adopted"] = True
+    with pytest.raises(admit_module.AdmissionError):
+        admit_module.admit_interlock_adoption_readiness(assessment)
+
+    assessment = blocked_assessment()
+    assessment["runtime_activation"] = True
+    with pytest.raises(admit_module.AdmissionError):
+        admit_module.admit_interlock_adoption_readiness(assessment)
+
+    assessment = blocked_assessment()
+    assessment["production_interlock_runtime_activated"] = True
+    with pytest.raises(admit_module.AdmissionError):
+        admit_module.admit_interlock_adoption_readiness(assessment)
+
+
+def test_current_kv_snapshot_exposes_upstream_interlock_blockers_without_activation():
+    snapshot = eval_module.evaluate()
+    review = snapshot["interlock_adoption_review"]
+    assert review["ready"] is False
+    assert review["state"] == "BLOCKED"
+    assert set(review["blockers"]) == {
+        "AUTHENTIC_RUNTIME_BINDING_MISSING",
+        "MASTER_RECORDS_CUSTODY_RECEIPT_MISSING",
+        "MASTER_RECORDS_RECONSTRUCTION_NOT_VERIFIED",
+    }
+    assert review["canonical_protocol_adopted"] is False
+    assert review["runtime_activation"] is False
+    assert review["authority_effect"] == "NONE"
+    assert snapshot["production_interlock_runtime_activated"] is False
+    assert snapshot["summary"]["governed_ready"] == 0
+    assert snapshot["summary"]["governed_blocked"] == 46


### PR DESCRIPTION
Closes #74. Adds a bounded adapter/schema/tests that consume StegOS `stegos.universal_interlock_adoption_readiness.v1` only as explanatory KnowledgeVault facts. The adapter cannot set production Interlock activation, canonical protocol adoption, module/service activation, provider/session evidence, or authority. Current connected KV readiness remains 45 local-ready / 1 local-blocked / 0 governed-ready / 46 governed-blocked, and now exposes exact upstream blockers: authentic runtime binding missing, Master Records custody receipt missing, and custody reconstruction unverified.