### PR TITLE
Align KV runtime response hash with canonical consumer projection

### DIFF
--- a/KV_INTERLOCK_RUNTIME_ENDPOINT_MIRROR_HANDOFF.md
+++ b/KV_INTERLOCK_RUNTIME_ENDPOINT_MIRROR_HANDOFF.md
@@ -110,3 +110,15 @@ authority_effect: NONE
 ```
 
 Existing runtime ownership remains upstream/downstream coordinated through the sovereign resident execution lane and TV/TVC authority boundaries. No new resident worker, credential broker, or Site endpoint is authorized by this handoff.
+
+
+## 2026-08-27 response-hash compatibility repair
+
+Cross-repository inspection against the hosted-validated StegHealth `KV-INTERLOCK-v1` specialization exposed a source-level runtime compatibility defect: issue #79 computed `receipt.response_hash` over the full response including receipt metadata (with only `response_hash` removed), while the established StegHealth client verifies the canonical response payload projection.
+
+The runtime core is corrected to hash exactly:
+`schema_version`, `request_id`, `decision`, `granted_scope`, `context`, and `source_refs`.
+
+The protocol now states this projection explicitly, and the runtime test independently constructs the projection before comparing the digest. This is a compatibility repair only. It does not deploy the endpoint, establish boundary identity/sealing, grant credential or execution authority, mutate canonical KV state, or activate production runtime.
+
+State until hosted validation/merge: `IMPLEMENTED_AWAITING_HOSTED_VALIDATION`.

--- a/docs/KNOWLEDGEVAULT_INTERLOCK_PROTOCOL.md
+++ b/docs/KNOWLEDGEVAULT_INTERLOCK_PROTOCOL.md
@@ -165,6 +165,21 @@ The core enforces:
 
 This source implementation is not production activation. A live boundary identity/sealing service, actual runtime deployment, canonical owner/device readback, and real InTr receipts remain separate evidence gates.
 
+## Canonical response-hash projection
+
+For `kv.interlock.response.v1`, `receipt.response_hash` is the lowercase SHA-256 hex digest of canonical JSON over exactly this response projection:
+
+```text
+schema_version
+request_id
+decision
+granted_scope
+context
+source_refs
+```
+
+Receipt metadata is not part of the hashed response projection. This keeps the response hash deterministic, non-circular, and compatible with existing consumers such as the StegHealth specialization. Receipt identity, policy, authority, timestamp, and writeback-candidate references remain separately validated receipt fields.
+
 ---
 
 🔒 Layer: Framework | KV

--- a/runtime/kv_interlock_endpoint.py
+++ b/runtime/kv_interlock_endpoint.py
@@ -91,12 +91,15 @@ def _parse_time(value: str) -> datetime:
 
 
 def response_hash(response: dict[str, Any]) -> str:
-    value = copy.deepcopy(response)
-    receipt = value.get("receipt")
-    if not isinstance(receipt, dict):
-        raise KVInterlockRuntimeError("response receipt missing")
-    receipt.pop("response_hash", None)
-    return sha256_hex(value)
+    projection = {
+        "schema_version": response.get("schema_version"),
+        "request_id": response.get("request_id"),
+        "decision": response.get("decision"),
+        "granted_scope": response.get("granted_scope"),
+        "context": response.get("context"),
+        "source_refs": response.get("source_refs"),
+    }
+    return sha256_hex(projection)
 
 
 class KVInterlockRuntime:

--- a/tests/test_kv_interlock_runtime_endpoint.py
+++ b/tests/test_kv_interlock_runtime_endpoint.py
@@ -130,6 +130,15 @@ class KVInterlockRuntimeTests(unittest.TestCase):
         self.assertEqual(response["decision"], "ALLOW_BOUNDED_CONTEXT")
         self.assertEqual(set(response["context"]), set(response["granted_scope"]))
         self.assertEqual(response["receipt"]["authority_ref"], "owner-assertion-1")
+        projection = {
+            "schema_version": response["schema_version"],
+            "request_id": response["request_id"],
+            "decision": response["decision"],
+            "granted_scope": response["granted_scope"],
+            "context": response["context"],
+            "source_refs": response["source_refs"],
+        }
+        self.assertEqual(response["receipt"]["response_hash"], self.m.sha256_hex(projection))
         self.assertEqual(response["receipt"]["response_hash"], self.m.response_hash(response))
         self.assertEqual(len(self.receipts), 1)
         self.assertNotIn("password", self.m.canonical_json(response).lower())


### PR DESCRIPTION
Repairs the issue #79 runtime endpoint response_hash semantics to hash exactly schema_version, request_id, decision, granted_scope, context, and source_refs; documents that projection in the canonical protocol; and tests it independently. This is source compatibility only and does not deploy or activate the endpoint.