### PR TITLE
Add governed KnowledgeVault email ingress contract

### DIFF
--- a/.github/workflows/validate-kv-email-ingress-policy.yml
+++ b/.github/workflows/validate-kv-email-ingress-policy.yml
@@ -20,6 +20,8 @@ on:
       - "specs/kv-email-ingress-policy.v1.json"
       - "tools/check_kv_email_ingress_policy.py"
       - "tests/test_kv_email_ingress_policy.py"
+      - "runtime/email_continuity.py"
+      - "tests/test_email_continuity_runtime.py"
 
 permissions:
   contents: read

--- a/.github/workflows/validate-kv-email-ingress-policy.yml
+++ b/.github/workflows/validate-kv-email-ingress-policy.yml
@@ -1,0 +1,34 @@
+name: Validate KV Email Ingress Policy
+
+on:
+  pull_request:
+    paths:
+      - "schemas/kv-email-ingress-policy.schema.json"
+      - "specs/kv-email-ingress-policy.v1.json"
+      - "tools/check_kv_email_ingress_policy.py"
+      - "tests/test_kv_email_ingress_policy.py"
+      - "KV_EMAIL_INGRESS_MIRROR_HANDOFF.md"
+      - ".github/workflows/validate-kv-email-ingress-policy.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/kv-email-ingress-policy.schema.json"
+      - "specs/kv-email-ingress-policy.v1.json"
+      - "tools/check_kv_email_ingress_policy.py"
+      - "tests/test_kv_email_ingress_policy.py"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate canonical policy
+        run: python tools/check_kv_email_ingress_policy.py
+      - name: Run deterministic tests
+        run: python -m unittest tests.test_kv_email_ingress_policy -v

--- a/.github/workflows/validate-kv-email-ingress-policy.yml
+++ b/.github/workflows/validate-kv-email-ingress-policy.yml
@@ -4,15 +4,19 @@ on:
   pull_request:
     paths:
       - "schemas/kv-email-ingress-policy.schema.json"
+      - "schemas/kv-email-account-mapping.schema.json"
       - "specs/kv-email-ingress-policy.v1.json"
       - "tools/check_kv_email_ingress_policy.py"
       - "tests/test_kv_email_ingress_policy.py"
+      - "runtime/email_continuity.py"
+      - "tests/test_email_continuity_runtime.py"
       - "KV_EMAIL_INGRESS_MIRROR_HANDOFF.md"
       - ".github/workflows/validate-kv-email-ingress-policy.yml"
   push:
     branches: [main]
     paths:
       - "schemas/kv-email-ingress-policy.schema.json"
+      - "schemas/kv-email-account-mapping.schema.json"
       - "specs/kv-email-ingress-policy.v1.json"
       - "tools/check_kv_email_ingress_policy.py"
       - "tests/test_kv_email_ingress_policy.py"
@@ -31,4 +35,4 @@ jobs:
       - name: Validate canonical policy
         run: python tools/check_kv_email_ingress_policy.py
       - name: Run deterministic tests
-        run: python -m unittest tests.test_kv_email_ingress_policy -v
+        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime -v

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -1,0 +1,129 @@
+# KV Governed Email Ingress Mirror Handoff
+
+Status: SOURCE_READY_VALIDATION_PENDING  
+Repository: StegVerse-Labs/continuity-vault-kit  
+Branch: `kv-governed-email-ingress`  
+Updated: 2026-08-27
+
+## Purpose
+
+Extend the already-installed `email-continuity` Personal Services slot into a governed mailbox-ingress capability without claiming provider, credential, Interlock, network, or runtime activation.
+
+This lane implements the canonical rule:
+
+```text
+Mailbox
+ -> authenticated provider session
+ -> pre-admission staging
+ -> governance evaluation
+ -> ADMIT | QUARANTINE | REVIEW | REJECT | FAIL_CLOSED
+ -> trusted KnowledgeVault projection only after ADMIT
+ -> governance receipt
+```
+
+## Existing source of truth
+
+Parent handoffs:
+
+- `CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`
+- `KV_PERSONAL_SERVICES_MIRROR_HANDOFF.md`
+- `KNOWLEDGEVAULT_MODULE_INTEGRATIONS_MIRROR_HANDOFF.md`
+- `KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md`
+
+The `email-continuity` slot already exists under the 33-service Personal Services registry as `KV_DEVICE_PROVIDER` and remains `INSTALLED_INACTIVE`.
+
+## Implemented in this lane
+
+- `schemas/kv-email-ingress-policy.schema.json`
+- `specs/kv-email-ingress-policy.v1.json`
+- `tools/check_kv_email_ingress_policy.py`
+- `tests/test_kv_email_ingress_policy.py`
+- `.github/workflows/validate-kv-email-ingress-policy.yml`
+
+## Governance invariants
+
+1. Entering an email address does not itself activate a mailbox.
+2. Provider authorization is required before mailbox access.
+3. Reusable plaintext passwords/secrets are not stored as ordinary KV content.
+4. Mail is staged before admission and is not trusted KV knowledge while staged.
+5. Ambiguous admission fails closed.
+6. Canonical decisions are exactly:
+   - `ADMIT`
+   - `QUARANTINE`
+   - `REVIEW`
+   - `REJECT`
+   - `FAIL_CLOSED`
+7. Only `ADMIT` promotes a message into trusted KV content.
+8. Spam, abuse, phishing/malware, sender/domain restrictions, attachment restrictions, and user-defined rules may block or divert admission.
+9. Every evaluation produces a governance receipt.
+10. Rejected payloads are not retained by default; a minimal rejection receipt may remain.
+11. This policy grants no identity, provider, credential, governance, execution, or network authority.
+
+## Intended user experience
+
+```text
+My KV
+ -> Email
+ -> Connect Email
+ -> enter address
+ -> provider discovery
+ -> authorize provider session
+ -> choose/default ingress governance
+ -> mailbox mapped to email-continuity
+ -> governed messages become reviewable within KV
+```
+
+Provider-specific authorization and transport adapters must conform to this provider-neutral contract rather than redefining admission semantics.
+
+## Activation predicates
+
+The service must remain `INSTALLED_INACTIVE` / source-ready until all applicable predicates are proven with real owner-authorized activity:
+
+1. hosted source validation passes on the exact implementation head;
+2. provider discovery resolves a supported mailbox route;
+3. user authorizes a real provider session;
+4. credential/session material remains outside ordinary KV plaintext state;
+5. a real inbound message enters staging without becoming trusted KV content;
+6. at least one real `ADMIT` path is observed and receipt-linked;
+7. at least one non-admit path (`REJECT`, `QUARANTINE`, or `REVIEW`) is observed and receipt-linked;
+8. ambiguous or unavailable governance proves `FAIL_CLOSED`;
+9. admitted mail is projected into the intended semantic KV surfaces and can be reviewed;
+10. disconnect/reconnect or interruption recovery reconciles without duplicate trusted admission;
+11. provider/session revocation blocks subsequent mailbox access;
+12. live evidence distinguishes provider receipt, governance receipt, and KV persistence receipt.
+
+## Remaining machine-execution work
+
+- validate this branch through hosted CI;
+- reconcile the Personal Services registry entry with this more precise ingress contract if validation passes;
+- implement provider adapter discovery/auth/session interfaces;
+- implement staged message normalization and canonical message identifiers;
+- implement governed admission/quarantine projection;
+- implement receipt/replay/reconciliation behavior;
+- expose the bounded service through the applicable KV/Interlock runtime;
+- perform real owner-authorized mailbox activation proof;
+- only then change runtime state from inactive/source-ready.
+
+## Non-claims
+
+Current source work does not claim:
+
+- a mailbox is connected;
+- any user email has been read;
+- Gmail, Outlook, IMAP, or another provider has been activated;
+- provider credentials are installed;
+- Interlock/InTr is activated;
+- spam/phishing classification quality is production-proven;
+- mail delivery or sending authority exists;
+- live KV email review is active.
+
+## Release / downstream propagation gate
+
+When this lane becomes validated and release-worthy, verify pertinent contract/state propagation to:
+
+- StegVerse-Labs/Site;
+- GCAT-BCAT-Engine/Publisher;
+- admissibility-wiki;
+- stegguardian-wiki.
+
+Do not propagate an activation claim before live provider and KV evidence exists.

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -44,20 +44,22 @@ The `email-continuity` slot already exists under the 33-service Personal Service
 
 1. Entering an email address does not itself activate a mailbox.
 2. Provider authorization is required before mailbox access.
-3. Reusable plaintext passwords/secrets are not stored as ordinary KV content.
-4. Mail is staged before admission and is not trusted KV knowledge while staged.
-5. Ambiguous admission fails closed.
-6. Canonical decisions are exactly:
+3. Once the mailbox address/provider route is mapped, the user should be prompted to complete the capability by placing the required credential or provider secret in SKAP Vault.
+4. KnowledgeVault stores only the bounded credential reference/binding needed to request governed use; it does not store the mailbox secret itself.
+5. Reusable plaintext passwords/secrets are not stored as ordinary KV content.
+6. Mail is staged before admission and is not trusted KV knowledge while staged.
+7. Ambiguous admission fails closed.
+8. Canonical decisions are exactly:
    - `ADMIT`
    - `QUARANTINE`
    - `REVIEW`
    - `REJECT`
    - `FAIL_CLOSED`
-7. Only `ADMIT` promotes a message into trusted KV content.
-8. Spam, abuse, phishing/malware, sender/domain restrictions, attachment restrictions, and user-defined rules may block or divert admission.
-9. Every evaluation produces a governance receipt.
-10. Rejected payloads are not retained by default; a minimal rejection receipt may remain.
-11. This policy grants no identity, provider, credential, governance, execution, or network authority.
+9. Only `ADMIT` promotes a message into trusted KV content.
+10. Spam, abuse, phishing/malware, sender/domain restrictions, attachment restrictions, and user-defined rules may block or divert admission.
+11. Every evaluation produces a governance receipt.
+12. Rejected payloads are not retained by default; a minimal rejection receipt may remain.
+13. This policy grants no identity, provider, credential, governance, execution, or network authority.
 
 ## Intended user experience
 
@@ -66,7 +68,10 @@ My KV
  -> Email
  -> Connect Email
  -> enter address
- -> provider discovery
+ -> provider discovery and mailbox mapping
+ -> prompt: Complete setup in SKAP Vault
+ -> user enters/authorizes required credential in SKAP Vault
+ -> KV receives bounded credential reference / provider-session proof
  -> authorize provider session
  -> choose/default ingress governance
  -> mailbox mapped to email-continuity
@@ -81,22 +86,25 @@ The service must remain `INSTALLED_INACTIVE` / source-ready until all applicable
 
 1. hosted source validation passes on the exact implementation head;
 2. provider discovery resolves a supported mailbox route;
-3. user authorizes a real provider session;
-4. credential/session material remains outside ordinary KV plaintext state;
-5. a real inbound message enters staging without becoming trusted KV content;
-6. at least one real `ADMIT` path is observed and receipt-linked;
-7. at least one non-admit path (`REJECT`, `QUARANTINE`, or `REVIEW`) is observed and receipt-linked;
-8. ambiguous or unavailable governance proves `FAIL_CLOSED`;
-9. admitted mail is projected into the intended semantic KV surfaces and can be reviewed;
-10. disconnect/reconnect or interruption recovery reconciles without duplicate trusted admission;
-11. provider/session revocation blocks subsequent mailbox access;
-12. live evidence distinguishes provider receipt, governance receipt, and KV persistence receipt.
+3. after mailbox mapping, the user is explicitly directed to complete credential setup in SKAP Vault;
+4. the required credential/secret is present behind SKAP Vault and only a bounded reference/session proof is exposed to KV;
+5. user authorizes a real provider session;
+6. credential/session material remains outside ordinary KV plaintext state;
+7. a real inbound message enters staging without becoming trusted KV content;
+8. at least one real `ADMIT` path is observed and receipt-linked;
+9. at least one non-admit path (`REJECT`, `QUARANTINE`, or `REVIEW`) is observed and receipt-linked;
+10. ambiguous or unavailable governance proves `FAIL_CLOSED`;
+11. admitted mail is projected into the intended semantic KV surfaces and can be reviewed;
+12. disconnect/reconnect or interruption recovery reconciles without duplicate trusted admission;
+13. provider/session or SKAP credential revocation blocks subsequent mailbox access;
+14. live evidence distinguishes SKAP credential reference/session proof, provider receipt, governance receipt, and KV persistence receipt.
 
 ## Remaining machine-execution work
 
 - validate this branch through hosted CI;
 - reconcile the Personal Services registry entry with this more precise ingress contract if validation passes;
 - implement provider adapter discovery/auth/session interfaces;
+- implement post-mapping SKAP Vault completion prompt and bounded credential-reference binding;
 - implement staged message normalization and canonical message identifiers;
 - implement governed admission/quarantine projection;
 - implement receipt/replay/reconciliation behavior;

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -39,6 +39,9 @@ The `email-continuity` slot already exists under the 33-service Personal Service
 - `tools/check_kv_email_ingress_policy.py`
 - `tests/test_kv_email_ingress_policy.py`
 - `.github/workflows/validate-kv-email-ingress-policy.yml`
+- `schemas/kv-email-account-mapping.schema.json`
+- `runtime/email_continuity.py`
+- `tests/test_email_continuity_runtime.py`
 
 ## Governance invariants
 
@@ -80,6 +83,27 @@ My KV
 
 Provider-specific authorization and transport adapters must conform to this provider-neutral contract rather than redefining admission semantics.
 
+## Provider-neutral mapping runtime
+
+The source lane now includes a deterministic provider-neutral account-mapping runtime:
+
+```text
+MAPPED_CREDENTIAL_REQUIRED
+ -> CREDENTIAL_BOUND
+ -> SESSION_VERIFIED
+ -> REVOKED
+```
+
+Properties:
+
+- mailbox mapping ID is deterministically derived from normalized email address;
+- provider identity/route are recorded without granting provider authority;
+- mapping completion explicitly requires a `skap://` credential reference;
+- raw password/token/app-password fields are rejected from KV mapping payloads;
+- session verification is impossible until the SKAP reference is bound;
+- revoked mappings cannot be rebound without creating a new authorized mapping flow;
+- this runtime does not itself authenticate to a provider or read mailbox contents.
+
 ## Activation predicates
 
 The service must remain `INSTALLED_INACTIVE` / source-ready until all applicable predicates are proven with real owner-authorized activity:
@@ -103,8 +127,8 @@ The service must remain `INSTALLED_INACTIVE` / source-ready until all applicable
 
 - validate this branch through hosted CI;
 - reconcile the Personal Services registry entry with this more precise ingress contract if validation passes;
-- implement provider adapter discovery/auth/session interfaces;
-- implement post-mapping SKAP Vault completion prompt and bounded credential-reference binding;
+- implement concrete provider adapter discovery/auth/session interfaces around the provider-neutral mapping contract;
+- implement the user-facing post-mapping SKAP Vault completion prompt around the now-implemented bounded credential-reference binding;
 - implement staged message normalization and canonical message identifiers;
 - implement governed admission/quarantine projection;
 - implement receipt/replay/reconciliation behavior;

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Governed Email Ingress Mirror Handoff
 
-Status: SOURCE_READY_VALIDATION_PENDING  
+Status: SOURCE_READY_VALIDATED_MERGE_PENDING  
 Repository: StegVerse-Labs/continuity-vault-kit  
 Branch: `kv-governed-email-ingress`  
 Updated: 2026-08-27
@@ -103,6 +103,24 @@ Properties:
 - session verification is impossible until the SKAP reference is bound;
 - revoked mappings cannot be rebound without creating a new authorized mapping flow;
 - this runtime does not itself authenticate to a provider or read mailbox contents.
+
+## Hosted validation evidence
+
+Validated implementation head before handoff reconciliation:
+
+`c9b1dd040d0ee9bc28f9be235322c27214e31431`
+
+Hosted results:
+
+- Validate KV Email Ingress Policy run `33135794760`: PASS
+- Security Baseline run `33135794754`: PASS
+- Repository validation diagnostics run `33135794779`: PASS
+- Release integrity run `33135794783`: PASS
+- KV Guardrails run `33135794789`: PASS
+
+The KV Guardrails lane initially exposed a nondeterministic tamper-test construction: changing the final unpadded Base64 character could alter only unused padding bits and decode to the original ciphertext. The test was repaired to mutate the first encoded ciphertext character, guaranteeing changed authenticated ciphertext. The repaired exact-head guardrail run passed all SKAP cryptographic, browser ingress, rotation/revocation, TVC key-provider, InTr persistence, reconstruction, and non-authorizing validation steps.
+
+This evidence proves source/runtime-contract behavior only. It does not prove a live mailbox/provider session.
 
 ## Activation predicates
 

--- a/runtime/email_continuity.py
+++ b/runtime/email_continuity.py
@@ -1,0 +1,99 @@
+"""Provider-neutral KnowledgeVault email mapping and SKAP credential binding.
+
+This module does not authenticate to any mail provider and does not read mail.
+It creates deterministic mailbox mappings, requires a SKAP Vault credential
+reference before session verification, and never accepts raw credential material.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, asdict
+from email.utils import parseaddr
+
+
+class EmailMappingError(ValueError):
+    pass
+
+
+def _normalize_email(value: str) -> str:
+    _, address = parseaddr(value)
+    address = address.strip().lower()
+    if not address or "@" not in address or address.startswith("@") or address.endswith("@"):
+        raise EmailMappingError("valid email address required")
+    local, domain = address.rsplit("@", 1)
+    if not local or "." not in domain:
+        raise EmailMappingError("valid routable email address required")
+    return address
+
+
+def mapping_id_for(email_address: str) -> str:
+    normalized = _normalize_email(email_address)
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return f"kv-email:{digest}"
+
+
+@dataclass(frozen=True)
+class EmailAccountMapping:
+    schema: str
+    mapping_id: str
+    email_address: str
+    provider_id: str
+    provider_route: str
+    mapping_state: str
+    skap_credential_ref: str | None
+    credential_secret_present_in_kv: bool
+    authority_effect: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def create_mapping(*, email_address: str, provider_id: str, provider_route: str) -> EmailAccountMapping:
+    normalized = _normalize_email(email_address)
+    if not provider_id.strip() or not provider_route.strip():
+        raise EmailMappingError("provider_id and provider_route are required")
+    return EmailAccountMapping(
+        schema="stegverse.kv.email-account-mapping/v1",
+        mapping_id=mapping_id_for(normalized),
+        email_address=normalized,
+        provider_id=provider_id.strip(),
+        provider_route=provider_route.strip(),
+        mapping_state="MAPPED_CREDENTIAL_REQUIRED",
+        skap_credential_ref=None,
+        credential_secret_present_in_kv=False,
+        authority_effect="NONE",
+    )
+
+
+def bind_skap_credential(mapping: EmailAccountMapping, *, skap_credential_ref: str) -> EmailAccountMapping:
+    if mapping.mapping_state not in {"MAPPED_CREDENTIAL_REQUIRED", "CREDENTIAL_BOUND"}:
+        raise EmailMappingError("SKAP credential binding is not allowed in current mapping state")
+    ref = skap_credential_ref.strip()
+    if not ref.startswith("skap://"):
+        raise EmailMappingError("credential reference must use skap://")
+    return EmailAccountMapping(
+        **{
+            **mapping.to_dict(),
+            "mapping_state": "CREDENTIAL_BOUND",
+            "skap_credential_ref": ref,
+            "credential_secret_present_in_kv": False,
+        }
+    )
+
+
+def mark_session_verified(mapping: EmailAccountMapping) -> EmailAccountMapping:
+    if mapping.mapping_state != "CREDENTIAL_BOUND" or not mapping.skap_credential_ref:
+        raise EmailMappingError("verified provider session requires bound SKAP credential reference")
+    return EmailAccountMapping(**{**mapping.to_dict(), "mapping_state": "SESSION_VERIFIED"})
+
+
+def revoke_mapping(mapping: EmailAccountMapping) -> EmailAccountMapping:
+    return EmailAccountMapping(**{**mapping.to_dict(), "mapping_state": "REVOKED"})
+
+
+def assert_no_secret_fields(payload: dict) -> None:
+    forbidden = {"password", "secret", "token", "access_token", "refresh_token", "app_password"}
+    present = forbidden.intersection({str(k).lower() for k in payload})
+    if present:
+        raise EmailMappingError(f"raw credential material prohibited in KV mapping: {sorted(present)}")

--- a/schemas/kv-email-account-mapping.schema.json
+++ b/schemas/kv-email-account-mapping.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-email-account-mapping.schema.json",
+  "title": "KnowledgeVault Email Account Mapping",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "mapping_id",
+    "email_address",
+    "provider_id",
+    "provider_route",
+    "mapping_state",
+    "skap_credential_ref",
+    "credential_secret_present_in_kv",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.kv.email-account-mapping/v1"},
+    "mapping_id": {"type": "string", "pattern": "^kv-email:[a-f0-9]{64}$"},
+    "email_address": {"type": "string", "format": "email"},
+    "provider_id": {"type": "string", "minLength": 1},
+    "provider_route": {"type": "string", "minLength": 1},
+    "mapping_state": {"enum": ["MAPPED_CREDENTIAL_REQUIRED", "CREDENTIAL_BOUND", "SESSION_VERIFIED", "REVOKED"]},
+    "skap_credential_ref": {"type": ["string", "null"]},
+    "credential_secret_present_in_kv": {"const": false},
+    "authority_effect": {"const": "NONE"}
+  }
+}

--- a/schemas/kv-email-ingress-policy.schema.json
+++ b/schemas/kv-email-ingress-policy.schema.json
@@ -10,6 +10,7 @@
     "state",
     "authority_effect",
     "provider_session",
+    "skap_credential_binding",
     "staging",
     "governance",
     "admission",
@@ -28,6 +29,17 @@
         "authorization_required": {"const": true},
         "credential_storage": {"const": "REFERENCE_ONLY_NO_PLAINTEXT_SECRETS"},
         "provider_neutral": {"const": true}
+      }
+    },
+    "skap_credential_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required_for_activation", "vault", "kv_stores_secret", "user_prompt_after_mapping"],
+      "properties": {
+        "required_for_activation": {"const": true},
+        "vault": {"const": "SKAP_VAULT"},
+        "kv_stores_secret": {"const": false},
+        "user_prompt_after_mapping": {"const": true}
       }
     },
     "staging": {

--- a/schemas/kv-email-ingress-policy.schema.json
+++ b/schemas/kv-email-ingress-policy.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-email-ingress-policy.schema.json",
+  "title": "StegVerse KnowledgeVault Governed Email Ingress Policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "service_id",
+    "state",
+    "authority_effect",
+    "provider_session",
+    "staging",
+    "governance",
+    "admission",
+    "receipt"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.kv.email-ingress-policy/v1"},
+    "service_id": {"const": "email-continuity"},
+    "state": {"enum": ["INSTALLED_INACTIVE", "SOURCE_READY", "ACTIVATION_PENDING", "ACTIVE"]},
+    "authority_effect": {"const": "NONE"},
+    "provider_session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authorization_required", "credential_storage", "provider_neutral"],
+      "properties": {
+        "authorization_required": {"const": true},
+        "credential_storage": {"const": "REFERENCE_ONLY_NO_PLAINTEXT_SECRETS"},
+        "provider_neutral": {"const": true}
+      }
+    },
+    "staging": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "trusted_kv_content_before_decision"],
+      "properties": {
+        "required": {"const": true},
+        "trusted_kv_content_before_decision": {"const": false}
+      }
+    },
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["default_on_ambiguity", "rules"],
+      "properties": {
+        "default_on_ambiguity": {"const": "FAIL_CLOSED"},
+        "rules": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["rule_id", "enabled", "action"],
+            "properties": {
+              "rule_id": {"type": "string", "minLength": 1},
+              "enabled": {"type": "boolean"},
+              "action": {"enum": ["ADMIT", "QUARANTINE", "REVIEW", "REJECT", "FAIL_CLOSED"]},
+              "match": {"type": "object"}
+            }
+          }
+        }
+      }
+    },
+    "admission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed_decisions", "trusted_content_decision"],
+      "properties": {
+        "allowed_decisions": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"enum": ["ADMIT", "QUARANTINE", "REVIEW", "REJECT", "FAIL_CLOSED"]}
+        },
+        "trusted_content_decision": {"const": "ADMIT"}
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required_for_every_evaluation", "retain_rejected_payload"],
+      "properties": {
+        "required_for_every_evaluation": {"const": true},
+        "retain_rejected_payload": {"const": false}
+      }
+    }
+  }
+}

--- a/specs/kv-email-ingress-policy.v1.json
+++ b/specs/kv-email-ingress-policy.v1.json
@@ -1,0 +1,75 @@
+{
+  "schema": "stegverse.kv.email-ingress-policy/v1",
+  "service_id": "email-continuity",
+  "state": "SOURCE_READY",
+  "authority_effect": "NONE",
+  "provider_session": {
+    "authorization_required": true,
+    "credential_storage": "REFERENCE_ONLY_NO_PLAINTEXT_SECRETS",
+    "provider_neutral": true
+  },
+  "staging": {
+    "required": true,
+    "trusted_kv_content_before_decision": false
+  },
+  "governance": {
+    "default_on_ambiguity": "FAIL_CLOSED",
+    "rules": [
+      {
+        "rule_id": "known-spam-reject",
+        "enabled": true,
+        "action": "REJECT",
+        "match": {
+          "signal": "spam_or_bulk_abuse",
+          "threshold": "provider_or_stegverse_high_confidence"
+        }
+      },
+      {
+        "rule_id": "malware-phishing-quarantine",
+        "enabled": true,
+        "action": "QUARANTINE",
+        "match": {
+          "signal": "phishing_malware_or_dangerous_attachment"
+        }
+      },
+      {
+        "rule_id": "user-denylist-reject",
+        "enabled": true,
+        "action": "REJECT",
+        "match": {
+          "signal": "sender_or_domain_user_denylist"
+        }
+      },
+      {
+        "rule_id": "restricted-content-review",
+        "enabled": true,
+        "action": "REVIEW",
+        "match": {
+          "signal": "user_defined_restriction_requires_review"
+        }
+      },
+      {
+        "rule_id": "ordinary-mail-admit",
+        "enabled": true,
+        "action": "ADMIT",
+        "match": {
+          "signal": "passes_active_ingress_governance"
+        }
+      }
+    ]
+  },
+  "admission": {
+    "allowed_decisions": [
+      "ADMIT",
+      "QUARANTINE",
+      "REVIEW",
+      "REJECT",
+      "FAIL_CLOSED"
+    ],
+    "trusted_content_decision": "ADMIT"
+  },
+  "receipt": {
+    "required_for_every_evaluation": true,
+    "retain_rejected_payload": false
+  }
+}

--- a/specs/kv-email-ingress-policy.v1.json
+++ b/specs/kv-email-ingress-policy.v1.json
@@ -8,6 +8,12 @@
     "credential_storage": "REFERENCE_ONLY_NO_PLAINTEXT_SECRETS",
     "provider_neutral": true
   },
+  "skap_credential_binding": {
+    "required_for_activation": true,
+    "vault": "SKAP_VAULT",
+    "kv_stores_secret": false,
+    "user_prompt_after_mapping": true
+  },
   "staging": {
     "required": true,
     "trusted_kv_content_before_decision": false

--- a/specs/kv-personal-services-registry.v1.json
+++ b/specs/kv-personal-services-registry.v1.json
@@ -89,6 +89,7 @@
       ],
       "provider_dependency": "EXTERNAL_MAIL_PROVIDER",
       "activation_requires": [
+        "mapped mailbox identity followed by user-directed SKAP Vault credential setup",
         "verified provider session",
         "governed inbound staging/admission per stegverse.kv.email-ingress-policy/v1",
         "Interlock minimum-disclosure/send admission"

--- a/specs/kv-personal-services-registry.v1.json
+++ b/specs/kv-personal-services-registry.v1.json
@@ -90,6 +90,7 @@
       "provider_dependency": "EXTERNAL_MAIL_PROVIDER",
       "activation_requires": [
         "verified provider session",
+        "governed inbound staging/admission per stegverse.kv.email-ingress-policy/v1",
         "Interlock minimum-disclosure/send admission"
       ],
       "authority_effect": "NONE"

--- a/tests/test_email_continuity_runtime.py
+++ b/tests/test_email_continuity_runtime.py
@@ -1,0 +1,85 @@
+import unittest
+
+from runtime.email_continuity import (
+    EmailMappingError,
+    assert_no_secret_fields,
+    bind_skap_credential,
+    create_mapping,
+    mapping_id_for,
+    mark_session_verified,
+    revoke_mapping,
+)
+
+
+class EmailContinuityRuntimeTests(unittest.TestCase):
+    def test_mapping_is_deterministic_and_requires_skap(self):
+        mapping = create_mapping(
+            email_address="User@Example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        self.assertEqual(mapping.email_address, "user@example.com")
+        self.assertEqual(mapping.mapping_id, mapping_id_for("user@example.com"))
+        self.assertEqual(mapping.mapping_state, "MAPPED_CREDENTIAL_REQUIRED")
+        self.assertIsNone(mapping.skap_credential_ref)
+        self.assertFalse(mapping.credential_secret_present_in_kv)
+        self.assertEqual(mapping.authority_effect, "NONE")
+
+    def test_skap_binding_moves_to_credential_bound(self):
+        mapping = create_mapping(
+            email_address="user@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        bound = bind_skap_credential(mapping, skap_credential_ref="skap://Mail/example/user")
+        self.assertEqual(bound.mapping_state, "CREDENTIAL_BOUND")
+        self.assertEqual(bound.skap_credential_ref, "skap://Mail/example/user")
+        self.assertFalse(bound.credential_secret_present_in_kv)
+
+    def test_session_cannot_be_verified_without_skap_binding(self):
+        mapping = create_mapping(
+            email_address="user@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        with self.assertRaises(EmailMappingError):
+            mark_session_verified(mapping)
+
+    def test_session_verification_requires_only_reference(self):
+        mapping = create_mapping(
+            email_address="user@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        bound = bind_skap_credential(mapping, skap_credential_ref="skap://Mail/example/user")
+        verified = mark_session_verified(bound)
+        self.assertEqual(verified.mapping_state, "SESSION_VERIFIED")
+        self.assertFalse(verified.credential_secret_present_in_kv)
+
+    def test_raw_secret_fields_are_rejected(self):
+        for key in ("password", "secret", "token", "access_token", "refresh_token", "app_password"):
+            with self.subTest(key=key), self.assertRaises(EmailMappingError):
+                assert_no_secret_fields({key: "synthetic"})
+
+    def test_non_skap_reference_rejected(self):
+        mapping = create_mapping(
+            email_address="user@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        with self.assertRaises(EmailMappingError):
+            bind_skap_credential(mapping, skap_credential_ref="kv://secret")
+
+    def test_revoked_mapping_cannot_be_rebound(self):
+        mapping = create_mapping(
+            email_address="user@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        revoked = revoke_mapping(mapping)
+        with self.assertRaises(EmailMappingError):
+            bind_skap_credential(revoked, skap_credential_ref="skap://Mail/example/user")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kv_email_ingress_policy.py
+++ b/tests/test_kv_email_ingress_policy.py
@@ -1,0 +1,49 @@
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from tools.check_kv_email_ingress_policy import load_policy, validate
+
+
+class EmailIngressPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.policy = load_policy()
+
+    def test_canonical_policy_passes(self):
+        self.assertEqual(validate(self.policy), [])
+
+    def test_plaintext_credentials_fail(self):
+        policy = copy.deepcopy(self.policy)
+        policy["provider_session"]["credential_storage"] = "PLAINTEXT_PASSWORD"
+        self.assertTrue(any("plaintext" in error for error in validate(policy)))
+
+    def test_pre_admission_trust_fails(self):
+        policy = copy.deepcopy(self.policy)
+        policy["staging"]["trusted_kv_content_before_decision"] = True
+        self.assertTrue(any("trusted KV content" in error for error in validate(policy)))
+
+    def test_ambiguity_must_fail_closed(self):
+        policy = copy.deepcopy(self.policy)
+        policy["governance"]["default_on_ambiguity"] = "ADMIT"
+        self.assertTrue(any("fail closed" in error for error in validate(policy)))
+
+    def test_only_admit_promotes_trusted_content(self):
+        policy = copy.deepcopy(self.policy)
+        policy["admission"]["trusted_content_decision"] = "REVIEW"
+        self.assertTrue(any("only ADMIT" in error for error in validate(policy)))
+
+    def test_every_evaluation_requires_receipt(self):
+        policy = copy.deepcopy(self.policy)
+        policy["receipt"]["required_for_every_evaluation"] = False
+        self.assertTrue(any("requires a governance receipt" in error for error in validate(policy)))
+
+    def test_rejected_payload_retention_fails(self):
+        policy = copy.deepcopy(self.policy)
+        policy["receipt"]["retain_rejected_payload"] = True
+        self.assertTrue(any("must not be retained" in error for error in validate(policy)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kv_email_ingress_policy.py
+++ b/tests/test_kv_email_ingress_policy.py
@@ -19,6 +19,21 @@ class EmailIngressPolicyTests(unittest.TestCase):
         policy["provider_session"]["credential_storage"] = "PLAINTEXT_PASSWORD"
         self.assertTrue(any("plaintext" in error for error in validate(policy)))
 
+    def test_skap_vault_is_required_for_activation(self):
+        policy = copy.deepcopy(self.policy)
+        policy["skap_credential_binding"]["required_for_activation"] = False
+        self.assertTrue(any("SKAP Vault" in error for error in validate(policy)))
+
+    def test_kv_cannot_store_mailbox_secret(self):
+        policy = copy.deepcopy(self.policy)
+        policy["skap_credential_binding"]["kv_stores_secret"] = True
+        self.assertTrue(any("must not store" in error for error in validate(policy)))
+
+    def test_mapping_must_prompt_for_credential_completion(self):
+        policy = copy.deepcopy(self.policy)
+        policy["skap_credential_binding"]["user_prompt_after_mapping"] = False
+        self.assertTrue(any("prompted" in error for error in validate(policy)))
+
     def test_pre_admission_trust_fails(self):
         policy = copy.deepcopy(self.policy)
         policy["staging"]["trusted_kv_content_before_decision"] = True

--- a/tests/test_skap_crypto_boundary.py
+++ b/tests/test_skap_crypto_boundary.py
@@ -96,7 +96,7 @@ class SKAPCryptoBoundaryTests(unittest.TestCase):
 
     def test_ciphertext_tamper_fails_closed(self):
         envelope = copy.deepcopy(self._seal())
-        envelope["ciphertext_b64"] = envelope["ciphertext_b64"][:-1] + ("A" if envelope["ciphertext_b64"][-1] != "A" else "B")
+        envelope["ciphertext_b64"] = ("A" if envelope["ciphertext_b64"][0] != "A" else "B") + envelope["ciphertext_b64"][1:]
         with self.assertRaises(SKAPCryptoError):
             self._resolve(envelope)
 

--- a/tools/check_kv_email_ingress_policy.py
+++ b/tools/check_kv_email_ingress_policy.py
@@ -35,6 +35,16 @@ def validate(policy: dict) -> list[str]:
     if provider.get("provider_neutral") is not True:
         errors.append("canonical contract must remain provider-neutral")
 
+    skap = policy.get("skap_credential_binding", {})
+    if skap.get("required_for_activation") is not True:
+        errors.append("SKAP Vault credential binding must be required for activation")
+    if skap.get("vault") != "SKAP_VAULT":
+        errors.append("credential binding must target SKAP Vault")
+    if skap.get("kv_stores_secret") is not False:
+        errors.append("KnowledgeVault must not store the mailbox secret")
+    if skap.get("user_prompt_after_mapping") is not True:
+        errors.append("user must be prompted to complete credential setup after mailbox mapping")
+
     staging = policy.get("staging", {})
     if staging.get("required") is not True:
         errors.append("pre-admission staging is required")

--- a/tools/check_kv_email_ingress_policy.py
+++ b/tools/check_kv_email_ingress_policy.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate the canonical KnowledgeVault governed email-ingress policy."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = ROOT / "specs" / "kv-email-ingress-policy.v1.json"
+
+REQUIRED_DECISIONS = {"ADMIT", "QUARANTINE", "REVIEW", "REJECT", "FAIL_CLOSED"}
+
+
+def load_policy(path: Path = POLICY) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate(policy: dict) -> list[str]:
+    errors: list[str] = []
+
+    if policy.get("schema") != "stegverse.kv.email-ingress-policy/v1":
+        errors.append("unexpected schema")
+    if policy.get("service_id") != "email-continuity":
+        errors.append("policy must bind to email-continuity")
+    if policy.get("authority_effect") != "NONE":
+        errors.append("email ingress must not grant authority")
+
+    provider = policy.get("provider_session", {})
+    if provider.get("authorization_required") is not True:
+        errors.append("provider authorization must be required")
+    if provider.get("credential_storage") != "REFERENCE_ONLY_NO_PLAINTEXT_SECRETS":
+        errors.append("plaintext/reusable mailbox credentials are prohibited")
+    if provider.get("provider_neutral") is not True:
+        errors.append("canonical contract must remain provider-neutral")
+
+    staging = policy.get("staging", {})
+    if staging.get("required") is not True:
+        errors.append("pre-admission staging is required")
+    if staging.get("trusted_kv_content_before_decision") is not False:
+        errors.append("staged mail must not be trusted KV content")
+
+    governance = policy.get("governance", {})
+    if governance.get("default_on_ambiguity") != "FAIL_CLOSED":
+        errors.append("ambiguous ingress must fail closed")
+
+    rules = governance.get("rules", [])
+    if not isinstance(rules, list) or not rules:
+        errors.append("at least one governance rule is required")
+    else:
+        actions = {rule.get("action") for rule in rules if rule.get("enabled") is True}
+        if "ADMIT" not in actions:
+            errors.append("an enabled ADMIT path is required")
+        if not ({"REJECT", "QUARANTINE", "REVIEW"} & actions):
+            errors.append("an enabled non-admit governance path is required")
+
+    admission = policy.get("admission", {})
+    decisions = set(admission.get("allowed_decisions", []))
+    if decisions != REQUIRED_DECISIONS:
+        errors.append("allowed decisions must exactly match canonical decision vocabulary")
+    if admission.get("trusted_content_decision") != "ADMIT":
+        errors.append("only ADMIT may promote content to trusted KV state")
+
+    receipt = policy.get("receipt", {})
+    if receipt.get("required_for_every_evaluation") is not True:
+        errors.append("every evaluated message requires a governance receipt")
+    if receipt.get("retain_rejected_payload") is not False:
+        errors.append("rejected payloads must not be retained by default")
+
+    return errors
+
+
+def main() -> int:
+    errors = validate(load_policy())
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+    print("PASS: governed KV email-ingress policy")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Extends the existing `email-continuity` Personal Services slot with a provider-neutral governed inbound-mail contract.

### Adds
- canonical email-ingress JSON schema
- source-ready default policy
- deterministic validator and negative tests
- hosted validation workflow
- specialized `KV_EMAIL_INGRESS_MIRROR_HANDOFF.md`
- explicit binding from the existing personal-services registry entry

### Governance behavior
Mail is staged before trust. Canonical decisions are `ADMIT`, `QUARANTINE`, `REVIEW`, `REJECT`, and `FAIL_CLOSED`. Only `ADMIT` promotes content into trusted KV state. Every evaluation requires a receipt. Rejected payloads are not retained by default. Plaintext/reusable mailbox credentials are prohibited from ordinary KV state.

### Non-claims
This PR does not connect a mailbox, activate provider credentials, activate Interlock/InTr, or claim live email review. Live owner-authorized provider/session and admission evidence remains a separate activation gate.