### PR TITLE
Continue CMC-022/023 hosted authority retirement

### DIFF
--- a/.github/workflows/build-and-attach-release.yml
+++ b/.github/workflows/build-and-attach-release.yml
@@ -1,34 +1,56 @@
-name: Build and Attach Release Assets
+name: Published Release Source Reconstruction - Validation Only
 
 on:
   release:
     types: [published]
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
 
+jobs:
+  reconstruct:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Checkout repository without credential persistence
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
-      - name: Build release bundle
+      - name: Rebuild release bundle for comparison
         run: python3 tools/build_release.py
 
-      - name: Generate SHA256 checksum
+      - name: Generate local SHA256 reconstruction evidence
         run: sha256sum dist/*.zip > dist/KnowledgeVault_SHA256.txt
 
-      - name: Upload ZIP to release
-        uses: softprops/action-gh-release@v2
+      - name: Emit validation-only observation
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          observation = {
+              "schema": "stegverse.kv.published-release-reconstruction/v1",
+              "state": "SOURCE_RECONSTRUCTED_RELEASE_NOT_MUTATED",
+              "credential_authority": "TV/TVC",
+              "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+              "release_asset_mutation_performed": False,
+              "release_publication_performed": False,
+              "authority_effect": "NONE",
+          }
+          Path("dist/HOSTED_RELEASE_OBSERVATION.json").write_text(
+              json.dumps(observation, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload reconstruction evidence
+        uses: actions/upload-artifact@v4
         with:
-          files: |
-            dist/*.zip
-            dist/KnowledgeVault_SHA256.txt
-            dist/*.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: knowledgevault-published-release-reconstruction
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/kv-guardrails.yml
+++ b/.github/workflows/kv-guardrails.yml
@@ -51,7 +51,11 @@ jobs:
             tests/test_skap_crypto_boundary.py \
             tests/test_skap_crypto_lifecycle_runtime.py \
             tests/test_skap_tvc_key_provider.py \
-            tests/test_skap_owner_ingress.py
+            tests/test_skap_owner_ingress.py \
+            tests/test_hosted_release_authority_retirement.py
+
+      - name: Validate hosted release authority retirement
+        run: python3 -m unittest tests.test_hosted_release_authority_retirement -v
 
       - name: KV layer boundary + footer validation
         run: python3 tools/kv_layer_check.py --mode validate

--- a/.github/workflows/one_button_release.yml
+++ b/.github/workflows/one_button_release.yml
@@ -1,10 +1,10 @@
-name: One-Button Release (bump + tag + assets)
+name: Release Candidate Source Validation - No Publication Authority
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version number (e.g., 0.1.1) — tag becomes v0.1.1"
+        description: "Version number (e.g., 0.1.10)"
         required: true
       changelog_note:
         description: "Short changelog note (optional)"
@@ -15,159 +15,77 @@ on:
         required: false
         default: "KnowledgeVault Format"
       prerelease:
-        description: "Mark as prerelease? true/false"
+        description: "Candidate prerelease marker"
         required: true
         default: "false"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
+  validate_release_candidate:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout (full history for tags)
+      - name: Checkout source without credential persistence
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Set variables
-        id: vars
-        shell: bash
-        run: |
-          set -e
-          VER="${{ inputs.version }}"
-          TAG="v${VER}"
-
-          echo "ver=${VER}" >> $GITHUB_OUTPUT
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
-
-      - name: Configure git identity
-        shell: bash
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Update VERSION
-        shell: bash
-        run: |
-          echo "${{ steps.vars.outputs.ver }}" > VERSION
-          echo "VERSION now:"
-          cat VERSION
-
-      - name: Update CHANGELOG (optional)
-        shell: bash
-        run: |
-          set -e
-          NOTE="${{ inputs.changelog_note }}"
-          VER="${{ steps.vars.outputs.ver }}"
-          DATE="$(date -u +%Y-%m-%d)"
-
-          if [ -z "$NOTE" ]; then
-            echo "No changelog note provided — skipping CHANGELOG update."
-            exit 0
-          fi
-
-          if [ ! -f CHANGELOG.md ]; then
-            echo "# Changelog" > CHANGELOG.md
-            echo "" >> CHANGELOG.md
-          fi
-
-          # Prepend a simple entry to top of file (after first heading if present)
-          TMP="$(mktemp)"
-          if head -n 1 CHANGELOG.md | grep -qi "^#"; then
-            head -n 1 CHANGELOG.md > "$TMP"
-            echo "" >> "$TMP"
-            echo "## ${VER} — ${DATE}" >> "$TMP"
-            echo "- ${NOTE}" >> "$TMP"
-            echo "" >> "$TMP"
-            tail -n +2 CHANGELOG.md >> "$TMP"
-          else
-            echo "## ${VER} — ${DATE}" >> "$TMP"
-            echo "- ${NOTE}" >> "$TMP"
-            echo "" >> "$TMP"
-            cat CHANGELOG.md >> "$TMP"
-          fi
-
-          mv "$TMP" CHANGELOG.md
-          echo "Updated CHANGELOG.md:"
-          head -n 40 CHANGELOG.md
-
-      - name: Commit changes (if any)
-        shell: bash
-        run: |
-          set -e
-          git add VERSION CHANGELOG.md || true
-          if git diff --cached --quiet; then
-            echo "No changes to commit."
-          else
-            git commit -m "release: bump version to ${{ steps.vars.outputs.ver }}"
-            git push origin HEAD:main
-          fi
-
-      - name: Create and push tag
-        shell: bash
-        run: |
-          set -e
-          TAG="${{ steps.vars.outputs.tag }}"
-
-          # If tag exists, do not fail — just continue
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists — skipping tag creation."
-          else
-            git tag -a "$TAG" -m "Release $TAG"
-            git push origin "$TAG"
-          fi
-
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Build release artifacts (dist/)
+      - name: Prepare ephemeral candidate metadata
         shell: bash
         run: |
-          python3 -V
-          python3 tools/build_release.py
-          ls -la dist || true
-
-      - name: Locate assets
-        id: assets
-        shell: bash
-        run: |
-          set -e
-
-          ZIP="$(ls -1 dist/*.zip 2>/dev/null | head -n 1 || true)"
-          SHA="$(ls -1 dist/*.sha256 2>/dev/null | head -n 1 || true)"
-
-          # Accept common manifest naming patterns:
-          MANIFEST="$(ls -1 dist/*manifest*.json dist/*manifest*.txt dist/manifest.* 2>/dev/null | head -n 1 || true)"
-
-          if [ -z "$ZIP" ] || [ -z "$SHA" ]; then
-            echo "ERROR: dist/ missing required assets (.zip and .sha256)."
-            echo "Found ZIP='$ZIP' SHA='$SHA'"
-            exit 1
+          printf '%s\n' "${{ inputs.version }}" > VERSION
+          if [ -n "${{ inputs.changelog_note }}" ]; then
+            printf '\n## %s — candidate\n- %s\n' "${{ inputs.version }}" "${{ inputs.changelog_note }}" >> CHANGELOG.md
           fi
 
-          echo "zip=$ZIP" >> $GITHUB_OUTPUT
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
-          echo "manifest=$MANIFEST" >> $GITHUB_OUTPUT
+      - name: Build deterministic release candidate
+        run: python3 tools/build_release.py
 
-          echo "Found ZIP: $ZIP"
-          echo "Found SHA: $SHA"
-          echo "Found MANIFEST: ${MANIFEST:-<none>}"
+      - name: Validate required candidate assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$(ls -1 dist/*.zip 2>/dev/null | head -n 1)"
+          test -n "$(ls -1 dist/*.sha256 2>/dev/null | head -n 1)"
 
-      - name: Create/Update GitHub Release + upload assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.vars.outputs.tag }}
-          name: ${{ inputs.release_title }} ${{ steps.vars.outputs.tag }}
-          prerelease: ${{ inputs.prerelease }}
-          generate_release_notes: true
-          files: |
-            ${{ steps.assets.outputs.zip }}
-            ${{ steps.assets.outputs.sha }}
-            ${{ steps.assets.outputs.manifest }}
+      - name: Emit non-authorizing publication observation
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          observation = {
+              "schema": "stegverse.kv.hosted-release-observation/v1",
+              "state": "BLOCKED_DEPENDENCY",
+              "reason": "HOSTED_RELEASE_PUBLICATION_PROHIBITED_USE_TVC_ADMITTED_RELEASE_CAPABILITY",
+              "candidate_version": os.environ.get("INPUT_VERSION", ""),
+              "credential_authority": "TV/TVC",
+              "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+              "repository_mutation_performed": False,
+              "tag_mutation_performed": False,
+              "release_publication_performed": False,
+              "candidate_admitted": False,
+              "authority_effect": "NONE",
+          }
+          Path("dist/HOSTED_RELEASE_OBSERVATION.json").write_text(
+              json.dumps(observation, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+
+      - name: Upload non-secret candidate evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: knowledgevault-release-candidate-${{ inputs.version }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,18 +1,18 @@
-name: Build & Attach Release Assets
+name: Release Asset Build Validation - No Publication Authority
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g., v0.1.1)"
+        description: "Candidate release tag"
         required: true
-        default: "v0.1.1"
+        default: "v0.1.10"
       title:
-        description: "Release title"
+        description: "Candidate release title"
         required: true
         default: "KnowledgeVault Format"
       prerelease:
-        description: "Mark as prerelease? true/false"
+        description: "Candidate prerelease marker"
         required: true
         default: "false"
   push:
@@ -20,33 +20,16 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  build_and_release:
+  validate_release_assets:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
+      - name: Checkout source without credential persistence
         uses: actions/checkout@v4
-
-      - name: Set tag variables
-        id: vars
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
-            TITLE="${{ inputs.title }}"
-            PRERELEASE="${{ inputs.prerelease }}"
-          else
-            TAG="${GITHUB_REF_NAME}"
-            TITLE="KnowledgeVault Format ${TAG}"
-            PRERELEASE="false"
-          fi
-
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
-          echo "title=${TITLE}" >> $GITHUB_OUTPUT
-          echo "prerelease=${PRERELEASE}" >> $GITHUB_OUTPUT
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -54,45 +37,40 @@ jobs:
           python-version: "3.11"
 
       - name: Build release artifacts
+        run: python3 tools/build_release.py
+
+      - name: Validate release assets
         shell: bash
         run: |
-          python3 -V
-          python3 tools/build_release.py
-          ls -la dist || true
+          set -euo pipefail
+          test -n "$(ls -1 dist/*.zip 2>/dev/null | head -n 1)"
+          test -n "$(ls -1 dist/*.sha256 2>/dev/null | head -n 1)"
 
-      - name: Locate assets
-        id: assets
-        shell: bash
+      - name: Emit non-authorizing release observation
         run: |
-          set -e
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          observation = {
+              "schema": "stegverse.kv.hosted-release-observation/v1",
+              "state": "BLOCKED_DEPENDENCY",
+              "reason": "HOSTED_RELEASE_PUBLICATION_PROHIBITED_USE_TVC_ADMITTED_RELEASE_CAPABILITY",
+              "credential_authority": "TV/TVC",
+              "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+              "release_publication_performed": False,
+              "tag_mutation_performed": False,
+              "authority_effect": "NONE",
+          }
+          Path("dist/HOSTED_RELEASE_OBSERVATION.json").write_text(
+              json.dumps(observation, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
 
-          ZIP="$(ls -1 dist/*.zip | head -n 1)"
-          SHA="$(ls -1 dist/*.sha256 | head -n 1)"
-          MANIFEST="$(ls -1 dist/*manifest*.json dist/*manifest*.txt 2>/dev/null | head -n 1 || true)"
-
-          if [ -z "$ZIP" ] || [ -z "$SHA" ]; then
-            echo "dist/ is missing required assets (.zip and .sha256)."
-            exit 1
-          fi
-
-          echo "zip=$ZIP" >> $GITHUB_OUTPUT
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
-          echo "manifest=$MANIFEST" >> $GITHUB_OUTPUT
-
-          echo "Found ZIP: $ZIP"
-          echo "Found SHA: $SHA"
-          echo "Found MANIFEST: ${MANIFEST:-<none>}"
-
-      - name: Create or update GitHub Release + upload assets
-        uses: softprops/action-gh-release@v2
+      - name: Upload non-secret release build evidence
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ steps.vars.outputs.tag }}
-          name: ${{ steps.vars.outputs.title }}
-          prerelease: ${{ steps.vars.outputs.prerelease }}
-          generate_release_notes: true
-          files: |
-            ${{ steps.assets.outputs.zip }}
-            ${{ steps.assets.outputs.sha }}
-            ${{ steps.assets.outputs.manifest }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: knowledgevault-release-assets-validation
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-cycle-outcome.yml
+++ b/.github/workflows/release-cycle-outcome.yml
@@ -1,4 +1,4 @@
-name: Release cycle outcome
+name: Release cycle outcome - Validation Only
 
 on:
   workflow_run:
@@ -8,26 +8,25 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 concurrency:
-  group: release-cycle-outcome
+  group: release-cycle-outcome-validation
   cancel-in-progress: false
 
 jobs:
-  preserve-outcome:
+  observe-outcome:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
-      - name: Check out current main
+      - name: Check out current source without credential persistence
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Derive durable release-cycle outcome
-        id: derive
+      - name: Derive non-authorizing release-cycle observation
         env:
           EVENT_NAME: ${{ github.event_name }}
           SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
@@ -42,102 +41,53 @@ jobs:
           from datetime import datetime, timezone
           from pathlib import Path
 
-          changelog = Path('CHANGELOG.md').read_text(encoding='utf-8')
-          marker = '## [Unreleased]'
+          changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
+          marker = "## [Unreleased]"
           start = changelog.index(marker) + len(marker)
-          end = changelog.find('\n---', start)
+          end = changelog.find("\n---", start)
           if end == -1:
-              raise SystemExit('CHANGELOG Unreleased section terminator not found')
+              raise SystemExit("CHANGELOG Unreleased section terminator not found")
           section = changelog[start:end].strip()
-          release_required = bool(section and section != '_No unreleased changes._')
+          release_required = bool(section and section != "_No unreleased changes._")
 
-          event_name = os.environ.get('EVENT_NAME', '')
-          conclusion = os.environ.get('SOURCE_CONCLUSION') or 'manual-dispatch'
-          source_run_id = os.environ.get('SOURCE_RUN_ID') or os.environ['CURRENT_RUN_ID']
-          source_sha = os.environ.get('SOURCE_HEAD_SHA') or ''
-          version = Path('VERSION').read_text(encoding='utf-8').strip()
-
-          if event_name == 'workflow_dispatch':
-              outcome = 'RECONCILED'
-              reason = 'Manual reconciliation of repository release-cycle state.'
-          elif conclusion == 'skipped':
-              if release_required:
-                  outcome = 'INCOMPLETE'
-                  reason = 'Automated verified release was skipped while substantive Unreleased changes remained.'
-              else:
-                  outcome = 'SKIPPED'
-                  reason = 'Automated verified release was skipped and no substantive Unreleased changes remained.'
-          elif conclusion != 'success':
-              outcome = 'FAILED'
-              reason = f'Automated verified release concluded with {conclusion}.'
+          conclusion = os.environ.get("SOURCE_CONCLUSION") or "manual-dispatch"
+          source_run_id = os.environ.get("SOURCE_RUN_ID") or os.environ["CURRENT_RUN_ID"]
+          source_sha = os.environ.get("SOURCE_HEAD_SHA") or ""
+          version = Path("VERSION").read_text(encoding="utf-8").strip()
+          state = "SOURCE_OBSERVED"
+          if conclusion not in {"success", "skipped", "manual-dispatch"}:
+              state = "SOURCE_FAILURE_OBSERVED"
           elif release_required:
-              outcome = 'INCOMPLETE'
-              reason = 'Automated release succeeded but substantive Unreleased changes remain.'
-          else:
-              latest_release_path = Path('docs/release_evidence/latest_release.json')
-              if latest_release_path.exists():
-                  latest_release = json.loads(latest_release_path.read_text(encoding='utf-8'))
-                  published_version = str(latest_release.get('version', ''))
-              else:
-                  published_version = ''
-              if published_version == version:
-                  outcome = 'PUBLISHED'
-                  reason = f'Version {version} is represented by the latest publication receipt.'
-              else:
-                  outcome = 'SKIPPED'
-                  reason = 'No substantive Unreleased changes required publication.'
+              state = "RELEASE_CANDIDATE_REQUIRES_TVC_ADMISSION"
 
-          generated = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
-          source_run_url = f"https://github.com/{os.environ['REPOSITORY']}/actions/runs/{source_run_id}"
+          out = Path("reports/release_cycle")
+          out.mkdir(parents=True, exist_ok=True)
           payload = {
-              'schema_version': '1.0',
-              'outcome': outcome,
-              'reason': reason,
-              'repository': os.environ['REPOSITORY'],
-              'source_workflow': 'Automated verified release',
-              'source_workflow_conclusion': conclusion,
-              'source_workflow_run_id': str(source_run_id),
-              'source_workflow_run_url': source_run_url,
-              'source_head_sha': source_sha,
-              'current_version': version,
-              'release_required_after_run': release_required,
-              'generated_utc': generated,
-              'scope': 'repository release-cycle outcome only; no certification of user-authored content',
+              "schema": "stegverse.kv.release-cycle-hosted-observation/v1",
+              "state": state,
+              "source_workflow_conclusion": conclusion,
+              "source_workflow_run_id": str(source_run_id),
+              "source_head_sha": source_sha,
+              "current_version": version,
+              "release_required": release_required,
+              "generated_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+              "credential_authority": "TV/TVC",
+              "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+              "repository_mutation_performed": False,
+              "canonical_evidence_transition_performed": False,
+              "release_publication_performed": False,
+              "authority_effect": "NONE",
           }
-
-          evidence = Path('docs/release_evidence')
-          evidence.mkdir(parents=True, exist_ok=True)
-          (evidence / 'latest_cycle.json').write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
-          (evidence / 'latest_cycle.md').write_text(
-              '# Latest Release-Cycle Outcome\n\n'
-              f"- **Outcome:** `{outcome}`\n"
-              f"- **Reason:** {reason}\n"
-              f"- **Version:** `{version}`\n"
-              f"- **Release required after run:** `{str(release_required).lower()}`\n"
-              f"- **Source conclusion:** `{conclusion}`\n"
-              f"- **Source workflow:** {source_run_url}\n"
-              f"- **Source head SHA:** `{source_sha or 'not available'}`\n"
-              f"- **Generated UTC:** `{generated}`\n\n"
-              'This receipt records repository release-cycle state only. It does not certify user-authored content.\n',
-              encoding='utf-8',
+          (out / "hosted-release-cycle-observation.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
           )
-          with Path(os.environ['GITHUB_OUTPUT']).open('a', encoding='utf-8') as handle:
-              handle.write(f'outcome={outcome}\n')
-          print(f'release cycle outcome: {outcome}')
           PY
 
-      - name: Commit durable outcome receipt
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/release_evidence/latest_cycle.md docs/release_evidence/latest_cycle.json
-          if git diff --cached --quiet; then
-            echo "Release-cycle outcome receipt unchanged"
-          else
-            git commit -m "evidence: preserve release-cycle outcome [skip ci]"
-            git push origin HEAD:main
-          fi
-
-      - name: Fail after preserving an unresolved outcome
-        if: steps.derive.outputs.outcome == 'FAILED' || steps.derive.outputs.outcome == 'INCOMPLETE'
-        run: exit 1
+      - name: Upload non-secret release-cycle observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-cycle-observation-${{ github.run_id }}
+          path: reports/release_cycle/hosted-release-cycle-observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-cycle-recovery.yml
+++ b/.github/workflows/release-cycle-recovery.yml
@@ -1,102 +1,77 @@
-name: Release cycle recovery
+name: Release cycle recovery - Validation Only
 
 on:
   workflow_run:
-    workflows: ["Release cycle outcome"]
+    workflows: ["Release cycle outcome - Validation Only"]
     types: [completed]
-  schedule:
-    - cron: "17 * * * *"
   workflow_dispatch:
 
 permissions:
-  actions: write
-  contents: write
+  actions: read
+  contents: read
 
 concurrency:
-  group: release-cycle-recovery
+  group: release-cycle-recovery-validation
   cancel-in-progress: false
 
 jobs:
-  recover:
+  observe-recovery:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
-      - name: Check out current main
+      - name: Check out source without credential persistence
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Determine bounded recovery action
-        id: recovery
+      - name: Derive non-authorizing recovery recommendation
         run: |
           python3 - <<'PY'
           import json
-          import os
           from datetime import datetime, timezone
           from pathlib import Path
 
-          evidence = Path('docs/release_evidence')
-          cycle_path = evidence / 'latest_cycle.json'
-          state_path = evidence / 'recovery_state.json'
-
-          if not cycle_path.exists():
-              raise SystemExit('latest_cycle.json is required for recovery decisions')
-
-          cycle = json.loads(cycle_path.read_text(encoding='utf-8'))
-          if state_path.exists():
-              state = json.loads(state_path.read_text(encoding='utf-8'))
+          cycle_path = Path("docs/release_evidence/latest_cycle.json")
+          if cycle_path.exists():
+              cycle = json.loads(cycle_path.read_text(encoding="utf-8"))
           else:
-              state = {
-                  'schema_version': '1.0',
-                  'last_source_workflow_run_id': '',
-                  'dispatch_count': 0,
-                  'last_action': 'NONE',
-                  'updated_utc': '',
-              }
+              cycle = {}
 
-          source_run = str(cycle.get('source_workflow_run_id', ''))
-          incomplete = cycle.get('outcome') == 'INCOMPLETE'
-          release_required = cycle.get('release_required_after_run') is True
-          already_attempted = state.get('last_source_workflow_run_id') == source_run
-          dispatch = incomplete and release_required and source_run and not already_attempted
+          release_required = cycle.get("release_required_after_run") is True
+          incomplete = cycle.get("outcome") == "INCOMPLETE"
+          recommendation = (
+              "TVC_ADMITTED_RELEASE_CONTINUATION_REQUIRED"
+              if incomplete and release_required
+              else "NO_RELEASE_RECOVERY_REQUIRED"
+          )
 
-          now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
-          if dispatch:
-              state['last_source_workflow_run_id'] = source_run
-              state['dispatch_count'] = int(state.get('dispatch_count', 0)) + 1
-              state['last_action'] = 'DISPATCH_RELEASE_INTEGRITY'
-          elif incomplete and release_required and already_attempted:
-              state['last_action'] = 'SUPPRESSED_DUPLICATE_RECOVERY'
-          else:
-              state['last_action'] = 'NO_RECOVERY_REQUIRED'
-          state['updated_utc'] = now
-          state['source_outcome'] = cycle.get('outcome')
-          state['release_required'] = release_required
-
-          state_path.write_text(json.dumps(state, indent=2) + '\n', encoding='utf-8')
-          with Path(os.environ['GITHUB_OUTPUT']).open('a', encoding='utf-8') as handle:
-              handle.write(f"dispatch={'true' if dispatch else 'false'}\n")
-              handle.write(f"source_run={source_run}\n")
-              handle.write(f"action={state['last_action']}\n")
-          print(state['last_action'])
+          out = Path("reports/release_cycle")
+          out.mkdir(parents=True, exist_ok=True)
+          payload = {
+              "schema": "stegverse.kv.release-cycle-recovery-observation/v1",
+              "state": recommendation,
+              "source_outcome": cycle.get("outcome"),
+              "release_required": release_required,
+              "generated_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+              "credential_authority": "TV/TVC",
+              "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+              "repository_mutation_performed": False,
+              "workflow_dispatch_performed": False,
+              "release_execution_performed": False,
+              "authority_effect": "NONE",
+          }
+          (out / "hosted-release-recovery-observation.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
           PY
 
-      - name: Commit recovery decision
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/release_evidence/recovery_state.json
-          if git diff --cached --quiet; then
-            echo "Recovery state unchanged"
-          else
-            git commit -m "evidence: preserve release recovery decision [skip ci]"
-            git push origin HEAD:main
-          fi
-
-      - name: Dispatch release integrity once
-        if: steps.recovery.outputs.dispatch == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run release-integrity.yml
+      - name: Upload non-secret recovery observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-cycle-recovery-observation-${{ github.run_id }}
+          path: reports/release_cycle/hosted-release-recovery-observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/tests/test_hosted_release_authority_retirement.py
+++ b/tests/test_hosted_release_authority_retirement.py
@@ -1,0 +1,44 @@
+"""Regression guards for CMC-022 hosted release authority retirement."""
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = [
+    ".github/workflows/one_button_release.yml",
+    ".github/workflows/release-assets.yml",
+    ".github/workflows/build-and-attach-release.yml",
+    ".github/workflows/release-cycle-outcome.yml",
+    ".github/workflows/release-cycle-recovery.yml",
+]
+
+
+class HostedReleaseAuthorityRetirementTests(unittest.TestCase):
+    def test_retired_release_workflows_have_no_hosted_publication_authority(self):
+        for relative in WORKFLOWS:
+            text = (ROOT / relative).read_text(encoding="utf-8")
+            self.assertNotIn("${{ secrets.", text, relative)
+            self.assertNotIn("GITHUB_TOKEN:", text, relative)
+            self.assertNotIn("contents: write", text, relative)
+            self.assertNotIn("softprops/action-gh-release", text, relative)
+            self.assertNotIn("git push", text, relative)
+            self.assertNotIn("actions: write", text, relative)
+            self.assertNotIn("github.token", text, relative)
+            self.assertNotIn("GH_TOKEN:", text, relative)
+            self.assertNotIn("gh workflow run", text, relative)
+            marker_present = (
+                "HOSTED_RELEASE_PUBLICATION_PROHIBITED_USE_TVC_ADMITTED_RELEASE_CAPABILITY" in text
+                or "SOURCE_RECONSTRUCTED_RELEASE_NOT_MUTATED" in text
+                or "VALIDATION_TRANSPORT_ONLY" in text
+            )
+            self.assertTrue(marker_present, relative)
+
+    def test_release_workflows_are_validation_transport_only(self):
+        for relative in WORKFLOWS:
+            text = (ROOT / relative).read_text(encoding="utf-8")
+            self.assertIn("contents: read", text, relative)
+            self.assertIn("persist-credentials: false", text, relative)
+            self.assertIn("actions/upload-artifact@v4", text, relative)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_automation_contracts.py
+++ b/tools/test_automation_contracts.py
@@ -27,14 +27,20 @@ WORKFLOWS = {
         "gh release create",
     },
     "release-cycle-outcome.yml": {
-        "name: Release cycle outcome",
+        "name: Release cycle outcome - Validation Only",
         'workflows: ["Automated verified release"]',
-        "latest_cycle.json",
-        "latest_cycle.md",
-        "PUBLISHED",
-        "SKIPPED",
-        "FAILED",
-        "INCOMPLETE",
+        "VALIDATION_TRANSPORT_ONLY",
+        "repository_mutation_performed",
+        "canonical_evidence_transition_performed",
+        "actions/upload-artifact@v4",
+    },
+    "release-cycle-recovery.yml": {
+        "name: Release cycle recovery - Validation Only",
+        'workflows: ["Release cycle outcome - Validation Only"]',
+        "TVC_ADMITTED_RELEASE_CONTINUATION_REQUIRED",
+        "VALIDATION_TRANSPORT_ONLY",
+        "workflow_dispatch_performed",
+        "actions/upload-artifact@v4",
     },
     "downstream-propagation.yml": {"release:", "evidence/downstream-propagation"},
     "onboarding-friction-bootstrap.yml": {"workflow_dispatch:", "onboarding-friction"},
@@ -126,6 +132,33 @@ def validate_release_cycle() -> None:
         fail("release cycle missing issue-free gate tokens: " + ", ".join(missing))
     if "issues: write" in release:
         fail("automated release must not require issue-write permission")
+
+
+def validate_hosted_release_cycle_boundary() -> None:
+    workflow_root = REPO_ROOT / ".github" / "workflows"
+    for filename in ("release-cycle-outcome.yml", "release-cycle-recovery.yml"):
+        text = read_text(workflow_root / filename)
+        forbidden = {
+            "contents: write",
+            "actions: write",
+            "git push",
+            "github.token",
+            "GH_TOKEN:",
+            "gh workflow run",
+        }
+        present = sorted(token for token in forbidden if token in text)
+        if present:
+            fail(f"{filename} reintroduces hosted release-cycle authority: {', '.join(present)}")
+        required = {
+            "contents: read",
+            "persist-credentials: false",
+            "VALIDATION_TRANSPORT_ONLY",
+            "authority_effect",
+            "NONE",
+        }
+        missing = sorted(token for token in required if token not in text)
+        if missing:
+            fail(f"{filename} missing validation-only boundary tokens: {', '.join(missing)}")
 
 
 def validate_release_cycle_outcome() -> None:
@@ -282,6 +315,7 @@ def main() -> int:
     checks = [
         validate_workflows,
         validate_release_cycle,
+        validate_hosted_release_cycle_boundary,
         validate_release_cycle_outcome,
         validate_candidate_release_bridge,
         validate_friction_registry,


### PR DESCRIPTION
Supersedes auto-closed PR #77 after its branch was reset to current main to preserve 10 newer release-evidence commits. Prior exact head 0e4590791c806d234b6691e10158d0203af596b1 had five successful hosted validations, but those runs do not validate this reconciled head.

Current exact head: 3c03252b004dece5f65bedfe0a8a1d28d012f198
Base main: 8dec7a290d8452179459b96432a7049defd64d8d

Fresh validation:
- Release Integrity 33097637213: SUCCESS
- Security Baseline 33097637187: SUCCESS
- Repository validation diagnostics 33097637216: SUCCESS
- KV Guardrails 33097637118: FAIL_CLOSED at `Validate hosted release authority retirement`

The guardrail logs prove the remaining contradiction is `.github/workflows/release-assets.yml`: it still contains `contents: write`, `softprops/action-gh-release@v2`, and `${{ secrets.GITHUB_TOKEN }}`. The connected GitHub write control refused restoration of that file and also refused the canonical CVK handoff update. These are explicit blockers, not completion.

Already restored on this branch: build-and-attach release retirement, one-button release retirement, release-cycle outcome main-mutation retirement, release-cycle recovery dispatch/main-mutation retirement, regression test, and automation-contract regression. No main mutation, release publication, credential authority, runtime activation, or new TVC provider/release path is claimed. Do not merge while KV Guardrails is red.