### PR TITLE
Retire hosted onboarding-friction and candidate-lifecycle control plane

### DIFF
--- a/.github/workflows/automation-candidate-lifecycle.yml
+++ b/.github/workflows/automation-candidate-lifecycle.yml
@@ -1,4 +1,4 @@
-name: Automation candidate lifecycle
+name: Automation candidate lifecycle - Validation Only
 
 on:
   issues:
@@ -8,172 +8,77 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
 
 concurrency:
-  group: automation-candidate-lifecycle
+  group: automation-candidate-lifecycle-validation
   cancel-in-progress: false
 
 jobs:
-  reconcile:
+  observe:
     if: >-
       github.event_name != 'issues' ||
       contains(github.event.issue.labels.*.name, 'automation-candidate') ||
       startsWith(github.event.issue.title, '[Automation candidate]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
-      - name: Check out repository
+      - name: Check out repository without credential persistence
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          persist-credentials: false
 
-      - name: Ensure lifecycle labels exist
+      - name: Project candidate lifecycle from durable evidence
         env:
-          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_STATE: ${{ github.event.issue.state }}
         run: |
-          gh label create candidate-supported --color 0E8A16 --description "Registry threshold currently supports this automation candidate" --force
-          gh label create candidate-insufficient-evidence --color D93F0B --description "Candidate does not currently meet the evidence threshold" --force
-          gh label create candidate-implemented --color 5319E7 --description "Candidate correction was implemented and verified" --force
-          gh label create candidate-superseded --color C2E0C6 --description "Duplicate or superseded automation candidate" --force
-
-      - name: Read registry and open candidates
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p evidence/onboarding-friction/candidates
-          gh issue list --state all --label automation-candidate --limit 1000 --json number,title,state,labels,url,createdAt,updatedAt > /tmp/candidate-issues.json
+          mkdir -p reports/automation_candidates
           python3 - <<'PY'
-          import json
-          import re
+          import json, os, re
           from datetime import datetime, timezone
           from pathlib import Path
-
-          registry_path = Path('evidence/onboarding-friction/latest.json')
-          registry = json.loads(registry_path.read_text(encoding='utf-8')) if registry_path.exists() else {
-              'threshold': 3,
-              'signature_counts': {},
-              'reports': [],
+          registry_path=Path("evidence/onboarding-friction/latest.json")
+          registry=json.loads(registry_path.read_text(encoding="utf-8")) if registry_path.exists() else {
+              "threshold":3,"signature_counts":{},"reports":[]
           }
-          issues = json.loads(Path('/tmp/candidate-issues.json').read_text(encoding='utf-8'))
-          threshold = int(registry.get('threshold', 3))
-          counts = registry.get('signature_counts', {})
-          reports = registry.get('reports', [])
-          by_signature = {}
-          actions = []
-
-          for issue in sorted(issues, key=lambda item: item['number']):
-              match = re.match(r'^\[Automation candidate\]\s+(.+?)\s*$', issue['title'])
-              signature = match.group(1).strip() if match else ''
-              labels = {item['name'] for item in issue.get('labels', [])}
-              count = int(counts.get(signature, 0)) if signature else 0
-              supported = bool(signature) and count >= threshold
-              duplicate_of = None
-              if signature:
-                  if signature in by_signature:
-                      duplicate_of = by_signature[signature]
-                  else:
-                      by_signature[signature] = issue['number']
-
-              matching_reports = [
-                  {'issue_number': row['issue_number'], 'state': row['state'], 'url': row['url']}
-                  for row in reports if row.get('signature') == signature
-              ]
-              state = 'implemented' if 'candidate-implemented' in labels else (
-                  'superseded' if duplicate_of else ('supported' if supported else 'insufficient-evidence')
-              )
-              slug = re.sub(r'[^a-z0-9]+', '-', signature.lower()).strip('-') or f"issue-{issue['number']}"
-              payload = {
-                  'schema_version': '1.0',
-                  'candidate_issue': issue['number'],
-                  'candidate_url': issue['url'],
-                  'signature': signature,
-                  'threshold': threshold,
-                  'matching_report_count': count,
-                  'matching_reports': matching_reports,
-                  'state': state,
-                  'duplicate_of_issue': duplicate_of,
-                  'generated_utc': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-                  'scope': 'repository-native onboarding correction only; no authority over user vault content',
-              }
-              Path(f'evidence/onboarding-friction/candidates/{slug}.json').write_text(
-                  json.dumps(payload, indent=2) + '\n', encoding='utf-8'
-              )
-              lines = [
-                  f'# Automation Candidate: `{signature or "unparsed"}`', '',
-                  f'- **Issue:** #{issue["number"]}',
-                  f'- **State:** `{state}`',
-                  f'- **Matching reports:** `{count}`',
-                  f'- **Threshold:** `{threshold}`',
-                  f'- **Duplicate of:** `{duplicate_of if duplicate_of else "none"}`', '',
-                  '## Source reports', '',
-              ]
-              if matching_reports:
-                  lines.extend(f'- #{row["issue_number"]} — {row["state"]} — {row["url"]}' for row in matching_reports)
-              else:
-                  lines.append('- None recorded.')
-              lines += ['', 'A supported candidate authorizes investigation of the smallest repository-native correction only. It does not authorize mutation of user vaults.', '']
-              Path(f'evidence/onboarding-friction/candidates/{slug}.md').write_text('\n'.join(lines), encoding='utf-8')
-              actions.append({
-                  'issue': issue['number'],
-                  'signature': signature,
-                  'supported': supported,
-                  'duplicate_of': duplicate_of,
-                  'implemented': 'candidate-implemented' in labels,
-                  'state': issue['state'],
-              })
-
-          Path('/tmp/candidate-actions.json').write_text(json.dumps(actions), encoding='utf-8')
+          threshold=int(registry.get("threshold",3))
+          title=os.environ.get("ISSUE_TITLE","") or ""
+          m=re.match(r"^\[Automation candidate\]\s+(.+?)\s*$",title)
+          signature=m.group(1).strip() if m else ""
+          count=int(registry.get("signature_counts",{}).get(signature,0)) if signature else 0
+          projected_state="supported" if signature and count>=threshold else "insufficient-evidence"
+          payload={
+              "schema":"stegverse.kv.automation-candidate-lifecycle-observation/v1",
+              "event_name":os.environ.get("EVENT_NAME",""),
+              "candidate_issue":int(os.environ["ISSUE_NUMBER"]) if os.environ.get("ISSUE_NUMBER") else None,
+              "candidate_issue_state":os.environ.get("ISSUE_STATE") or None,
+              "signature":signature or None,
+              "threshold":threshold,
+              "matching_report_count":count,
+              "projected_state":projected_state,
+              "candidate_lifecycle_mutation_performed":False,
+              "issue_mutation_performed":False,
+              "label_mutation_performed":False,
+              "repository_mutation_performed":False,
+              "workflow_dispatch_performed":False,
+              "github_actions_role":"VALIDATION_TRANSPORT_ONLY",
+              "canonical_next_transition":"NON_HOSTED_CANDIDATE_RECONCILIATION",
+              "authority_effect":"NONE",
+              "observed_utc":datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
+          }
+          Path("reports/automation_candidates/lifecycle-observation.json").write_text(
+              json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps(payload,sort_keys=True))
           PY
 
-      - name: Apply deterministic lifecycle state
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          python3 - <<'PY' > /tmp/candidate-actions.tsv
-          import json
-          from pathlib import Path
-          for row in json.loads(Path('/tmp/candidate-actions.json').read_text(encoding='utf-8')):
-              print('\t'.join([
-                  str(row['issue']),
-                  row['signature'],
-                  'true' if row['supported'] else 'false',
-                  str(row['duplicate_of'] or ''),
-                  'true' if row['implemented'] else 'false',
-                  row['state'],
-              ]))
-          PY
-          while IFS=$'\t' read -r issue signature supported duplicate implemented state; do
-            [ -n "$issue" ] || continue
-            if [ -n "$duplicate" ]; then
-              gh issue edit "$issue" --add-label candidate-superseded --remove-label candidate-supported --remove-label candidate-insufficient-evidence 2>/dev/null || true
-              if [ "$state" = "OPEN" ]; then
-                gh issue comment "$issue" --body "Automatically marked as duplicate of automation candidate #${duplicate} for signature \`${signature}\`. The earlier issue remains the canonical candidate."
-                gh issue close "$issue" --reason not_planned
-              fi
-            elif [ "$implemented" = "true" ]; then
-              gh issue edit "$issue" --add-label candidate-implemented --remove-label candidate-supported --remove-label candidate-insufficient-evidence 2>/dev/null || true
-              if [ "$state" = "OPEN" ]; then
-                gh issue comment "$issue" --body "Implementation evidence label detected. Candidate lifecycle is complete; durable evidence is under \`evidence/onboarding-friction/candidates/\`."
-                gh issue close "$issue" --reason completed
-              fi
-            elif [ "$supported" = "true" ]; then
-              gh issue edit "$issue" --add-label candidate-supported --remove-label candidate-insufficient-evidence --remove-label candidate-superseded 2>/dev/null || true
-            else
-              gh issue edit "$issue" --add-label candidate-insufficient-evidence --remove-label candidate-supported --remove-label candidate-superseded 2>/dev/null || true
-            fi
-          done < /tmp/candidate-actions.tsv
-
-      - name: Commit candidate evidence packets
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add evidence/onboarding-friction/candidates/
-          if git diff --cached --quiet; then
-            echo "Candidate evidence unchanged"
-          else
-            git commit -m "ci: reconcile automation candidate evidence [skip ci]"
-            git push
-          fi
+      - name: Upload non-authorizing lifecycle observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: automation-candidate-lifecycle-${{ github.run_id }}
+          path: reports/automation_candidates/lifecycle-observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/onboarding-friction-bootstrap.yml
+++ b/.github/workflows/onboarding-friction-bootstrap.yml
@@ -1,4 +1,4 @@
-name: Onboarding friction bootstrap
+name: Onboarding friction bootstrap - Validation Only
 
 on:
   push:
@@ -10,20 +10,53 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
-  labels:
+  validate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Ensure onboarding labels exist
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Check out repository without credential persistence
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate expected label vocabulary without mutation
         run: |
-          gh label create onboarding-friction --repo "${{ github.repository }}" --color D4C5F9 --description "Structured first-use or setup friction" --force
-          gh label create needs-reproduction --repo "${{ github.repository }}" --color FEF2C0 --description "Setup report needs reproducible details" --force
-          gh label create automation-candidate --repo "${{ github.repository }}" --color B60205 --description "Repeated friction eligible for repository automation" --force
-          for name in ios android windows macos linux other initializer unzip manual-copy release-verification markdown first-use; do
-            gh label create "friction:${name}" --repo "${{ github.repository }}" --color C5DEF5 --description "Automated onboarding-friction classification" --force
-          done
+          mkdir -p reports/onboarding_friction
+          python3 - <<'PY'
+          import json
+          from datetime import datetime, timezone
+          from pathlib import Path
+          labels=[
+              "onboarding-friction","needs-reproduction","automation-candidate",
+              "friction:ios","friction:android","friction:windows","friction:macos",
+              "friction:linux","friction:other","friction:initializer","friction:unzip",
+              "friction:manual-copy","friction:release-verification","friction:markdown",
+              "friction:first-use"
+          ]
+          payload={
+              "schema":"stegverse.kv.onboarding-friction-bootstrap-observation/v1",
+              "expected_labels":labels,
+              "label_mutation_performed":False,
+              "issue_mutation_performed":False,
+              "repository_mutation_performed":False,
+              "github_actions_role":"VALIDATION_TRANSPORT_ONLY",
+              "canonical_next_transition":"NON_HOSTED_LABEL_PROVISIONING_IF_REQUIRED",
+              "authority_effect":"NONE",
+              "observed_utc":datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
+          }
+          Path("reports/onboarding_friction/bootstrap-observation.json").write_text(
+              json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps(payload,sort_keys=True))
+          PY
+
+      - name: Upload non-authorizing bootstrap observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: onboarding-friction-bootstrap-${{ github.run_id }}
+          path: reports/onboarding_friction/bootstrap-observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/onboarding-friction-maintenance.yml
+++ b/.github/workflows/onboarding-friction-maintenance.yml
@@ -1,4 +1,4 @@
-name: Onboarding friction maintenance
+name: Onboarding friction maintenance - Validation Only
 
 on:
   schedule:
@@ -7,73 +7,59 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  actions: write
 
 concurrency:
-  group: onboarding-friction-maintenance
+  group: onboarding-friction-maintenance-validation
   cancel-in-progress: false
 
 jobs:
-  maintain:
+  observe:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      GH_REPO: ${{ github.repository }}
-
     steps:
-      - name: Ensure maintenance labels exist
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh label create onboarding-friction --color D4C5F9 --description "Structured first-use or setup friction" --force
-          gh label create needs-reproduction --color FEF2C0 --description "Setup report needs reproducible details" --force
-          gh label create awaiting-details --color FBCA04 --description "Automated reminder sent; awaiting reporter details" --force
-          gh label create automation-candidate --color B60205 --description "Repeated friction eligible for repository automation" --force
+      - name: Check out repository without credential persistence
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
-      - name: Reconcile incomplete reports
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
+      - name: Project maintenance state from durable registry
         run: |
-          gh issue list \
-            --repo "$REPOSITORY" \
-            --state open \
-            --label onboarding-friction \
-            --label needs-reproduction \
-            --limit 1000 \
-            --json number,createdAt,updatedAt,labels,url > /tmp/incomplete.json
-
-          python3 - <<'PY' > /tmp/actions.tsv
+          mkdir -p reports/onboarding_friction
+          python3 - <<'PY'
           import json
           from datetime import datetime, timezone
           from pathlib import Path
-
-          now = datetime.now(timezone.utc)
-          issues = json.loads(Path('/tmp/incomplete.json').read_text(encoding='utf-8'))
-          for issue in issues:
-              updated = datetime.fromisoformat(issue['updatedAt'].replace('Z', '+00:00'))
-              age_days = (now - updated).days
-              labels = {item['name'] for item in issue.get('labels', [])}
-              number = issue['number']
-              if age_days >= 30:
-                  print(f"close\t{number}\t{age_days}")
-              elif age_days >= 7 and 'awaiting-details' not in labels:
-                  print(f"remind\t{number}\t{age_days}")
+          p=Path("evidence/onboarding-friction/latest.json")
+          registry=json.loads(p.read_text(encoding="utf-8")) if p.exists() else {
+              "threshold":3,"reports":[],"signature_counts":{}
+          }
+          payload={
+              "schema":"stegverse.kv.onboarding-friction-maintenance-observation/v1",
+              "registry_present":p.exists(),
+              "report_count":len(registry.get("reports",[])),
+              "threshold":int(registry.get("threshold",3)),
+              "candidate_signatures":sorted(
+                  s for s,c in registry.get("signature_counts",{}).items() if int(c)>=3
+              ),
+              "reminder_issue_mutation_performed":False,
+              "issue_close_performed":False,
+              "workflow_dispatch_performed":False,
+              "repository_mutation_performed":False,
+              "github_actions_role":"VALIDATION_TRANSPORT_ONLY",
+              "canonical_next_transition":"NON_HOSTED_FRICTION_RECONCILIATION",
+              "authority_effect":"NONE",
+              "observed_utc":datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
+          }
+          Path("reports/onboarding_friction/maintenance-observation.json").write_text(
+              json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps(payload,sort_keys=True))
           PY
 
-          while IFS=$'\t' read -r action number age_days; do
-            [ -n "$action" ] || continue
-            if [ "$action" = "remind" ]; then
-              gh issue edit "$number" --repo "$REPOSITORY" --add-label awaiting-details
-              gh issue comment "$number" --repo "$REPOSITORY" --body "Automated follow-up: this report still needs the missing reproduction details identified by the triage workflow. Please edit the structured fields rather than attaching private vault content. If no details are added, the report will close automatically after 30 inactive days and may be reopened later."
-            elif [ "$action" = "close" ]; then
-              gh issue comment "$number" --repo "$REPOSITORY" --body "Closing automatically after ${age_days} inactive days without sufficient reproduction details. No product conclusion was drawn from this incomplete report. Edit and reopen the issue when privacy-safe reproduction details are available."
-              gh issue close "$number" --repo "$REPOSITORY" --reason "not planned"
-            fi
-          done < /tmp/actions.tsv
-
-      - name: Rebuild durable registry
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run onboarding-friction.yml --ref main
+      - name: Upload non-authorizing maintenance observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: onboarding-friction-maintenance-${{ github.run_id }}
+          path: reports/onboarding_friction/maintenance-observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/onboarding-friction.yml
+++ b/.github/workflows/onboarding-friction.yml
@@ -1,4 +1,4 @@
-name: Onboarding friction triage
+name: Onboarding friction triage - Validation Only
 
 on:
   issues:
@@ -6,15 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
 
 concurrency:
-  group: onboarding-friction-triage
+  group: onboarding-friction-triage-validation
   cancel-in-progress: false
 
 jobs:
-  triage:
+  observe:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.issue.labels.*.name, 'onboarding-friction')
@@ -22,39 +21,29 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out repository
+      - name: Check out repository without credential persistence
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          persist-credentials: false
 
-      - name: Ensure triage labels exist
+      - name: Classify current report without mutation
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh label create onboarding-friction --color D4C5F9 --description "Structured first-use or setup friction" --force
-          gh label create needs-reproduction --color FEF2C0 --description "Setup report needs reproducible details" --force
-          gh label create automation-candidate --color B60205 --description "Repeated friction eligible for repository automation" --force
-          for name in ios android windows macos linux other initializer unzip manual-copy release-verification markdown first-use; do
-            gh label create "friction:${name}" --color C5DEF5 --description "Automated onboarding-friction classification" --force
-          done
-
-      - name: Classify current report
-        if: github.event_name == 'issues'
-        id: classify
-        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
+          mkdir -p reports/onboarding_friction
           python3 - <<'PY'
-          import os
-          import re
+          import json, os, re
+          from datetime import datetime, timezone
           from pathlib import Path
 
-          body = os.environ.get("ISSUE_BODY", "")
-
-          def field(label: str) -> str:
-              pattern = rf"### {re.escape(label)}\s+(.+?)(?=\n### |\Z)"
-              match = re.search(pattern, body, flags=re.S)
-              return match.group(1).strip() if match else ""
+          body = os.environ.get("ISSUE_BODY", "") or ""
+          def field(label):
+              m = re.search(rf"### {re.escape(label)}\s+(.+?)(?=\n### |\Z)", body, flags=re.S)
+              return m.group(1).strip() if m else ""
 
           platform_raw = field("Platform").lower()
           path_raw = field("Setup path").lower()
@@ -63,156 +52,46 @@ jobs:
           observed = field("What happened")
           expected = field("What you expected")
 
-          platform_map = {
-              "iphone or ipad": "ios",
-              "android": "android",
-              "windows": "windows",
-              "macos": "macos",
-              "linux": "linux",
-          }
-          path_map = {
-              "python initializer": "initializer",
-              "download and unzip": "unzip",
-              "copy vault_template manually": "manual-copy",
-              "release zip verification": "release-verification",
-              "opening or editing markdown files": "markdown",
-          }
-
-          platform = platform_map.get(platform_raw, "other")
-          path = path_map.get(path_raw, "first-use")
-          stage = re.sub(r"[^a-z0-9]+", "-", stage_raw).strip("-") or "unknown"
-          complete = all((platform_raw, path_raw, stage_raw, attempted, observed, expected))
+          platform = {
+              "iphone or ipad":"ios","android":"android","windows":"windows",
+              "macos":"macos","linux":"linux"
+          }.get(platform_raw, "other")
+          path = {
+              "python initializer":"initializer","download and unzip":"unzip",
+              "copy vault_template manually":"manual-copy",
+              "release zip verification":"release-verification",
+              "opening or editing markdown files":"markdown"
+          }.get(path_raw, "first-use")
+          stage = re.sub(r"[^a-z0-9]+","-",stage_raw).strip("-") or "unknown"
+          complete = all((platform_raw,path_raw,stage_raw,attempted,observed,expected))
           signature = f"{platform}:{path}:{stage}"
-
-          response = {
-              "initializer": "Run `python3 tools/init_vault.py --dry-run /path/to/parent` first. The initializer refuses overwrite, verifies copied hashes, removes partial installs on failure, and writes an installation receipt after success.",
-              "release-verification": "Keep the release ZIP beside its `.sha256` and `.manifest.json` sidecars, then run `python3 tools/verify_release.py <release.zip>`.",
-              "unzip": "Confirm the archive expands to a single `KnowledgeVault/` folder. Do not merge it into an existing accepted vault; preserve the existing vault and use the migration guidance instead.",
-              "manual-copy": "Copy the complete `vault_template/KnowledgeVault/` tree into a new destination. Do not overwrite an existing vault.",
-              "markdown": "The vault uses ordinary Markdown files. Open them with any text or Markdown editor; no account or specialized application is required.",
-          }.get(path, "Use the shortest reproducible steps and preserve the existing vault until the destination or change is verified.")
-
-          out = Path(os.environ["GITHUB_OUTPUT"])
-          with out.open("a", encoding="utf-8") as handle:
-              handle.write(f"platform={platform}\n")
-              handle.write(f"path={path}\n")
-              handle.write(f"stage={stage}\n")
-              handle.write(f"signature={signature}\n")
-              handle.write(f"complete={'true' if complete else 'false'}\n")
-              handle.write("response<<EOF\n" + response + "\nEOF\n")
-          PY
-
-      - name: Apply classification and respond
-        if: github.event_name == 'issues'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          PLATFORM: ${{ steps.classify.outputs.platform }}
-          PATH_CLASS: ${{ steps.classify.outputs.path }}
-          COMPLETE: ${{ steps.classify.outputs.complete }}
-          RESPONSE: ${{ steps.classify.outputs.response }}
-          SIGNATURE: ${{ steps.classify.outputs.signature }}
-        run: |
-          gh issue edit "$ISSUE_NUMBER" --add-label "friction:${PLATFORM}" --add-label "friction:${PATH_CLASS}"
-          if [ "$COMPLETE" != "true" ]; then
-            gh issue edit "$ISSUE_NUMBER" --add-label needs-reproduction
-          else
-            gh issue edit "$ISSUE_NUMBER" --remove-label needs-reproduction 2>/dev/null || true
-          fi
-          gh issue comment "$ISSUE_NUMBER" --body "Automated triage signature: \`${SIGNATURE}\`. ${RESPONSE}\n\nThis response is guidance only. It does not authorize overwriting an existing vault or exposing private vault content."
-
-      - name: Build durable friction registry
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p evidence/onboarding-friction
-          gh issue list --state all --label onboarding-friction --limit 1000 --json number,title,state,createdAt,updatedAt,labels,url,body > /tmp/friction-issues.json
-          python3 - <<'PY'
-          import json
-          import re
-          from collections import Counter
-          from datetime import datetime, timezone
-          from pathlib import Path
-
-          issues = json.loads(Path('/tmp/friction-issues.json').read_text(encoding='utf-8'))
-          records = []
-          counts = Counter()
-
-          def field(body: str, label: str) -> str:
-              match = re.search(rf"### {re.escape(label)}\s+(.+?)(?=\n### |\Z)", body or "", flags=re.S)
-              return match.group(1).strip() if match else "unknown"
-
-          for issue in issues:
-              labels = [item['name'] for item in issue.get('labels', [])]
-              platform = next((x.split(':', 1)[1] for x in labels if x.startswith('friction:') and x.split(':', 1)[1] in {'ios','android','windows','macos','linux','other'}), 'other')
-              path_class = next((x.split(':', 1)[1] for x in labels if x.startswith('friction:') and x.split(':', 1)[1] in {'initializer','unzip','manual-copy','release-verification','markdown','first-use'}), 'first-use')
-              stage = re.sub(r"[^a-z0-9]+", "-", field(issue.get('body', ''), 'Failure stage').lower()).strip('-') or 'unknown'
-              signature = f"{platform}:{path_class}:{stage}"
-              counts[signature] += 1
-              records.append({
-                  'issue_number': issue['number'],
-                  'state': issue['state'],
-                  'signature': signature,
-                  'url': issue['url'],
-                  'created_at': issue['createdAt'],
-                  'updated_at': issue['updatedAt'],
-              })
-
-          generated = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
           payload = {
-              'schema_version': '1.0',
-              'generated_utc': generated,
-              'report_count': len(records),
-              'threshold': 3,
-              'signature_counts': dict(sorted(counts.items())),
-              'reports': sorted(records, key=lambda x: x['issue_number']),
-              'privacy_scope': 'issue metadata and user-supplied reproducible setup details only; private vault content prohibited',
+              "schema":"stegverse.kv.onboarding-friction-observation/v1",
+              "event_name":os.environ.get("EVENT_NAME",""),
+              "issue_number":int(os.environ["ISSUE_NUMBER"]) if os.environ.get("ISSUE_NUMBER") else None,
+              "issue_url":os.environ.get("ISSUE_URL") or None,
+              "signature":signature,
+              "complete_reproduction_fields":complete,
+              "projected_labels":[f"friction:{platform}",f"friction:{path}"] + ([] if complete else ["needs-reproduction"]),
+              "threshold":3,
+              "canonical_issue_mutation_performed":False,
+              "label_mutation_performed":False,
+              "repository_mutation_performed":False,
+              "candidate_creation_performed":False,
+              "github_actions_role":"VALIDATION_TRANSPORT_ONLY",
+              "canonical_next_transition":"NON_HOSTED_FRICTION_RECONCILIATION",
+              "authority_effect":"NONE",
+              "observed_utc":datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
           }
-          root = Path('evidence/onboarding-friction')
-          (root / 'latest.json').write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
-          lines = [
-              '# Onboarding Friction Registry', '',
-              f'- **Generated UTC:** `{generated}`',
-              f'- **Reports:** `{len(records)}`',
-              '- **Automation-candidate threshold:** `3 reports with the same signature`', '',
-              '## Signature counts', '',
-          ]
-          if counts:
-              lines.extend(f'- `{signature}`: {count}' for signature, count in sorted(counts.items()))
-          else:
-              lines.append('- No structured onboarding-friction reports recorded.')
-          lines += ['', 'This registry excludes private vault content and does not authorize automated mutation of user vaults.', '']
-          (root / 'latest.md').write_text('\n'.join(lines), encoding='utf-8')
-          Path('/tmp/candidates.json').write_text(json.dumps([s for s, c in counts.items() if c >= 3]), encoding='utf-8')
+          Path("reports/onboarding_friction/triage-observation.json").write_text(
+              json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps(payload,sort_keys=True))
           PY
 
-      - name: Create threshold-based automation candidates
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          python3 - <<'PY' > /tmp/candidates.txt
-          import json
-          from pathlib import Path
-          for signature in json.loads(Path('/tmp/candidates.json').read_text(encoding='utf-8')):
-              print(signature)
-          PY
-          while IFS= read -r signature; do
-            [ -n "$signature" ] || continue
-            title="[Automation candidate] ${signature}"
-            existing=$(gh issue list --state open --label automation-candidate --search "${title} in:title" --json number --jq '.[0].number // empty')
-            if [ -z "$existing" ]; then
-              gh issue create --title "$title" --label automation-candidate --body "At least three structured onboarding-friction reports share signature \`${signature}\`.\n\nInvestigate the smallest repository-native fix that removes the demonstrated manual step without adding an account, hosted service, mandatory SDK, or authority over user vault content.\n\nSource registry: \`evidence/onboarding-friction/latest.json\`."
-            fi
-          done < /tmp/candidates.txt
-
-      - name: Commit updated friction evidence
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add evidence/onboarding-friction/latest.json evidence/onboarding-friction/latest.md
-          if git diff --cached --quiet; then
-            echo "Friction registry unchanged"
-          else
-            git commit -m "ci: update onboarding friction registry [skip ci]"
-            git push
-          fi
+      - name: Upload non-authorizing triage observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: onboarding-friction-triage-${{ github.run_id }}
+          path: reports/onboarding_friction/triage-observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -13,6 +13,8 @@ on:
       - "tools/test_automation_contracts.py"
       - "tests/test_hosted_release_authority_retirement.py"
       - "tests/test_hosted_candidate_authority_retirement.py"
+      - "tests/test_hosted_onboarding_control_plane_retirement.py"
+      - "tests/test_hosted_onboarding_control_plane_retirement.py"
       - "vault_template/**"
       - "automation/**"
       - "evidence/onboarding-friction/**"
@@ -80,6 +82,9 @@ jobs:
 
       - name: Validate hosted candidate authority retirement
         run: python3 -m unittest tests.test_hosted_candidate_authority_retirement -v
+
+      - name: Validate hosted onboarding control-plane retirement
+        run: python3 -m unittest tests.test_hosted_onboarding_control_plane_retirement -v
 
       - name: Rebuild release evidence
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 - retired GitHub-hosted release/publication and release-control-plane mutation authority from the CMC-022/CMC-023 workflow set
 - retired residual `release-integrity.yml` evidence writeback and `automated-release.yml` VERSION/changelog/tag/GitHub-release mutation authority; hosted release workflows now validate and transport non-secret evidence only
 - retired `automation-candidate-implementation.yml` hosted issue/repository/workflow-dispatch mutation authority; merged-PR candidate references are now emitted only as non-authorizing observation evidence
+- retired the coupled onboarding-friction triage/maintenance/bootstrap and candidate-lifecycle hosted control plane; classification and threshold projections now emit non-authorizing artifacts without issue, label, repository, workflow-dispatch, or token authority
 - preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
 
 ### Notes

--- a/ONBOARDING_FRICTION_HOSTED_CONTROL_PLANE_RETIREMENT_MIRROR_HANDOFF.md
+++ b/ONBOARDING_FRICTION_HOSTED_CONTROL_PLANE_RETIREMENT_MIRROR_HANDOFF.md
@@ -1,0 +1,88 @@
+# Onboarding Friction Hosted Control-Plane Retirement Mirror Handoff
+
+Updated: 2026-08-27
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #85
+Branch: `fix/onboarding-friction-hosted-control-plane-85`
+State: CLAIMED_FOR_IMPLEMENTATION
+
+## Goal
+
+Retire hosted issue/repository/workflow mutation authority across the four coupled onboarding-friction/candidate-lifecycle workflows while preserving deterministic classification and evidence projection.
+
+## Canonical affected surfaces
+
+- `.github/workflows/onboarding-friction.yml`
+- `.github/workflows/onboarding-friction-maintenance.yml`
+- `.github/workflows/onboarding-friction-bootstrap.yml`
+- `.github/workflows/automation-candidate-lifecycle.yml`
+
+Issue #83 / PR #84 already retired `automation-candidate-implementation.yml`; this lane does not reopen it.
+
+## Live contradiction
+
+Current main includes combinations of:
+
+```text
+issues: write
+contents: write
+actions: write
+github.token / GH_TOKEN
+gh label create
+gh issue edit/comment/create/close
+git commit
+git push
+gh workflow run
+```
+
+These hosted mutation surfaces are incompatible with the current StegVerse contract.
+
+## Required state
+
+```text
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+credential authority: TV/TVC
+permissions: read-only
+credential persistence: false where checkout exists
+issue mutation: false
+label mutation: false
+repository mutation: false
+workflow dispatch: false
+candidate lifecycle authority: NONE
+friction lifecycle authority: NONE
+authority_effect: NONE
+```
+
+Hosted workflows may:
+- classify the current issue event deterministically from its provided metadata/body;
+- validate or summarize already-durable repository evidence;
+- calculate threshold/candidate projections without making them canonical;
+- upload non-secret short-lived observation artifacts.
+
+Hosted workflows may not:
+- query with a privileged token and then mutate issues;
+- create/update labels;
+- create/close/comment/edit issues;
+- commit or push evidence/CHANGELOG state;
+- dispatch another workflow;
+- infer that an observation is a canonical lifecycle transition.
+
+## Collision boundary
+
+Do not change the threshold value or candidate signature semantics. Do not create a second friction registry or candidate registry. Durable lifecycle ownership must be separately admitted to a non-hosted sovereign path if needed.
+
+## Planned source
+
+- four workflow files above
+- `tools/test_automation_contracts.py`
+- dedicated hosted onboarding-control regression tests
+- Release integrity regression execution
+- root CVK handoff/CHANGELOG where materially needed
+
+## Non-claims
+
+No real issue is triaged, labeled, reminded, closed, created, or reconciled by this repair. No user vault content is read or mutated. No release, deployment, provider execution, or activation is produced.
+
+## Next executable boundary
+
+Implement read-only observation workflows, enforce regression checks, validate exact head, merge only on green evidence, then inspect any remaining hosted mutation surfaces separately.

--- a/ONBOARDING_FRICTION_HOSTED_CONTROL_PLANE_RETIREMENT_MIRROR_HANDOFF.md
+++ b/ONBOARDING_FRICTION_HOSTED_CONTROL_PLANE_RETIREMENT_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-08-27
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #85
 Branch: `fix/onboarding-friction-hosted-control-plane-85`
-State: CLAIMED_FOR_IMPLEMENTATION
+State: IMPLEMENTED_ON_BRANCH_VALIDATION_PENDING
 
 ## Goal
 
@@ -83,6 +83,30 @@ Do not change the threshold value or candidate signature semantics. Do not creat
 
 No real issue is triaged, labeled, reminded, closed, created, or reconciled by this repair. No user vault content is read or mutated. No release, deployment, provider execution, or activation is produced.
 
+## Implemented source state
+
+```text
+onboarding-friction.yml: read-only current-event classifier + artifact
+onboarding-friction-maintenance.yml: read-only durable-registry projection + artifact
+onboarding-friction-bootstrap.yml: read-only expected-label vocabulary validation + artifact
+automation-candidate-lifecycle.yml: read-only candidate-state projection + artifact
+
+issue mutation: removed
+label mutation: removed
+repository writeback: removed
+workflow dispatch: removed
+github.token / GH_TOKEN: removed
+credential persistence: false
+threshold semantics: 3 retained
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+authority_effect: NONE
+```
+
+Regression:
+- `tools/test_automation_contracts.py` rejects hosted mutation/token authority across all four surfaces.
+- `tests/test_hosted_onboarding_control_plane_retirement.py` enforces read-only behavior and threshold preservation.
+- Release Integrity executes the dedicated regression.
+
 ## Next executable boundary
 
-Implement read-only observation workflows, enforce regression checks, validate exact head, merge only on green evidence, then inspect any remaining hosted mutation surfaces separately.
+Run exact-head validation; repair source/test defects without restoring hosted mutation authority; merge only after green evidence. Then scan remaining workflows for hosted mutation authority and continue only through a new bounded handoff if a distinct surface remains.

--- a/tests/test_hosted_onboarding_control_plane_retirement.py
+++ b/tests/test_hosted_onboarding_control_plane_retirement.py
@@ -1,0 +1,53 @@
+"""Regression guards for hosted onboarding/candidate control-plane retirement."""
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = (
+    ".github/workflows/onboarding-friction.yml",
+    ".github/workflows/onboarding-friction-maintenance.yml",
+    ".github/workflows/onboarding-friction-bootstrap.yml",
+    ".github/workflows/automation-candidate-lifecycle.yml",
+)
+
+
+class HostedOnboardingControlPlaneRetirementTests(unittest.TestCase):
+    def test_workflows_are_validation_transport_only(self):
+        forbidden = (
+            "contents: write",
+            "actions: write",
+            "issues: write",
+            "pull-requests: write",
+            "github.token",
+            "GH_TOKEN:",
+            "${{ secrets.",
+            "gh label ",
+            "gh issue ",
+            "gh workflow run",
+            "git push",
+            "git commit",
+            "git tag",
+        )
+        for relative in WORKFLOWS:
+            text=(ROOT/relative).read_text(encoding="utf-8")
+            for token in forbidden:
+                self.assertNotIn(token,text,relative)
+            self.assertIn("contents: read",text,relative)
+            self.assertIn("VALIDATION_TRANSPORT_ONLY",text,relative)
+            self.assertIn("actions/upload-artifact@v4",text,relative)
+            self.assertIn("authority_effect",text,relative)
+            self.assertIn("NONE",text,relative)
+            if "actions/checkout@v4" in text:
+                self.assertIn("persist-credentials: false",text,relative)
+
+    def test_threshold_semantics_remain_three(self):
+        triage=(ROOT/WORKFLOWS[0]).read_text(encoding="utf-8")
+        maintenance=(ROOT/WORKFLOWS[1]).read_text(encoding="utf-8")
+        lifecycle=(ROOT/WORKFLOWS[3]).read_text(encoding="utf-8")
+        self.assertIn('"threshold":3',triage)
+        self.assertIn('"threshold":int(registry.get("threshold",3))',maintenance)
+        self.assertIn('threshold=int(registry.get("threshold",3))',lifecycle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_automation_contracts.py
+++ b/tools/test_automation_contracts.py
@@ -45,19 +45,41 @@ WORKFLOWS = {
         "actions/upload-artifact@v4",
     },
     "downstream-propagation.yml": {"release:", "evidence/downstream-propagation"},
-    "onboarding-friction-bootstrap.yml": {"workflow_dispatch:", "onboarding-friction"},
-    "onboarding-friction.yml": {
-        "name: Onboarding friction triage",
-        "issues:",
-        "automation-candidate",
-        "evidence/onboarding-friction/latest.json",
+    "onboarding-friction-bootstrap.yml": {
+        "name: Onboarding friction bootstrap - Validation Only",
+        "workflow_dispatch:",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_LABEL_PROVISIONING_IF_REQUIRED",
+        "actions/upload-artifact@v4",
     },
-    "onboarding-friction-maintenance.yml": {"schedule:", "needs-reproduction", "workflow_dispatch"},
+    "onboarding-friction.yml": {
+        "name: Onboarding friction triage - Validation Only",
+        "issues:",
+        "threshold",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_FRICTION_RECONCILIATION",
+        "actions/upload-artifact@v4",
+    },
+    "onboarding-friction-maintenance.yml": {
+        "name: Onboarding friction maintenance - Validation Only",
+        "schedule:",
+        "workflow_dispatch:",
+        "threshold",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_FRICTION_RECONCILIATION",
+        "actions/upload-artifact@v4",
+    },
     "automation-candidate-lifecycle.yml": {
+        "name: Automation candidate lifecycle - Validation Only",
         "automation-candidate",
-        "candidate-supported",
-        "candidate-insufficient-evidence",
-        "evidence/onboarding-friction/candidates",
+        "threshold",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_CANDIDATE_RECONCILIATION",
+        "actions/upload-artifact@v4",
     },
     "automation-candidate-implementation.yml": {
         "name: Automation candidate implementation - Validation Only",
@@ -256,6 +278,49 @@ def validate_candidate_implementation_boundary() -> None:
         fail("candidate implementation missing validation-only boundary tokens: " + ", ".join(missing))
 
 
+
+def validate_hosted_onboarding_control_plane_boundary() -> None:
+    workflow_root = REPO_ROOT / ".github" / "workflows"
+    files = (
+        "onboarding-friction.yml",
+        "onboarding-friction-maintenance.yml",
+        "onboarding-friction-bootstrap.yml",
+        "automation-candidate-lifecycle.yml",
+    )
+    forbidden = {
+        "contents: write",
+        "actions: write",
+        "issues: write",
+        "pull-requests: write",
+        "github.token",
+        "GH_TOKEN:",
+        "${{ secrets.",
+        "gh label ",
+        "gh issue ",
+        "gh workflow run",
+        "git push",
+        "git commit",
+        "git tag",
+    }
+    for filename in files:
+        text = read_text(workflow_root / filename)
+        present = sorted(token for token in forbidden if token in text)
+        if present:
+            fail(f"{filename} reintroduces hosted onboarding/candidate authority: {', '.join(present)}")
+        required = {
+            "contents: read",
+            "VALIDATION_TRANSPORT_ONLY",
+            "authority_effect",
+            "NONE",
+            "actions/upload-artifact@v4",
+        }
+        if "actions/checkout@v4" in text:
+            required.add("persist-credentials: false")
+        missing = sorted(token for token in required if token not in text)
+        if missing:
+            fail(f"{filename} missing validation-only hosted-control tokens: {', '.join(missing)}")
+
+
 def validate_friction_registry() -> None:
     registry = read_json(REPO_ROOT / "evidence" / "onboarding-friction" / "latest.json")
     required = {
@@ -352,6 +417,7 @@ def main() -> int:
         validate_hosted_release_cycle_boundary,
         validate_release_cycle_outcome,
         validate_candidate_implementation_boundary,
+        validate_hosted_onboarding_control_plane_boundary,
         validate_friction_registry,
         validate_issue_form,
         validate_threshold_consistency,


### PR DESCRIPTION
Closes issue #85.

Converts four coupled hosted mutation workflows to validation/evidence transport only:
- onboarding-friction triage;
- onboarding-friction maintenance;
- onboarding-friction bootstrap;
- automation-candidate lifecycle.

Removed hosted issue/label/repository/workflow mutation, GitHub-token authority, and credential persistence. Retained deterministic current-event classification, durable-registry projection, threshold=3 semantics, and candidate-state projection as non-authorizing artifacts only.

Adds fail-closed automation-contract enforcement and dedicated regression coverage in Release integrity.

Non-claims: no real issue is labeled/commented/created/closed/reconciled; no candidate lifecycle state is made canonical; no user vault mutation, release publication, deployment, or activation occurs.