### PR TITLE
Retire hosted automation-candidate mutation authority

### DIFF
--- a/.github/workflows/automation-candidate-implementation.yml
+++ b/.github/workflows/automation-candidate-implementation.yml
@@ -1,150 +1,85 @@
-name: Automation candidate implementation
+name: Automation candidate implementation - Validation Only
 
 on:
   pull_request:
     types: [closed]
 
 permissions:
-  actions: write
-  contents: write
-  issues: write
+  contents: read
   pull-requests: read
 
 concurrency:
-  group: automation-candidate-implementation
+  group: automation-candidate-implementation-validation
   cancel-in-progress: false
 
 jobs:
-  complete:
+  observe:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-      - name: Check out current main
+      - name: Check out current main without credential persistence
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Resolve referenced candidates
-        id: candidates
+      - name: Observe referenced candidate identifiers
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          python3 - <<'PY'
-          import os
-          import re
-          from pathlib import Path
-
-          text = os.environ.get('PR_TITLE', '') + '\n' + os.environ.get('PR_BODY', '')
-          patterns = [
-              r'(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)',
-              r'(?i)\bautomation[- ]candidate\s+#(\d+)',
-          ]
-          numbers = sorted({int(value) for pattern in patterns for value in re.findall(pattern, text)})
-          Path('/tmp/candidate-numbers.txt').write_text(
-              '\n'.join(map(str, numbers)) + ('\n' if numbers else ''), encoding='utf-8'
-          )
-          with Path(os.environ['GITHUB_OUTPUT']).open('a', encoding='utf-8') as handle:
-              handle.write(f"count={len(numbers)}\n")
-          PY
-
-      - name: Mark supported candidates implemented
-        if: steps.candidates.outputs.count != '0'
-        env:
-          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          : > /tmp/implemented-candidates.tsv
-          while IFS= read -r issue; do
-            [ -n "$issue" ] || continue
-            issue_json=$(gh issue view "$issue" --json labels,title 2>/dev/null || true)
-            [ -n "$issue_json" ] || continue
-            labels=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | join(",")')
-            case ",$labels," in
-              *,automation-candidate,*) ;;
-              *) continue ;;
-            esac
-            case ",$labels," in
-              *,candidate-supported,*)
-                signature=$(printf '%s' "$issue_json" | jq -r '.title | sub("^\\[Automation candidate\\]\\s+"; "")')
-                gh issue edit "$issue" --add-label candidate-implemented --remove-label candidate-supported 2>/dev/null || true
-                gh issue comment "$issue" --body "Merged PR #${PR_NUMBER} completed this supported automation candidate. PR: ${{ github.event.pull_request.html_url }}. Merge commit: \`${MERGE_SHA}\`. Lifecycle reconciliation will preserve the implementation receipt and close the candidate automatically."
-                printf '%s\t%s\n' "$issue" "$signature" >> /tmp/implemented-candidates.tsv
-                ;;
-              *)
-                gh issue comment "$issue" --body "Merged PR #${PR_NUMBER} referenced this candidate, but the current registry does not mark it supported. No implementation authority was inferred; candidate lifecycle reconciliation will retain the evidence state."
-                ;;
-            esac
-          done < /tmp/candidate-numbers.txt
-
-      - name: Record implemented corrections in Unreleased changelog
-        if: steps.candidates.outputs.count != '0'
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          if [ ! -s /tmp/implemented-candidates.tsv ]; then
-            echo "No supported candidate was implemented; changelog remains unchanged."
-            exit 0
-          fi
           python3 - <<'PY'
+          import json
           import os
+          import re
+          from datetime import datetime, timezone
           from pathlib import Path
 
-          path = Path('CHANGELOG.md')
-          text = path.read_text(encoding='utf-8')
-          marker = '## [Unreleased]'
-          if text.count(marker) != 1:
-              raise SystemExit('CHANGELOG must contain exactly one Unreleased section')
-
-          issue_rows = []
-          for line in Path('/tmp/implemented-candidates.tsv').read_text(encoding='utf-8').splitlines():
-              issue, signature = line.split('\t', 1)
-              issue_rows.append((issue, signature))
-
-          entries = []
-          for issue, signature in issue_rows:
-              entry = (
-                  f"- Automated onboarding correction for `{signature}` from supported candidate "
-                  f"#{issue}, implemented by PR #{os.environ['PR_NUMBER']} (`{os.environ['PR_TITLE']}`)."
-              )
-              if entry not in text:
-                  entries.append(entry)
-          if not entries:
-              print('Changelog entries already present')
-              raise SystemExit(0)
-
-          start = text.index(marker) + len(marker)
-          next_release = text.find('\n---', start)
-          if next_release == -1:
-              raise SystemExit('CHANGELOG Unreleased section terminator not found')
-          section = text[start:next_release]
-          section = section.replace('_No unreleased changes._', '').rstrip()
-          heading = '### Improved'
-          if heading in section:
-              section = section.rstrip() + '\n' + '\n'.join(entries) + '\n\n'
-          else:
-              section = section.rstrip() + f"\n\n{heading}\n" + '\n'.join(entries) + '\n\n'
-          path.write_text(text[:start] + section + text[next_release:], encoding='utf-8')
+          text = os.environ.get("PR_TITLE", "") + "\n" + os.environ.get("PR_BODY", "")
+          patterns = [
+              r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)",
+              r"(?i)\bautomation[- ]candidate\s+#(\d+)",
+          ]
+          numbers = sorted({int(value) for pattern in patterns for value in re.findall(pattern, text)})
+          out = Path("reports/automation_candidates")
+          out.mkdir(parents=True, exist_ok=True)
+          payload = {
+              "schema": "stegverse.kv.automation-candidate-implementation-observation/v1",
+              "state": "MERGED_PR_REFERENCES_OBSERVED" if numbers else "NO_CANDIDATE_REFERENCES_OBSERVED",
+              "pull_request_number": int(os.environ["PR_NUMBER"]),
+              "pull_request_url": os.environ["PR_URL"],
+              "merge_sha": os.environ["MERGE_SHA"],
+              "referenced_candidate_numbers": numbers,
+              "candidate_support_state_resolved": False,
+              "candidate_lifecycle_mutation_performed": False,
+              "issue_mutation_performed": False,
+              "changelog_mutation_performed": False,
+              "repository_mutation_performed": False,
+              "workflow_dispatch_performed": False,
+              "release_authority": "NONE",
+              "credential_authority": "TV/TVC",
+              "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+              "canonical_next_transition": "NON_HOSTED_CANDIDATE_RECONCILIATION" if numbers else "NONE",
+              "authority_effect": "NONE",
+              "observed_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+          }
+          (out / "candidate-implementation-observation.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(payload, sort_keys=True))
           PY
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          if git diff --cached --quiet; then
-            echo "Changelog unchanged"
-          else
-            git commit -m "chore: record implemented automation candidate"
-            git push origin HEAD:main
-          fi
-
-      - name: Trigger candidate reconciliation
-        if: steps.candidates.outputs.count != '0'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run automation-candidate-lifecycle.yml
+      - name: Upload non-authorizing candidate observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: automation-candidate-implementation-observation-${{ github.run_id }}
+          path: reports/automation_candidates/candidate-implementation-observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -12,6 +12,7 @@ on:
       - "tools/test_clean_room_user_kv.py"
       - "tools/test_automation_contracts.py"
       - "tests/test_hosted_release_authority_retirement.py"
+      - "tests/test_hosted_candidate_authority_retirement.py"
       - "vault_template/**"
       - "automation/**"
       - "evidence/onboarding-friction/**"
@@ -76,6 +77,9 @@ jobs:
 
       - name: Validate hosted release authority retirement
         run: python3 -m unittest tests.test_hosted_release_authority_retirement -v
+
+      - name: Validate hosted candidate authority retirement
+        run: python3 -m unittest tests.test_hosted_candidate_authority_retirement -v
 
       - name: Rebuild release evidence
         run: |

--- a/AUTOMATION_CANDIDATE_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
+++ b/AUTOMATION_CANDIDATE_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
@@ -1,0 +1,69 @@
+# Automation Candidate Hosted Authority Retirement Mirror Handoff
+
+Updated: 2026-08-27
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #83
+Branch: `fix/automation-candidate-hosted-authority-83`
+State: CLAIMED_FOR_IMPLEMENTATION
+
+## Goal
+
+Convert the existing hosted automation-candidate implementation observer to validation/evidence transport only.
+
+## Live contradiction
+
+Current main `.github/workflows/automation-candidate-implementation.yml` has:
+
+```text
+actions: write
+contents: write
+issues: write
+GH_TOKEN <- github.token
+gh issue edit/comment
+CHANGELOG.md mutation
+git commit
+git push origin HEAD:main
+gh workflow run automation-candidate-lifecycle.yml
+```
+
+These are hosted control-plane/repository mutation behaviors and conflict with the current StegVerse boundary.
+
+## Required state
+
+```text
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+permissions: contents: read / pull-requests: read
+persist-credentials: false
+issue mutation: false
+repository mutation: false
+workflow dispatch: false
+credential/token consumption: false
+release authority: NONE
+authority_effect: NONE
+```
+
+The hosted workflow may deterministically parse candidate references from a merged PR and emit a non-secret observation artifact. It must not determine canonical candidate lifecycle state or mutate it.
+
+## Collision boundary
+
+- Do not create another candidate registry or lifecycle owner.
+- Do not change candidate threshold semantics.
+- Do not publish releases or update canonical CHANGELOG state from hosted execution.
+- Do not introduce TVC credentials into Actions.
+- Existing candidate lifecycle/reconciliation surfaces remain separate and must be audited under their own authority if still hosted-mutating.
+
+## Planned source
+
+- `.github/workflows/automation-candidate-implementation.yml`
+- `tools/test_automation_contracts.py`
+- `tests/test_hosted_release_authority_retirement.py` only if broad hosted mutation regression can be safely generalized
+- this handoff
+- root CVK handoff/status where materially required
+
+## Non-claims
+
+No candidate is implemented, reconciled, labeled, closed, released, deployed, or activated by this source repair.
+
+## Next executable boundary
+
+Replace hosted mutation with deterministic observation artifact generation, install fail-closed regression coverage, validate exact head, merge on green evidence, then continue audit of adjacent candidate lifecycle surfaces without duplicating ownership.

--- a/AUTOMATION_CANDIDATE_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
+++ b/AUTOMATION_CANDIDATE_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-08-27
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #83
 Branch: `fix/automation-candidate-hosted-authority-83`
-State: CLAIMED_FOR_IMPLEMENTATION
+State: IMPLEMENTED_ON_BRANCH_VALIDATION_PENDING
 
 ## Goal
 
@@ -64,6 +64,31 @@ The hosted workflow may deterministically parse candidate references from a merg
 
 No candidate is implemented, reconciled, labeled, closed, released, deployed, or activated by this source repair.
 
+## Implemented source state
+
+```text
+automation-candidate-implementation.yml:
+  name: Automation candidate implementation - Validation Only
+  contents: read
+  pull-requests: read
+  persist-credentials: false
+  candidate ID parsing: retained
+  issue status/label resolution: deferred
+  issue mutation: removed
+  CHANGELOG mutation: removed
+  git commit/push: removed
+  workflow dispatch: removed
+  github.token / GH_TOKEN: removed
+  artifact: candidate-implementation-observation.json
+  canonical_next_transition: NON_HOSTED_CANDIDATE_RECONCILIATION
+  authority_effect: NONE
+
+regression:
+  tools/test_automation_contracts.py rejects hosted mutation tokens
+  tests/test_hosted_candidate_authority_retirement.py enforces read-only validation boundary
+  release-integrity workflow executes the dedicated regression
+```
+
 ## Next executable boundary
 
-Replace hosted mutation with deterministic observation artifact generation, install fail-closed regression coverage, validate exact head, merge on green evidence, then continue audit of adjacent candidate lifecycle surfaces without duplicating ownership.
+Run exact-head hosted validation, repair any source/test defects without restoring hosted mutation authority, merge only after green evidence, then inspect adjacent candidate-lifecycle workflows separately. Candidate lifecycle state itself remains outside this hosted observer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 ### Security
 - retired GitHub-hosted release/publication and release-control-plane mutation authority from the CMC-022/CMC-023 workflow set
 - retired residual `release-integrity.yml` evidence writeback and `automated-release.yml` VERSION/changelog/tag/GitHub-release mutation authority; hosted release workflows now validate and transport non-secret evidence only
+- retired `automation-candidate-implementation.yml` hosted issue/repository/workflow-dispatch mutation authority; merged-PR candidate references are now emitted only as non-authorizing observation evidence
 - preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
 
 ### Notes

--- a/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -597,3 +597,22 @@ authority_effect: NONE
 ```
 
 This closes the residual `release-integrity.yml` and `automated-release.yml` hosted mutation/publication contradiction. The previous v0.1.9 publication remains the latest canonical release. Any successor release is now explicitly gated on admitted TV/TVC release runtime evidence.
+
+
+### Automation candidate hosted control-plane retirement — issue #83
+
+Live main inspection after CVK release-authority closure found `.github/workflows/automation-candidate-implementation.yml` still carrying hosted control-plane authority:
+
+```text
+actions: write
+contents: write
+issues: write
+github.token -> GH_TOKEN
+gh issue edit/comment
+CHANGELOG commit/push
+gh workflow run automation-candidate-lifecycle.yml
+```
+
+Issue #83 / branch `fix/automation-candidate-hosted-authority-83` is the sole bounded continuation for that surface. The branch preserves deterministic merged-PR candidate-reference parsing but converts output to a non-authorizing artifact and defers canonical lifecycle reconciliation to a non-hosted owner.
+
+This source repair is not candidate implementation, candidate lifecycle mutation, release publication, deployment, or activation.

--- a/tests/test_hosted_candidate_authority_retirement.py
+++ b/tests/test_hosted_candidate_authority_retirement.py
@@ -1,0 +1,44 @@
+"""Regression guards for hosted automation-candidate mutation retirement."""
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "automation-candidate-implementation.yml"
+
+
+class HostedCandidateAuthorityRetirementTests(unittest.TestCase):
+    def test_candidate_observer_is_read_only_validation_transport(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        for token in (
+            "contents: write",
+            "actions: write",
+            "issues: write",
+            "git push",
+            "git commit",
+            "gh issue ",
+            "gh workflow run",
+            "github.token",
+            "GH_TOKEN:",
+            "CHANGELOG.md",
+        ):
+            self.assertNotIn(token, text, token)
+        for token in (
+            "contents: read",
+            "pull-requests: read",
+            "persist-credentials: false",
+            "VALIDATION_TRANSPORT_ONLY",
+            "NON_HOSTED_CANDIDATE_RECONCILIATION",
+            "candidate_lifecycle_mutation_performed",
+            "issue_mutation_performed",
+            "changelog_mutation_performed",
+            "repository_mutation_performed",
+            "workflow_dispatch_performed",
+            "actions/upload-artifact@v4",
+            "authority_effect",
+            "NONE",
+        ):
+            self.assertIn(token, text, token)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_automation_contracts.py
+++ b/tools/test_automation_contracts.py
@@ -60,13 +60,15 @@ WORKFLOWS = {
         "evidence/onboarding-friction/candidates",
     },
     "automation-candidate-implementation.yml": {
+        "name: Automation candidate implementation - Validation Only",
         "pull_request:",
         "types: [closed]",
-        "candidate-supported",
-        "contents: write",
-        "Record implemented corrections in Unreleased changelog",
-        "CHANGELOG.md",
-        'git commit -m "chore: record implemented automation candidate"',
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_CANDIDATE_RECONCILIATION",
+        "candidate_lifecycle_mutation_performed",
+        "repository_mutation_performed",
+        "actions/upload-artifact@v4",
     },
 }
 
@@ -215,23 +217,43 @@ def validate_release_cycle_outcome() -> None:
     read_text(REPO_ROOT / "docs" / "release_evidence" / "latest_cycle.md")
 
 
-def validate_candidate_release_bridge() -> None:
+def validate_candidate_implementation_boundary() -> None:
     workflow = read_text(
         REPO_ROOT / ".github" / "workflows" / "automation-candidate-implementation.yml"
     )
-    required = {
-        "candidate-supported",
-        "candidate-implemented",
+    forbidden = {
+        "contents: write",
+        "actions: write",
+        "issues: write",
+        "git push",
+        "git commit",
+        "gh issue ",
+        "gh workflow run",
+        "github.token",
+        "GH_TOKEN:",
         "CHANGELOG.md",
-        "## [Unreleased]",
-        "Automated onboarding correction",
-        "git push origin HEAD:main",
+    }
+    present = sorted(token for token in forbidden if token in workflow)
+    if present:
+        fail("candidate implementation reintroduces hosted mutation authority: " + ", ".join(present))
+    required = {
+        "contents: read",
+        "pull-requests: read",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_CANDIDATE_RECONCILIATION",
+        "candidate_lifecycle_mutation_performed",
+        "issue_mutation_performed",
+        "changelog_mutation_performed",
+        "repository_mutation_performed",
+        "workflow_dispatch_performed",
+        "actions/upload-artifact@v4",
+        "authority_effect",
+        "NONE",
     }
     missing = sorted(token for token in required if token not in workflow)
     if missing:
-        fail("candidate implementation is not connected to release activation: " + ", ".join(missing))
-    if "[skip ci]" in workflow:
-        fail("candidate changelog commit must not suppress release-integrity validation")
+        fail("candidate implementation missing validation-only boundary tokens: " + ", ".join(missing))
 
 
 def validate_friction_registry() -> None:
@@ -329,7 +351,7 @@ def main() -> int:
         validate_release_cycle,
         validate_hosted_release_cycle_boundary,
         validate_release_cycle_outcome,
-        validate_candidate_release_bridge,
+        validate_candidate_implementation_boundary,
         validate_friction_registry,
         validate_issue_form,
         validate_threshold_consistency,


### PR DESCRIPTION
Closes issue #83.

Converts `.github/workflows/automation-candidate-implementation.yml` from hosted control-plane mutation to read-only validation/evidence transport.

Removed:
- actions/issues/contents write permissions;
- `github.token` / `GH_TOKEN` consumption;
- issue label/comment mutation;
- CHANGELOG commit/push;
- hosted workflow dispatch.

Retained:
- deterministic parsing of candidate references from merged PR metadata;
- non-secret observation artifact with explicit `NON_HOSTED_CANDIDATE_RECONCILIATION` next transition;
- no authority effect.

Regression enforcement is added to `tools/test_automation_contracts.py`, a dedicated unit test, and Release integrity. No candidate lifecycle state, release state, deployment, or activation is mutated by this PR.