### PR TITLE
Record KV runtime hash compatibility closure

### DIFF
--- a/KNOWLEDGEVAULT_MODULE_INTEGRATIONS_MIRROR_HANDOFF.md
+++ b/KNOWLEDGEVAULT_MODULE_INTEGRATIONS_MIRROR_HANDOFF.md
@@ -341,3 +341,10 @@ live boundary identity/sealing: NOT OBSERVED
 canonical Site readback: NOT OBSERVED
 activation: false
 ```
+
+
+## KV runtime response-hash compatibility closure — 2026-08-27
+
+Issue #79 runtime response hashing is now explicitly aligned with the canonical consumer projection after PR `#86`, merge `1cb64044e9e10364f7ddb4b0ff514c1f06c3eac5`. The canonical projection is `schema_version`, `request_id`, `decision`, `granted_scope`, `context`, and `source_refs`.
+
+Source compatibility is **HOSTED_VALIDATED_MERGED**. Production endpoint deployment, verified live DEVICE→KV identity/sealing, durable production receipt-store binding, and owner/device activation remain separate open runtime gates.

--- a/KV_INTERLOCK_RUNTIME_ENDPOINT_MIRROR_HANDOFF.md
+++ b/KV_INTERLOCK_RUNTIME_ENDPOINT_MIRROR_HANDOFF.md
@@ -121,4 +121,16 @@ The runtime core is corrected to hash exactly:
 
 The protocol now states this projection explicitly, and the runtime test independently constructs the projection before comparing the digest. This is a compatibility repair only. It does not deploy the endpoint, establish boundary identity/sealing, grant credential or execution authority, mutate canonical KV state, or activate production runtime.
 
-State until hosted validation/merge: `IMPLEMENTED_AWAITING_HOSTED_VALIDATION`.
+State: `HOSTED_VALIDATED_MERGED`.
+
+Validation evidence:
+- PR `#86`;
+- exact head `e48bcc53e93c0f059a3e557a146e35dbe49097ce`;
+- Repository validation diagnostics run `33121047732`: PASS;
+- Validate KV Interlock Contract run `33121047747`: PASS;
+- KV Guardrails run `33121047902`: PASS;
+- Security Baseline run `33121047899`: PASS;
+- merge `1cb64044e9e10364f7ddb4b0ff514c1f06c3eac5`;
+- durable evidence `evidence/kv/2026-08-27-runtime-response-hash-compatibility-validation.json`.
+
+Production endpoint deployment and live boundary identity/sealing remain unobserved.

--- a/evidence/kv/2026-08-27-runtime-response-hash-compatibility-validation.json
+++ b/evidence/kv/2026-08-27-runtime-response-hash-compatibility-validation.json
@@ -1,0 +1,29 @@
+{
+  "schema": "stegverse.kv-interlock.runtime-response-hash-compatibility-evidence/v1",
+  "repository": "StegVerse-Labs/continuity-vault-kit",
+  "issue": 79,
+  "pull_request": 86,
+  "validation_head": "e48bcc53e93c0f059a3e557a146e35dbe49097ce",
+  "merge": "1cb64044e9e10364f7ddb4b0ff514c1f06c3eac5",
+  "runs": {
+    "repository_validation_diagnostics": 33121047732,
+    "kv_interlock_contract": 33121047747,
+    "kv_guardrails": 33121047902,
+    "security_baseline": 33121047899
+  },
+  "blobs": {
+    "runtime": "9c1de93e373fbfc6f7a6e9d1c7b7eaa61ac689a5",
+    "protocol": "d4b07228d5d5f128e8c6b901344e22f6d4b3b360"
+  },
+  "canonical_response_hash_projection": [
+    "schema_version",
+    "request_id",
+    "decision",
+    "granted_scope",
+    "context",
+    "source_refs"
+  ],
+  "state": "HOSTED_VALIDATED_MERGED",
+  "production_endpoint_deployed": false,
+  "authority_effect": "NONE"
+}


### PR DESCRIPTION
Records durable evidence for PR #86 and reconciles the runtime endpoint/module handoffs from awaiting validation to HOSTED_VALIDATED_MERGED. Production endpoint deployment and live identity/sealing remain explicitly open.