### PR TITLE
Retire residual hosted release-integrity and automated-release authority

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -1,4 +1,4 @@
-name: Automated verified release
+name: Automated release readiness - Validation Only
 
 on:
   workflow_run:
@@ -6,30 +6,31 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: automated-verified-release
+  group: automated-release-readiness-validation
   cancel-in-progress: false
 
 jobs:
-  release:
+  validate_release_readiness:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
-      - name: Check out current main
+      - name: Check out current main without credential persistence
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Determine whether a release is required
+      - name: Determine whether a release candidate is required
         id: gate
         env:
           SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
@@ -39,17 +40,11 @@ jobs:
           import os
           import subprocess
           from pathlib import Path
-
           conclusion = os.environ.get("SOURCE_CONCLUSION", "")
           source_sha = os.environ.get("SOURCE_HEAD_SHA", "")
           source_on_main = False
           if source_sha:
-              result = subprocess.run(
-                  ["git", "merge-base", "--is-ancestor", source_sha, "HEAD"],
-                  check=False,
-              )
-              source_on_main = result.returncode == 0
-
+              source_on_main = subprocess.run(["git", "merge-base", "--is-ancestor", source_sha, "HEAD"], check=False).returncode == 0
           text = Path("CHANGELOG.md").read_text(encoding="utf-8")
           marker = "## [Unreleased]"
           if text.count(marker) != 1:
@@ -59,9 +54,8 @@ jobs:
           substantive = normalized not in {"", "_no unreleased changes._", "no unreleased changes."}
           eligible_source = conclusion == "success" and source_on_main
           enabled = eligible_source and substantive
-
           reason = (
-              "release required"
+              "release required; TVC-admitted publication continuation required"
               if enabled
               else "source integrity SHA is not contained in main or did not succeed"
               if not eligible_source
@@ -76,13 +70,13 @@ jobs:
           print(reason)
           PY
 
-      - name: Select backward-compatible patch version
+      - name: Prepare ephemeral patch release candidate
         if: steps.gate.outputs.enabled == 'true'
         id: version
         run: |
           python3 - <<'PY'
+          from datetime import date
           from pathlib import Path
-
           current = Path("VERSION").read_text(encoding="utf-8").strip()
           parts = current.split(".")
           if len(parts) != 3 or not all(part.isdigit() for part in parts):
@@ -90,140 +84,75 @@ jobs:
           major, minor, patch = map(int, parts)
           next_version = f"{major}.{minor}.{patch + 1}"
           Path("VERSION").write_text(next_version + "\n", encoding="utf-8")
+          changelog = Path("CHANGELOG.md")
+          text = changelog.read_text(encoding="utf-8")
+          marker = "## [Unreleased]"
+          replacement = "## [Unreleased]\n\n_No unreleased changes._\n\n---\n\n" + f"## [{next_version}] – {date.today().isoformat()}"
+          changelog.write_text(text.replace(marker, replacement, 1), encoding="utf-8")
           Path(".next-version").write_text(next_version + "\n", encoding="utf-8")
           print(next_version)
           PY
           echo "value=$(cat .next-version)" >> "$GITHUB_OUTPUT"
 
-      - name: Finalize changelog entry
-        if: steps.gate.outputs.enabled == 'true'
-        env:
-          NEXT_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          python3 - <<'PY'
-          import os
-          from datetime import date
-          from pathlib import Path
-
-          path = Path("CHANGELOG.md")
-          text = path.read_text(encoding="utf-8")
-          marker = "## [Unreleased]"
-          replacement = (
-              "## [Unreleased]\n\n_No unreleased changes._\n\n---\n\n"
-              f"## [{os.environ['NEXT_VERSION']}] – {date.today().isoformat()}"
-          )
-          path.write_text(text.replace(marker, replacement, 1), encoding="utf-8")
-          PY
-
-      - name: Verify release candidate
+      - name: Verify ephemeral release candidate
         if: steps.gate.outputs.enabled == 'true'
         run: |
           rm -rf dist
           python3 tools/test_release_tools.py
           python3 tools/test_init_vault.py
           python3 tools/test_automation_contracts.py
+          python3 -m unittest tests.test_hosted_release_authority_retirement -v
           rm -rf dist
           python3 tools/build_release.py
           python3 tools/verify_release.py "dist/ContinuityVault_v${{ steps.version.outputs.value }}.zip"
 
-      - name: Commit verified candidate
-        if: steps.gate.outputs.enabled == 'true'
-        id: commit
-        run: |
-          rm -f .next-version
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add VERSION CHANGELOG.md
-          git commit -m "release: v${{ steps.version.outputs.value }}"
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Tag and push verified candidate
-        if: steps.gate.outputs.enabled == 'true'
-        run: |
-          tag="v${{ steps.version.outputs.value }}"
-          if git rev-parse "$tag" >/dev/null 2>&1; then
-            echo "Tag $tag already exists"
-            exit 1
-          fi
-          git tag -a "$tag" -m "Continuity Vault Kit $tag"
-          git push origin HEAD:main
-          git push origin "$tag"
-
-      - name: Publish release assets
-        if: steps.gate.outputs.enabled == 'true'
+      - name: Emit non-authorizing release-readiness observation
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          version="${{ steps.version.outputs.value }}"
-          tag="v${version}"
-          zip="dist/ContinuityVault_v${version}.zip"
-          gh release create "$tag" "$zip" "${zip}.sha256" "${zip}.manifest.json" \
-            --title "Continuity Vault Kit ${tag}" \
-            --notes "Automated verified patch release. Release, initializer, and automation-contract tests passed before tagging commit ${{ steps.commit.outputs.sha }}. This release verifies package integrity and installer copy behavior only."
-
-      - name: Create durable final release receipt
-        if: steps.gate.outputs.enabled == 'true'
-        env:
-          VERSION_VALUE: ${{ steps.version.outputs.value }}
-          RELEASE_COMMIT: ${{ steps.commit.outputs.sha }}
-          RUN_ID: ${{ github.run_id }}
-          REPOSITORY: ${{ github.repository }}
+          SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          SOURCE_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          ELIGIBLE_SOURCE: ${{ steps.gate.outputs.eligible_source }}
+          RELEASE_REQUIRED: ${{ steps.gate.outputs.enabled }}
+          REASON: ${{ steps.gate.outputs.reason }}
+          CANDIDATE_VERSION: ${{ steps.version.outputs.value }}
         run: |
           python3 - <<'PY'
           import json
           import os
           from datetime import datetime, timezone
           from pathlib import Path
-
-          version = os.environ["VERSION_VALUE"]
-          zip_path = Path("dist") / f"ContinuityVault_v{version}.zip"
-          checksum = zip_path.with_suffix(zip_path.suffix + ".sha256").read_text(encoding="utf-8").split()[0]
-          manifest = json.loads(zip_path.with_suffix(zip_path.suffix + ".manifest.json").read_text(encoding="utf-8"))
-          generated = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-          receipt = {
-              "schema_version": "1.1",
-              "result": "PUBLISHED",
-              "repository": os.environ["REPOSITORY"],
-              "version": version,
-              "tag": f"v{version}",
-              "release_commit": os.environ["RELEASE_COMMIT"],
-              "workflow_run_url": f"https://github.com/{os.environ['REPOSITORY']}/actions/runs/{os.environ['RUN_ID']}",
-              "release_url": f"https://github.com/{os.environ['REPOSITORY']}/releases/tag/v{version}",
-              "release_artifact": zip_path.name,
-              "release_sha256": checksum,
-              "manifest_schema_version": manifest["schema_version"],
-              "manifest_file_count": manifest["file_count"],
-              "release_assets": [zip_path.name, zip_path.name + ".sha256", zip_path.name + ".manifest.json"],
-              "builder_verifier_self_test": "PASS",
-              "initializer_self_test": "PASS",
-              "automation_contract_test": "PASS",
-              "published_utc": generated,
-              "scope": "package integrity and installer copy verification only",
+          release_required = os.environ.get("RELEASE_REQUIRED") == "true"
+          eligible = os.environ.get("ELIGIBLE_SOURCE") == "true"
+          state = "TVC_ADMITTED_RELEASE_CONTINUATION_REQUIRED" if release_required else "NO_RELEASE_REQUIRED" if eligible else "SOURCE_NOT_ELIGIBLE"
+          out = Path("reports/release_readiness")
+          out.mkdir(parents=True, exist_ok=True)
+          payload = {
+              "schema": "stegverse.kv.release-readiness-hosted-observation/v1",
+              "state": state,
+              "reason": os.environ.get("REASON", ""),
+              "source_workflow_conclusion": os.environ.get("SOURCE_CONCLUSION", ""),
+              "source_head_sha": os.environ.get("SOURCE_HEAD_SHA", ""),
+              "candidate_version": os.environ.get("CANDIDATE_VERSION") or None,
+              "release_required": release_required,
+              "credential_authority": "TV/TVC",
+              "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+              "repository_mutation_performed": False,
+              "version_mutation_persisted": False,
+              "changelog_mutation_persisted": False,
+              "tag_mutation_performed": False,
+              "release_publication_performed": False,
+              "authority_effect": "NONE",
+              "generated_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
           }
-          evidence = Path("docs/release_evidence")
-          evidence.mkdir(parents=True, exist_ok=True)
-          (evidence / "latest_release.json").write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
-          (evidence / "latest_release.md").write_text(
-              "# Latest Published Release\n\n"
-              f"- **Result:** PUBLISHED\n"
-              f"- **Version:** `{receipt['version']}`\n"
-              f"- **Tag:** `{receipt['tag']}`\n"
-              f"- **Release commit:** `{receipt['release_commit']}`\n"
-              f"- **Workflow:** {receipt['workflow_run_url']}\n"
-              f"- **Release:** {receipt['release_url']}\n"
-              f"- **Artifact:** `{receipt['release_artifact']}`\n"
-              f"- **SHA-256:** `{receipt['release_sha256']}`\n"
-              f"- **Manifest files:** `{receipt['manifest_file_count']}`\n"
-              f"- **Published UTC:** `{receipt['published_utc']}`\n\n"
-              "Release, initializer, and automation-contract tests passed before tagging. This receipt verifies package integrity and installer copy behavior only.\n",
-              encoding="utf-8",
-          )
+          (out / "release-readiness-observation.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          print(json.dumps(payload, sort_keys=True))
           PY
 
-      - name: Commit final release receipt
-        if: steps.gate.outputs.enabled == 'true'
-        run: |
-          git add docs/release_evidence/latest_release.md docs/release_evidence/latest_release.json
-          git commit -m "evidence: record published release v${{ steps.version.outputs.value }} [skip ci]"
-          git pull --rebase origin main
-          git push origin HEAD:main
+      - name: Upload non-secret release-readiness evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: continuity-vault-release-readiness-${{ github.run_id }}
+          path: |
+            reports/release_readiness/release-readiness-observation.json
+            dist/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/release-cycle-outcome.yml
+++ b/.github/workflows/release-cycle-outcome.yml
@@ -2,7 +2,7 @@ name: Release cycle outcome - Validation Only
 
 on:
   workflow_run:
-    workflows: ["Automated verified release"]
+    workflows: ["Automated release readiness - Validation Only"]
     types: [completed]
   workflow_dispatch:
 

--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -11,6 +11,7 @@ on:
       - "tools/test_init_vault.py"
       - "tools/test_clean_room_user_kv.py"
       - "tools/test_automation_contracts.py"
+      - "tests/test_hosted_release_authority_retirement.py"
       - "vault_template/**"
       - "automation/**"
       - "evidence/onboarding-friction/**"
@@ -27,6 +28,7 @@ on:
       - "tools/test_init_vault.py"
       - "tools/test_clean_room_user_kv.py"
       - "tools/test_automation_contracts.py"
+      - "tests/test_hosted_release_authority_retirement.py"
       - "vault_template/**"
       - "automation/**"
       - "evidence/onboarding-friction/**"
@@ -37,7 +39,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release-integrity-${{ github.ref }}
@@ -49,10 +51,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out repository
+      - name: Check out repository without credential persistence
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -71,6 +74,9 @@ jobs:
       - name: Validate automation contracts
         run: python3 tools/test_automation_contracts.py
 
+      - name: Validate hosted release authority retirement
+        run: python3 -m unittest tests.test_hosted_release_authority_retirement -v
+
       - name: Rebuild release evidence
         run: |
           rm -rf dist
@@ -82,7 +88,6 @@ jobs:
           python3 - <<'PY'
           import json
           from pathlib import Path
-
           version = Path("VERSION").read_text(encoding="utf-8").strip()
           manifest_path = Path("dist") / f"ContinuityVault_v{version}.zip.manifest.json"
           manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -97,8 +102,7 @@ jobs:
           print(f"manifest validated: {manifest['file_count']} files")
           PY
 
-      - name: Create durable evidence receipt
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Create non-authorizing release-integrity observation
         env:
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -110,28 +114,23 @@ jobs:
           import os
           from datetime import datetime, timezone
           from pathlib import Path
-
           version = Path("VERSION").read_text(encoding="utf-8").strip()
           zip_name = f"ContinuityVault_v{version}.zip"
           manifest = json.loads((Path("dist") / f"{zip_name}.manifest.json").read_text(encoding="utf-8"))
           checksum = (Path("dist") / f"{zip_name}.sha256").read_text(encoding="utf-8").split()[0]
-          run_url = f"https://github.com/{os.environ['REPOSITORY']}/actions/runs/{os.environ['RUN_ID']}"
-          artifact_name = f"continuity-vault-release-integrity-{os.environ['COMMIT_SHA']}"
-          generated_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
           changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
           section = changelog.split("## [Unreleased]", 1)[1].split("\n---", 1)[0]
           normalized = " ".join(section.split()).lower()
           release_required = normalized not in {"", "_no unreleased changes._", "no unreleased changes."}
-
+          out = Path("reports/release_integrity")
+          out.mkdir(parents=True, exist_ok=True)
           receipt = {
-              "schema_version": "1.3",
+              "schema": "stegverse.kv.release-integrity-hosted-observation/v1",
               "result": "PASS",
               "repository": os.environ["REPOSITORY"],
               "commit_sha": os.environ["COMMIT_SHA"],
               "workflow_run_id": os.environ["RUN_ID"],
               "workflow_run_attempt": os.environ["RUN_ATTEMPT"],
-              "workflow_run_url": run_url,
-              "artifact_name": artifact_name,
               "version": version,
               "release_required": release_required,
               "release_artifact": zip_name,
@@ -141,49 +140,25 @@ jobs:
               "initializer_self_test": "PASS",
               "clean_room_user_kv_test": "PASS",
               "automation_contract_test": "PASS",
-              "generated_utc": generated_utc,
-              "scope": "package integrity, installer copy verification, and repository automation contract consistency only",
+              "credential_authority": "TV/TVC",
+              "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+              "repository_mutation_performed": False,
+              "tag_mutation_performed": False,
+              "release_publication_performed": False,
+              "canonical_evidence_transition_performed": False,
+              "authority_effect": "NONE",
+              "generated_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
           }
-
-          evidence_dir = Path("docs/release_evidence")
-          evidence_dir.mkdir(parents=True, exist_ok=True)
-          (evidence_dir / "latest.json").write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
-          (evidence_dir / "latest.md").write_text(
-              "# Latest Release-Integrity Evidence\n\n"
-              f"- **Result:** PASS\n"
-              f"- **Repository:** `{receipt['repository']}`\n"
-              f"- **Tested commit:** `{receipt['commit_sha']}`\n"
-              f"- **Workflow run:** {receipt['workflow_run_url']}\n"
-              f"- **Uploaded artifact:** `{receipt['artifact_name']}`\n"
-              f"- **Current version:** `{receipt['version']}`\n"
-              f"- **Release required:** `{str(receipt['release_required']).lower()}`\n"
-              f"- **Release SHA-256:** `{receipt['release_sha256']}`\n"
-              f"- **Verified file count:** `{receipt['manifest_file_count']}`\n"
-              f"- **Initializer self-test:** `{receipt['initializer_self_test']}`\n"
-              f"- **Automation contract test:** `{receipt['automation_contract_test']}`\n"
-              f"- **Generated UTC:** `{receipt['generated_utc']}`\n\n"
-              "The workflow completed release tooling tests, safe initialization tests, automation contract validation, a clean rebuild, manifest validation, and full archive verification. Automated publication is determined from the Unreleased changelog section rather than historical issue state.\n",
-              encoding="utf-8",
-          )
+          (out / "release-integrity-observation.json").write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          print(json.dumps(receipt, sort_keys=True))
           PY
 
-      - name: Upload release evidence
+      - name: Upload release validation evidence
         uses: actions/upload-artifact@v4
         with:
           name: continuity-vault-release-integrity-${{ github.sha }}
-          path: dist/
+          path: |
+            dist/
+            reports/release_integrity/release-integrity-observation.json
           if-no-files-found: error
           retention-days: 30
-
-      - name: Commit durable evidence receipt
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/release_evidence/latest.md docs/release_evidence/latest.json
-          if git diff --cached --quiet; then
-            echo "Evidence receipt unchanged"
-          else
-            git commit -m "ci: preserve release-integrity evidence [skip ci]"
-            git push
-          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ The format is based on [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+- fail-closed `KV-INTERLOCK-v1` runtime endpoint core with exact DEVICE→KV InTr admission binding, injected authority/policy/storage boundaries, bounded-context enforcement, deterministic receipts, and candidate-only `COMMIT_CANDIDATE` semantics
+- deterministic runtime endpoint tests and canonical runtime handoff for the Site/KV production backend seam
+
+### Security
+- retired GitHub-hosted release/publication and release-control-plane mutation authority from the CMC-022/CMC-023 workflow set
+- retired residual `release-integrity.yml` evidence writeback and `automated-release.yml` VERSION/changelog/tag/GitHub-release mutation authority; hosted release workflows now validate and transport non-secret evidence only
+- preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
+
+### Notes
+- production KV endpoint deployment, live InTr boundary identity/sealing, canonical Site readback, SKAP owner ingress, provider execution, and TVC release publication remain separate runtime evidence gates
 
 ---
 

--- a/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -549,3 +549,30 @@ Final verified source state:
 - COMPLETE: YES for CMC-022/CMC-023 source-retirement goal only
 
 The KnowledgeVault production activation, owner ingress, provider execution, runtime Interlock/InTr, bearer/delivery, and reconstruction goals remain separate canonical lanes and are not satisfied by this source-retirement merge.
+
+
+## Residual hosted release-integrity authority correction — issue #81
+
+Post-PR #78 inspection found two hosted authority surfaces outside the five-workflow retirement set:
+
+```text
+.github/workflows/release-integrity.yml:
+  contents: write
+  durable docs/release_evidence/latest.* commit/push
+
+.github/workflows/automated-release.yml:
+  contents: write
+  persistent VERSION/CHANGELOG mutation
+  commit/tag/push
+  github.token via GH_TOKEN
+  gh release create
+  durable release-receipt commit/push
+```
+
+Issue #81 / branch `fix/residual-hosted-release-authority-81` is the sole continuation for this exact residual. The branch converts both surfaces to read-only validation/evidence transport, preserves release-integrity and ephemeral candidate verification, and routes any substantive candidate to `TVC_ADMITTED_RELEASE_CONTINUATION_REQUIRED` without persistent mutation or publication.
+
+Canonical scoped handoff: `RELEASE_INTEGRITY_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md`.
+
+The Unreleased changelog now records #78, #80, and this residual authority repair. `VERSION` remains 0.1.9 until a real admitted TV/TVC release publication transition occurs.
+
+No source repair, hosted PASS, or candidate artifact is a release/tag/deployment/activation claim.

--- a/RELEASE_INTEGRITY_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
+++ b/RELEASE_INTEGRITY_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-08-27
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #81
 Branch: `fix/residual-hosted-release-authority-81`
-State: CLAIMED_FOR_IMPLEMENTATION
+State: IMPLEMENTED_ON_BRANCH_VALIDATION_PENDING
 
 ## Purpose
 
@@ -68,6 +68,40 @@ Hosted workflows may rebuild, validate, derive candidate readiness, and upload n
 
 No release, tag, deployment, publication, resident TVC capability, or activation is produced by this source repair.
 
+## Implemented source state
+
+```text
+release-integrity.yml:
+  contents: read
+  checkout credential persistence: false
+  release build/verify: retained
+  durable main writeback: removed
+  hosted observation: short-lived artifact only
+
+automated-release.yml:
+  state: Automated release readiness - Validation Only
+  contents: read
+  checkout credential persistence: false
+  ephemeral patch candidate build: allowed for validation
+  persistent VERSION mutation: false
+  persistent CHANGELOG mutation: false
+  commit/tag/push: removed
+  github.token / GH_TOKEN: removed
+  GitHub release publication: removed
+  TVC_ADMITTED_RELEASE_CONTINUATION_REQUIRED: explicit
+
+release-cycle-outcome.yml:
+  observes renamed validation-only readiness workflow
+
+regression:
+  release-integrity + automated-release included in hosted-authority retirement tests
+  automation contract rejects hosted mutation/publication tokens on all four release-cycle validation surfaces
+```
+
+## Release metadata correction
+
+`CHANGELOG.md#Unreleased` now records the merged KV Interlock endpoint and hosted release-authority retirements. `VERSION` intentionally remains `0.1.9`; successor version mutation/tag/publication is reserved for admitted TV/TVC release execution.
+
 ## Next executable boundary
 
-Implement validation-only workflow behavior, extend regression enforcement, run exact-head validation, merge only after all applicable checks pass, then reconcile TVC credential-model consistency source so the hosted-authority claim matches live CVK state.
+Run exact-head hosted validation, repair any source/test defect without reintroducing hosted authority, merge only after green evidence, then reconcile TVC credential-model consistency and the global project handoff. A successor release remains blocked until the TVC-admitted release runtime is actually observed.

--- a/RELEASE_INTEGRITY_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
+++ b/RELEASE_INTEGRITY_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
@@ -1,0 +1,73 @@
+# Residual Hosted Release Authority Retirement Mirror Handoff
+
+Updated: 2026-08-27
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #81
+Branch: `fix/residual-hosted-release-authority-81`
+State: CLAIMED_FOR_IMPLEMENTATION
+
+## Purpose
+
+Close the residual CMC-023 hosted repository/publication authority still present after PR #78.
+
+Live main still contains:
+
+```text
+.github/workflows/release-integrity.yml:
+  contents: write
+  commits docs/release_evidence/latest.*
+  git push
+
+.github/workflows/automated-release.yml:
+  contents: write
+  mutates VERSION + CHANGELOG
+  creates commit + tag
+  git push
+  consumes github.token through GH_TOKEN
+  gh release create
+  commits release receipt
+```
+
+These behaviors contradict the current TV/TVC credential/release model and the downstream TVC consistency claim that hosted repository control-plane authority is NONE.
+
+## Required state
+
+```text
+GitHub Actions release authority: NONE
+GitHub Actions repository mutation authority: NONE
+GitHub Actions tag authority: NONE
+GitHub Actions publication authority: NONE
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+credential/release authority: TV/TVC
+VERSION persistent mutation: TVC-admitted release only
+CHANGELOG finalization persistent mutation: TVC-admitted release only
+release publication runtime: separate / NOT OBSERVED
+```
+
+Hosted workflows may rebuild, validate, derive candidate readiness, and upload non-secret short-lived evidence artifacts. They may not persist canonical state or execute release publication.
+
+## Collision boundary
+
+- PR #78 is completed historical source retirement and must not be reopened.
+- Do not alter v0.1.9 release evidence or claim a successor release.
+- Do not introduce a new GitHub credential or TVC credential into Actions.
+- Do not change production KV/SKAP/InTr runtime authority.
+- Do not create a second release credential model.
+
+## Planned source
+
+- `.github/workflows/release-integrity.yml`
+- `.github/workflows/automated-release.yml`
+- `.github/workflows/release-cycle-outcome.yml` only for renamed workflow observation binding
+- `tools/test_automation_contracts.py`
+- `tests/test_hosted_release_authority_retirement.py`
+- `STATUS.md`
+- `CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`
+
+## Non-claims
+
+No release, tag, deployment, publication, resident TVC capability, or activation is produced by this source repair.
+
+## Next executable boundary
+
+Implement validation-only workflow behavior, extend regression enforcement, run exact-head validation, merge only after all applicable checks pass, then reconcile TVC credential-model consistency source so the hosted-authority claim matches live CVK state.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,10 @@
 state: active
 works_today: yes — use the verified initializer or copy the template directly; no accounts, services, or lock-in
 current_version: 0.1.9
-current_focus: preserve verified v0.1.9 release-cycle health while completing active recoverable-execution orchestration, maintaining portable KnowledgeVault installation fidelity, and validating the consolidated root user-document path
+current_focus: preserve verified v0.1.9 as the last published release while validating the next Unreleased candidate under TV/TVC-only publication authority, deploying the merged KV Interlock runtime endpoint on the sovereign runtime, and completing remaining recoverable-execution evidence
 known_gaps:
+  - Replacement TVC-admitted KnowledgeVault release publication runtime is not yet observed; hosted GitHub workflows are validation/evidence transport only
+  - Merged KV Interlock runtime endpoint core is not yet deployed behind a live verified DEVICE-to-KV InTr boundary identity/sealing service and durable receipt store
   - Internal historical/developer references to removed root onboarding documents still need stale-link validation against current main
   - Data-sharing revenue behavior is documented but not implemented
   - No real onboarding-friction reports have yet crossed the automation-candidate threshold
@@ -23,11 +25,11 @@ completed_recently:
   - Added bounded release-cycle recovery state to suppress duplicate recovery loops
 next_steps:
   - Validate current-main internal links for stale references to removed root onboarding files and redirect active references to README.md or USER_GUIDE.md
-  - Treat docs/release_evidence/latest.json as the machine-readable integrity and release-required gate
-  - Treat docs/release_evidence/latest_release.json as the latest successful publication receipt
-  - Treat docs/release_evidence/latest_cycle.json as the authoritative latest release-cycle outcome
-  - Treat docs/release_evidence/recovery_state.json as the bounded recovery source of truth
+  - Treat docs/release_evidence/latest_release.json as the immutable latest successful publication receipt for v0.1.9
+  - Treat docs/release_evidence/latest.json, latest_cycle.json, and recovery_state.json as retained historical pre-retirement hosted writeback evidence, not current mutation authority
+  - Use the Unreleased changelog plus validation-only hosted artifacts to determine candidate readiness; persistent VERSION/changelog/tag/release transitions require admitted TV/TVC release authority
+  - Bind the merged KV Interlock runtime endpoint to the existing sovereign runtime with authentic InTr boundary verification and durable receipt persistence before Site production readback
   - Complete issue #39 recoverable execution orchestration without creating new authority during recovery
   - Keep issue #16 external provider activation separate from baseline KnowledgeVault usability and fail closed until live evidence exists
   - Keep first-contact use independent of accounts, hosted services, mandatory SDKs, and vault telemetry
-last_reviewed_utc: 2026-08-26T19:32:00Z
+last_reviewed_utc: 2026-08-27T21:42:00Z

--- a/tests/test_hosted_release_authority_retirement.py
+++ b/tests/test_hosted_release_authority_retirement.py
@@ -7,6 +7,8 @@ WORKFLOWS = [
     ".github/workflows/one_button_release.yml",
     ".github/workflows/release-assets.yml",
     ".github/workflows/build-and-attach-release.yml",
+    ".github/workflows/release-integrity.yml",
+    ".github/workflows/automated-release.yml",
     ".github/workflows/release-cycle-outcome.yml",
     ".github/workflows/release-cycle-recovery.yml",
 ]

--- a/tools/test_automation_contracts.py
+++ b/tools/test_automation_contracts.py
@@ -20,15 +20,17 @@ WORKFLOWS = {
         '"release_required": release_required',
     },
     "automated-release.yml": {
-        "name: Automated verified release",
+        "name: Automated release readiness - Validation Only",
         "workflow_run:",
-        "Determine whether a release is required",
+        "Determine whether a release candidate is required",
         "## [Unreleased]",
-        "gh release create",
+        "TVC_ADMITTED_RELEASE_CONTINUATION_REQUIRED",
+        "VALIDATION_TRANSPORT_ONLY",
+        "actions/upload-artifact@v4",
     },
     "release-cycle-outcome.yml": {
         "name: Release cycle outcome - Validation Only",
-        'workflows: ["Automated verified release"]',
+        'workflows: ["Automated release readiness - Validation Only"]',
         "VALIDATION_TRANSPORT_ONLY",
         "repository_mutation_performed",
         "canonical_evidence_transition_performed",
@@ -136,7 +138,12 @@ def validate_release_cycle() -> None:
 
 def validate_hosted_release_cycle_boundary() -> None:
     workflow_root = REPO_ROOT / ".github" / "workflows"
-    for filename in ("release-cycle-outcome.yml", "release-cycle-recovery.yml"):
+    for filename in (
+        "release-integrity.yml",
+        "automated-release.yml",
+        "release-cycle-outcome.yml",
+        "release-cycle-recovery.yml",
+    ):
         text = read_text(workflow_root / filename)
         forbidden = {
             "contents: write",
@@ -145,6 +152,10 @@ def validate_hosted_release_cycle_boundary() -> None:
             "github.token",
             "GH_TOKEN:",
             "gh workflow run",
+            "gh release create",
+            "git commit",
+            "git tag",
+            "git pull",
         }
         present = sorted(token for token in forbidden if token in text)
         if present:
@@ -155,6 +166,7 @@ def validate_hosted_release_cycle_boundary() -> None:
             "VALIDATION_TRANSPORT_ONLY",
             "authority_effect",
             "NONE",
+            "actions/upload-artifact@v4",
         }
         missing = sorted(token for token in required if token not in text)
         if missing:


### PR DESCRIPTION
Closes issue #81.

This is the residual CMC-023 correction after PR #78. It removes the two remaining hosted release/control-plane mutation paths:
- `release-integrity.yml` no longer commits/pushes durable evidence to main;
- `automated-release.yml` no longer persists VERSION/CHANGELOG changes, commits, tags, pushes, uses `github.token`, or creates GitHub releases.

Hosted workflows retain deterministic build/verification and upload only non-secret short-lived validation artifacts. A substantive candidate emits `TVC_ADMITTED_RELEASE_CONTINUATION_REQUIRED` and leaves persistent release mutation/publication to TV/TVC.

Also:
- updates release-cycle outcome trigger to the validation-only readiness workflow;
- extends regression and automation-contract enforcement to both residual surfaces;
- records #78/#80/#81 in `CHANGELOG.md#Unreleased` while preserving persistent `VERSION=0.1.9`;
- updates STATUS and canonical handoffs.

Non-claims: no release, tag, deployment, resident TVC capability, KV activation, or provider execution is produced by this PR.