### PR TITLE
Extend governed email ingress with staging, receipts, and replay

### DIFF
--- a/.github/workflows/validate-kv-email-ingress-policy.yml
+++ b/.github/workflows/validate-kv-email-ingress-policy.yml
@@ -5,11 +5,14 @@ on:
     paths:
       - "schemas/kv-email-ingress-policy.schema.json"
       - "schemas/kv-email-account-mapping.schema.json"
+      - "schemas/kv-email-ingress-receipt.schema.json"
       - "specs/kv-email-ingress-policy.v1.json"
       - "tools/check_kv_email_ingress_policy.py"
       - "tests/test_kv_email_ingress_policy.py"
       - "runtime/email_continuity.py"
       - "tests/test_email_continuity_runtime.py"
+      - "runtime/email_ingress_pipeline.py"
+      - "tests/test_email_ingress_pipeline.py"
       - "KV_EMAIL_INGRESS_MIRROR_HANDOFF.md"
       - ".github/workflows/validate-kv-email-ingress-policy.yml"
   push:
@@ -37,4 +40,4 @@ jobs:
       - name: Validate canonical policy
         run: python tools/check_kv_email_ingress_policy.py
       - name: Run deterministic tests
-        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime -v
+        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime tests.test_email_ingress_pipeline -v

--- a/.github/workflows/validate-kv-email-ingress-policy.yml
+++ b/.github/workflows/validate-kv-email-ingress-policy.yml
@@ -13,8 +13,10 @@ on:
       - "tests/test_email_continuity_runtime.py"
       - "runtime/email_ingress_pipeline.py"
       - "runtime/email_provider_adapter.py"
+      - "runtime/email_interlock.py"
       - "tests/test_email_ingress_pipeline.py"
       - "tests/test_email_provider_adapter.py"
+      - "tests/test_email_interlock.py"
       - "KV_EMAIL_INGRESS_MIRROR_HANDOFF.md"
       - ".github/workflows/validate-kv-email-ingress-policy.yml"
   push:
@@ -42,4 +44,4 @@ jobs:
       - name: Validate canonical policy
         run: python tools/check_kv_email_ingress_policy.py
       - name: Run deterministic tests
-        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime tests.test_email_ingress_pipeline tests.test_email_provider_adapter -v
+        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime tests.test_email_ingress_pipeline tests.test_email_provider_adapter tests.test_email_interlock -v

--- a/.github/workflows/validate-kv-email-ingress-policy.yml
+++ b/.github/workflows/validate-kv-email-ingress-policy.yml
@@ -12,7 +12,9 @@ on:
       - "runtime/email_continuity.py"
       - "tests/test_email_continuity_runtime.py"
       - "runtime/email_ingress_pipeline.py"
+      - "runtime/email_provider_adapter.py"
       - "tests/test_email_ingress_pipeline.py"
+      - "tests/test_email_provider_adapter.py"
       - "KV_EMAIL_INGRESS_MIRROR_HANDOFF.md"
       - ".github/workflows/validate-kv-email-ingress-policy.yml"
   push:
@@ -40,4 +42,4 @@ jobs:
       - name: Validate canonical policy
         run: python tools/check_kv_email_ingress_policy.py
       - name: Run deterministic tests
-        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime tests.test_email_ingress_pipeline -v
+        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime tests.test_email_ingress_pipeline tests.test_email_provider_adapter -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- governed KnowledgeVault email-continuity ingress contract with pre-admission staging, fail-closed admission decisions, SKAP Vault credential-reference binding, deterministic mailbox mapping, and source-ready runtime validation
+- provider-neutral email account mapping runtime that prohibits raw mailbox secrets in KV state and requires `skap://` binding before provider-session verification
 - fail-closed `KV-INTERLOCK-v1` runtime endpoint core with exact DEVICE→KV InTr admission binding, injected authority/policy/storage boundaries, bounded-context enforcement, deterministic receipts, and candidate-only `COMMIT_CANDIDATE` semantics
 - deterministic runtime endpoint tests and canonical runtime handoff for the Site/KV production backend seam
 

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -42,6 +42,9 @@ The `email-continuity` slot already exists under the 33-service Personal Service
 - `schemas/kv-email-account-mapping.schema.json`
 - `runtime/email_continuity.py`
 - `tests/test_email_continuity_runtime.py`
+- `schemas/kv-email-ingress-receipt.schema.json`
+- `runtime/email_ingress_pipeline.py`
+- `tests/test_email_ingress_pipeline.py`
 
 ## Governance invariants
 
@@ -104,6 +107,20 @@ Properties:
 - revoked mappings cannot be rebound without creating a new authorized mapping flow;
 - this runtime does not itself authenticate to a provider or read mailbox contents.
 
+## Staging / admission runtime extension
+
+The current runtime-extension branch adds:
+
+- deterministic canonical message identifiers bound to mailbox mapping + provider message ID;
+- `STAGED_UNTRUSTED` pre-admission state;
+- governed decisions `ADMIT | QUARANTINE | REVIEW | REJECT | FAIL_CLOSED`;
+- trusted projection creation only for `ADMIT`;
+- payload-free governance receipts;
+- deterministic duplicate reconciliation;
+- fail-closed content-drift detection when the same provider message identity presents changed content.
+
+This remains provider-neutral and uses caller-supplied classification signals. It does not claim production spam/phishing detection or live provider access.
+
 ## Hosted validation evidence
 
 Validated implementation head before handoff reconciliation:
@@ -160,9 +177,6 @@ The service must remain `INSTALLED_INACTIVE` / source-ready until all applicable
 
 - implement concrete provider adapter discovery/auth/session interfaces around the provider-neutral mapping contract;
 - implement the user-facing post-mapping SKAP Vault completion prompt around the now-implemented bounded credential-reference binding;
-- implement staged message normalization and canonical message identifiers;
-- implement governed admission/quarantine projection;
-- implement receipt/replay/reconciliation behavior;
 - expose the bounded service through the applicable KV/Interlock runtime;
 - perform real owner-authorized mailbox activation proof;
 - only then change runtime state from inactive/source-ready.

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -47,6 +47,8 @@ The `email-continuity` slot already exists under the 33-service Personal Service
 - `tests/test_email_ingress_pipeline.py`
 - `runtime/email_provider_adapter.py`
 - `tests/test_email_provider_adapter.py`
+- `runtime/email_interlock.py`
+- `tests/test_email_interlock.py`
 
 ## Governance invariants
 
@@ -133,7 +135,10 @@ The runtime extension now includes a concrete provider-adapter protocol/registry
 - the mapping runtime returns `COMPLETE_SKAP_CREDENTIAL_SETUP` immediately after mapping;
 - the next action explicitly names `SKAP_VAULT` as credential destination and `PROHIBITED_IN_KV` as raw-secret destination;
 - after SKAP reference binding, the next action becomes `VERIFY_PROVIDER_SESSION`;
-- only after session verification can the runtime surface `BEGIN_GOVERNED_INGRESS`, still subject to Interlock admission.
+- only after session verification can the runtime surface `BEGIN_GOVERNED_INGRESS`, still subject to Interlock admission;
+- email-specific Interlock builders now use the canonical `DISCOVER`, `REQUEST`, and `COMMIT_CANDIDATE` operations;
+- Interlock requests disclose source references/metadata only and contain no mailbox secret;
+- admitted email writeback is represented as a candidate-only projection until canonical policy admission.
 
 ## Hosted validation evidence
 
@@ -189,7 +194,6 @@ The service must remain `INSTALLED_INACTIVE` / source-ready until all applicable
 
 ## Remaining machine-execution work
 
-- expose the bounded service through the applicable KV/Interlock runtime;
 - perform real owner-authorized mailbox activation proof;
 - only then change runtime state from inactive/source-ready.
 

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -45,6 +45,8 @@ The `email-continuity` slot already exists under the 33-service Personal Service
 - `schemas/kv-email-ingress-receipt.schema.json`
 - `runtime/email_ingress_pipeline.py`
 - `tests/test_email_ingress_pipeline.py`
+- `runtime/email_provider_adapter.py`
+- `tests/test_email_provider_adapter.py`
 
 ## Governance invariants
 
@@ -121,6 +123,18 @@ The current runtime-extension branch adds:
 
 This remains provider-neutral and uses caller-supplied classification signals. It does not claim production spam/phishing detection or live provider access.
 
+## Provider adapter / post-mapping activation interface
+
+The runtime extension now includes a concrete provider-adapter protocol/registry:
+
+- domain/provider discovery must resolve exactly one registered route or fail closed;
+- discovery produces `MAPPED_CREDENTIAL_REQUIRED`, never an authenticated session;
+- provider session descriptors are metadata-only and are rejected if they expose password/secret/token fields;
+- the mapping runtime returns `COMPLETE_SKAP_CREDENTIAL_SETUP` immediately after mapping;
+- the next action explicitly names `SKAP_VAULT` as credential destination and `PROHIBITED_IN_KV` as raw-secret destination;
+- after SKAP reference binding, the next action becomes `VERIFY_PROVIDER_SESSION`;
+- only after session verification can the runtime surface `BEGIN_GOVERNED_INGRESS`, still subject to Interlock admission.
+
 ## Hosted validation evidence
 
 Validated implementation head before handoff reconciliation:
@@ -175,8 +189,6 @@ The service must remain `INSTALLED_INACTIVE` / source-ready until all applicable
 
 ## Remaining machine-execution work
 
-- implement concrete provider adapter discovery/auth/session interfaces around the provider-neutral mapping contract;
-- implement the user-facing post-mapping SKAP Vault completion prompt around the now-implemented bounded credential-reference binding;
 - expose the bounded service through the applicable KV/Interlock runtime;
 - perform real owner-authorized mailbox activation proof;
 - only then change runtime state from inactive/source-ready.

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -1,8 +1,8 @@
 # KV Governed Email Ingress Mirror Handoff
 
-Status: SOURCE_READY_VALIDATED_MERGE_PENDING  
+Status: SOURCE_READY_VALIDATED_MERGED_RUNTIME_EXTENSION_ACTIVE  
 Repository: StegVerse-Labs/continuity-vault-kit  
-Branch: `kv-governed-email-ingress`  
+Branch: `kv-email-ingress-runtime-v2`  
 Updated: 2026-08-27
 
 ## Purpose
@@ -122,6 +122,21 @@ The KV Guardrails lane initially exposed a nondeterministic tamper-test construc
 
 This evidence proves source/runtime-contract behavior only. It does not prove a live mailbox/provider session.
 
+## Merge evidence
+
+- PR: `#88`
+- final validated head: `e2eb801b0b39619e950174e8bc29ed77f5f3a4b1`
+- merge: `2784cdb6c39ee5fd95f3896e359de33472f04ac4`
+- merge method: squash
+- merged state: SOURCE_READY / NOT LIVE-ACTIVATED
+
+Final exact-head validation:
+- Validate KV Email Ingress Policy run `33135831775`: PASS
+- Security Baseline run `33135831717`: PASS
+- Repository validation diagnostics run `33135831685`: PASS
+- Release integrity run `33135831849`: PASS
+- KV Guardrails run `33135831764`: PASS
+
 ## Activation predicates
 
 The service must remain `INSTALLED_INACTIVE` / source-ready until all applicable predicates are proven with real owner-authorized activity:
@@ -143,8 +158,6 @@ The service must remain `INSTALLED_INACTIVE` / source-ready until all applicable
 
 ## Remaining machine-execution work
 
-- validate this branch through hosted CI;
-- reconcile the Personal Services registry entry with this more precise ingress contract if validation passes;
 - implement concrete provider adapter discovery/auth/session interfaces around the provider-neutral mapping contract;
 - implement the user-facing post-mapping SKAP Vault completion prompt around the now-implemented bounded credential-reference binding;
 - implement staged message normalization and canonical message identifiers;

--- a/runtime/email_continuity.py
+++ b/runtime/email_continuity.py
@@ -97,3 +97,46 @@ def assert_no_secret_fields(payload: dict) -> None:
     present = forbidden.intersection({str(k).lower() for k in payload})
     if present:
         raise EmailMappingError(f"raw credential material prohibited in KV mapping: {sorted(present)}")
+
+
+def next_activation_action(mapping: EmailAccountMapping) -> dict:
+    """Return the bounded user-visible next step for the current mapping state."""
+    if mapping.mapping_state == "MAPPED_CREDENTIAL_REQUIRED":
+        return {
+            "action": "COMPLETE_SKAP_CREDENTIAL_SETUP",
+            "message": "Complete setup in SKAP Vault to activate this email connection.",
+            "mapping_id": mapping.mapping_id,
+            "provider_id": mapping.provider_id,
+            "credential_destination": "SKAP_VAULT",
+            "raw_secret_destination": "PROHIBITED_IN_KV",
+            "authority_effect": "NONE",
+        }
+    if mapping.mapping_state == "CREDENTIAL_BOUND":
+        return {
+            "action": "VERIFY_PROVIDER_SESSION",
+            "message": "Verify the provider session using the bound SKAP credential reference.",
+            "mapping_id": mapping.mapping_id,
+            "provider_id": mapping.provider_id,
+            "credential_destination": "SKAP_VAULT",
+            "raw_secret_destination": "PROHIBITED_IN_KV",
+            "authority_effect": "NONE",
+        }
+    if mapping.mapping_state == "SESSION_VERIFIED":
+        return {
+            "action": "BEGIN_GOVERNED_INGRESS",
+            "message": "Provider session verified; governed ingress may begin when Interlock admission is available.",
+            "mapping_id": mapping.mapping_id,
+            "provider_id": mapping.provider_id,
+            "credential_destination": "SKAP_VAULT",
+            "raw_secret_destination": "PROHIBITED_IN_KV",
+            "authority_effect": "NONE",
+        }
+    return {
+        "action": "REAUTHORIZE_MAPPING",
+        "message": "This mapping is revoked and requires a new owner-authorized mapping flow.",
+        "mapping_id": mapping.mapping_id,
+        "provider_id": mapping.provider_id,
+        "credential_destination": "SKAP_VAULT",
+        "raw_secret_destination": "PROHIBITED_IN_KV",
+        "authority_effect": "NONE",
+    }

--- a/runtime/email_ingress_pipeline.py
+++ b/runtime/email_ingress_pipeline.py
@@ -1,0 +1,191 @@
+"""Deterministic pre-admission email staging and governed projection.
+
+No provider access occurs here. Callers supply already-retrieved message material and
+classification signals. Staged content remains untrusted until an ADMIT decision.
+Receipts contain hashes/metadata only and never persist the message payload.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, asdict
+from typing import Iterable
+
+DECISIONS = {"ADMIT", "QUARANTINE", "REVIEW", "REJECT", "FAIL_CLOSED"}
+
+
+class EmailIngressError(ValueError):
+    pass
+
+
+def _sha256_uri(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class StagedEmail:
+    mapping_id: str
+    canonical_message_id: str
+    provider_message_id: str
+    from_address: str
+    subject: str
+    payload: str
+    staged_content_hash: str
+    trust_state: str
+
+    def metadata(self) -> dict:
+        data = asdict(self)
+        data.pop("payload")
+        return data
+
+
+@dataclass(frozen=True)
+class EmailIngressReceipt:
+    schema: str
+    receipt_id: str
+    mapping_id: str
+    canonical_message_id: str
+    staged_content_hash: str
+    decision: str
+    reason: str
+    trusted_projection_created: bool
+    payload_retained_in_receipt: bool
+    authority_effect: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TrustedEmailProjection:
+    mapping_id: str
+    canonical_message_id: str
+    from_address: str
+    subject: str
+    payload: str
+    source_content_hash: str
+    trust_state: str
+
+
+def canonical_message_id(*, mapping_id: str, provider_message_id: str) -> str:
+    if not mapping_id.startswith("kv-email:"):
+        raise EmailIngressError("valid KV email mapping_id required")
+    provider_message_id = provider_message_id.strip()
+    if not provider_message_id:
+        raise EmailIngressError("provider_message_id required")
+    material = {
+        "mapping_id": mapping_id,
+        "provider_message_id": provider_message_id,
+    }
+    return "kv-email-message:" + hashlib.sha256(_canonical_bytes(material)).hexdigest()
+
+
+def stage_message(
+    *,
+    mapping_id: str,
+    provider_message_id: str,
+    from_address: str,
+    subject: str,
+    payload: str,
+) -> StagedEmail:
+    if not from_address.strip():
+        raise EmailIngressError("from_address required")
+    if not isinstance(payload, str):
+        raise EmailIngressError("payload must be text for canonical staging")
+    message_id = canonical_message_id(
+        mapping_id=mapping_id,
+        provider_message_id=provider_message_id,
+    )
+    hash_material = {
+        "mapping_id": mapping_id,
+        "canonical_message_id": message_id,
+        "from_address": from_address.strip().lower(),
+        "subject": subject.strip(),
+        "payload": payload,
+    }
+    return StagedEmail(
+        mapping_id=mapping_id,
+        canonical_message_id=message_id,
+        provider_message_id=provider_message_id.strip(),
+        from_address=from_address.strip().lower(),
+        subject=subject.strip(),
+        payload=payload,
+        staged_content_hash=_sha256_uri(_canonical_bytes(hash_material)),
+        trust_state="STAGED_UNTRUSTED",
+    )
+
+
+def decide(
+    staged: StagedEmail,
+    *,
+    signals: Iterable[str],
+    governance_available: bool = True,
+) -> tuple[EmailIngressReceipt, TrustedEmailProjection | None]:
+    normalized = {str(signal).strip().lower() for signal in signals if str(signal).strip()}
+
+    if not governance_available:
+        decision, reason = "FAIL_CLOSED", "governance_unavailable_or_ambiguous"
+    elif "spam_or_bulk_abuse" in normalized or "user_denylist" in normalized:
+        decision, reason = "REJECT", "active_rejection_rule"
+    elif "phishing" in normalized or "malware" in normalized or "dangerous_attachment" in normalized:
+        decision, reason = "QUARANTINE", "security_quarantine_rule"
+    elif "user_review_required" in normalized or "restricted_content" in normalized:
+        decision, reason = "REVIEW", "user_or_policy_review_rule"
+    else:
+        decision, reason = "ADMIT", "passes_active_ingress_governance"
+
+    projection = None
+    if decision == "ADMIT":
+        projection = TrustedEmailProjection(
+            mapping_id=staged.mapping_id,
+            canonical_message_id=staged.canonical_message_id,
+            from_address=staged.from_address,
+            subject=staged.subject,
+            payload=staged.payload,
+            source_content_hash=staged.staged_content_hash,
+            trust_state="TRUSTED_ADMITTED",
+        )
+
+    receipt_material = {
+        "mapping_id": staged.mapping_id,
+        "canonical_message_id": staged.canonical_message_id,
+        "staged_content_hash": staged.staged_content_hash,
+        "decision": decision,
+        "reason": reason,
+    }
+    receipt = EmailIngressReceipt(
+        schema="stegverse.kv.email-ingress-receipt/v1",
+        receipt_id="kv-email-receipt:" + hashlib.sha256(_canonical_bytes(receipt_material)).hexdigest(),
+        mapping_id=staged.mapping_id,
+        canonical_message_id=staged.canonical_message_id,
+        staged_content_hash=staged.staged_content_hash,
+        decision=decision,
+        reason=reason,
+        trusted_projection_created=projection is not None,
+        payload_retained_in_receipt=False,
+        authority_effect="NONE",
+    )
+    return receipt, projection
+
+
+def reconcile_duplicate(
+    *,
+    staged: StagedEmail,
+    prior_receipt: EmailIngressReceipt,
+) -> str:
+    if prior_receipt.canonical_message_id != staged.canonical_message_id:
+        return "NEW_MESSAGE"
+    if prior_receipt.staged_content_hash != staged.staged_content_hash:
+        raise EmailIngressError("canonical message id collision with content drift")
+    return "ALREADY_EVALUATED"

--- a/runtime/email_interlock.py
+++ b/runtime/email_interlock.py
@@ -1,0 +1,99 @@
+"""Email-continuity specialization for the canonical KV-INTERLOCK-v1 request contract."""
+
+from __future__ import annotations
+
+from runtime.email_continuity import EmailAccountMapping, EmailMappingError
+
+
+def _base_request(
+    *,
+    operation: str,
+    request_id: str,
+    purpose: str,
+    authority_ref: str,
+    requested_scope: list[str],
+    mapping: EmailAccountMapping,
+) -> dict:
+    if mapping.mapping_state == "REVOKED":
+        raise EmailMappingError("revoked email mapping cannot request Interlock admission")
+    if not request_id or not authority_ref:
+        raise EmailMappingError("request_id and authority_ref are required")
+    return {
+        "schema_version": "kv.interlock.request.v1",
+        "operation": operation,
+        "request_id": request_id,
+        "requester": {
+            "module": "email-continuity",
+            "component": "governed-ingress",
+        },
+        "purpose": purpose,
+        "record_class": "email-continuity",
+        "requested_scope": requested_scope,
+        "minimum_necessary_justification": (
+            f"Govern mailbox mapping {mapping.mapping_id} without disclosing mailbox secrets."
+        ),
+        "authority_ref": authority_ref,
+        "disclosure_mode": "SOURCE_REFERENCE_ONLY",
+    }
+
+
+def build_ingress_discovery_request(
+    *,
+    request_id: str,
+    authority_ref: str,
+    mapping: EmailAccountMapping,
+) -> dict:
+    return _base_request(
+        operation="DISCOVER",
+        request_id=request_id,
+        purpose="email.ingress.discover",
+        authority_ref=authority_ref,
+        requested_scope=["email_mapping_state", "email_provider_state"],
+        mapping=mapping,
+    )
+
+
+def build_ingress_evaluation_request(
+    *,
+    request_id: str,
+    authority_ref: str,
+    mapping: EmailAccountMapping,
+) -> dict:
+    if mapping.mapping_state != "SESSION_VERIFIED":
+        raise EmailMappingError("ingress evaluation requires verified provider session")
+    return _base_request(
+        operation="REQUEST",
+        request_id=request_id,
+        purpose="email.ingress.evaluate",
+        authority_ref=authority_ref,
+        requested_scope=["email_message_metadata", "email_ingress_policy"],
+        mapping=mapping,
+    )
+
+
+def build_projection_candidate_request(
+    *,
+    request_id: str,
+    authority_ref: str,
+    mapping: EmailAccountMapping,
+    payload_ref: str,
+    requested_destination: str = "03_Records/Email",
+) -> dict:
+    if mapping.mapping_state != "SESSION_VERIFIED":
+        raise EmailMappingError("email projection candidate requires verified provider session")
+    if not payload_ref.startswith("sha256:"):
+        raise EmailMappingError("candidate payload_ref must be a sha256 reference")
+    request = _base_request(
+        operation="COMMIT_CANDIDATE",
+        request_id=request_id,
+        purpose="email.ingress.project-admitted",
+        authority_ref=authority_ref,
+        requested_scope=["email_projection_candidate"],
+        mapping=mapping,
+    )
+    request["candidate_writeback"] = {
+        "candidate_type": "email_admitted_projection",
+        "payload_ref": payload_ref,
+        "requested_destination": requested_destination,
+    }
+    return request

--- a/runtime/email_provider_adapter.py
+++ b/runtime/email_provider_adapter.py
@@ -1,0 +1,57 @@
+"""Provider discovery/session interface for KnowledgeVault email continuity.
+
+Concrete provider adapters implement this contract outside ordinary KV secret state.
+Discovery may identify a provider route, but authentication/session verification
+must remain separate and requires a bound SKAP credential reference.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from runtime.email_continuity import EmailAccountMapping, EmailMappingError, create_mapping
+
+
+class EmailProviderAdapter(Protocol):
+    provider_id: str
+    provider_route: str
+
+    def matches_domain(self, domain: str) -> bool: ...
+
+    def session_descriptor(self, mapping: EmailAccountMapping) -> dict: ...
+
+
+@dataclass
+class ProviderRegistry:
+    adapters: list[EmailProviderAdapter]
+
+    def discover(self, email_address: str) -> EmailAccountMapping:
+        if "@" not in email_address:
+            raise EmailMappingError("valid email address required")
+        domain = email_address.rsplit("@", 1)[1].strip().lower()
+        matches = [adapter for adapter in self.adapters if adapter.matches_domain(domain)]
+        if len(matches) != 1:
+            raise EmailMappingError("provider discovery must resolve exactly one supported route")
+        adapter = matches[0]
+        return create_mapping(
+            email_address=email_address,
+            provider_id=adapter.provider_id,
+            provider_route=adapter.provider_route,
+        )
+
+    def descriptor_for(self, mapping: EmailAccountMapping) -> dict:
+        matches = [
+            adapter for adapter in self.adapters
+            if adapter.provider_id == mapping.provider_id
+            and adapter.provider_route == mapping.provider_route
+        ]
+        if len(matches) != 1:
+            raise EmailMappingError("mapped provider adapter unavailable or ambiguous")
+        descriptor = matches[0].session_descriptor(mapping)
+        if not isinstance(descriptor, dict):
+            raise EmailMappingError("provider session descriptor must be an object")
+        forbidden = {"password", "secret", "token", "access_token", "refresh_token", "app_password"}
+        if forbidden.intersection({str(key).lower() for key in descriptor}):
+            raise EmailMappingError("provider session descriptor may not contain raw credential material")
+        return descriptor

--- a/schemas/kv-email-ingress-receipt.schema.json
+++ b/schemas/kv-email-ingress-receipt.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-email-ingress-receipt.schema.json",
+  "title": "KnowledgeVault Email Ingress Governance Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "receipt_id",
+    "mapping_id",
+    "canonical_message_id",
+    "staged_content_hash",
+    "decision",
+    "reason",
+    "trusted_projection_created",
+    "payload_retained_in_receipt",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.kv.email-ingress-receipt/v1"},
+    "receipt_id": {"type": "string", "pattern": "^kv-email-receipt:[a-f0-9]{64}$"},
+    "mapping_id": {"type": "string", "pattern": "^kv-email:[a-f0-9]{64}$"},
+    "canonical_message_id": {"type": "string", "pattern": "^kv-email-message:[a-f0-9]{64}$"},
+    "staged_content_hash": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+    "decision": {"enum": ["ADMIT", "QUARANTINE", "REVIEW", "REJECT", "FAIL_CLOSED"]},
+    "reason": {"type": "string", "minLength": 1},
+    "trusted_projection_created": {"type": "boolean"},
+    "payload_retained_in_receipt": {"const": false},
+    "authority_effect": {"const": "NONE"}
+  }
+}

--- a/tests/test_email_continuity_runtime.py
+++ b/tests/test_email_continuity_runtime.py
@@ -7,6 +7,7 @@ from runtime.email_continuity import (
     create_mapping,
     mapping_id_for,
     mark_session_verified,
+    next_activation_action,
     revoke_mapping,
 )
 
@@ -24,6 +25,18 @@ class EmailContinuityRuntimeTests(unittest.TestCase):
         self.assertIsNone(mapping.skap_credential_ref)
         self.assertFalse(mapping.credential_secret_present_in_kv)
         self.assertEqual(mapping.authority_effect, "NONE")
+
+    def test_mapping_next_action_prompts_skap_vault(self):
+        mapping = create_mapping(
+            email_address="user@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        action = next_activation_action(mapping)
+        self.assertEqual(action["action"], "COMPLETE_SKAP_CREDENTIAL_SETUP")
+        self.assertEqual(action["credential_destination"], "SKAP_VAULT")
+        self.assertEqual(action["raw_secret_destination"], "PROHIBITED_IN_KV")
+        self.assertEqual(action["authority_effect"], "NONE")
 
     def test_skap_binding_moves_to_credential_bound(self):
         mapping = create_mapping(

--- a/tests/test_email_ingress_pipeline.py
+++ b/tests/test_email_ingress_pipeline.py
@@ -1,0 +1,83 @@
+import unittest
+
+from runtime.email_ingress_pipeline import (
+    EmailIngressError,
+    decide,
+    reconcile_duplicate,
+    stage_message,
+)
+
+
+class EmailIngressPipelineTests(unittest.TestCase):
+    def setUp(self):
+        self.mapping_id = "kv-email:" + ("a" * 64)
+
+    def _stage(self, *, payload="hello"):
+        return stage_message(
+            mapping_id=self.mapping_id,
+            provider_message_id="provider-123",
+            from_address="Sender@Example.com",
+            subject="Subject",
+            payload=payload,
+        )
+
+    def test_stage_is_untrusted_and_deterministic(self):
+        first = self._stage()
+        second = self._stage()
+        self.assertEqual(first.canonical_message_id, second.canonical_message_id)
+        self.assertEqual(first.staged_content_hash, second.staged_content_hash)
+        self.assertEqual(first.trust_state, "STAGED_UNTRUSTED")
+
+    def test_admit_creates_trusted_projection_and_payload_free_receipt(self):
+        staged = self._stage()
+        receipt, projection = decide(staged, signals=[])
+        self.assertEqual(receipt.decision, "ADMIT")
+        self.assertTrue(receipt.trusted_projection_created)
+        self.assertFalse(receipt.payload_retained_in_receipt)
+        self.assertIsNotNone(projection)
+        self.assertEqual(projection.trust_state, "TRUSTED_ADMITTED")
+        self.assertNotIn("payload", receipt.to_dict())
+
+    def test_spam_rejects_without_projection(self):
+        staged = self._stage()
+        receipt, projection = decide(staged, signals=["spam_or_bulk_abuse"])
+        self.assertEqual(receipt.decision, "REJECT")
+        self.assertIsNone(projection)
+        self.assertFalse(receipt.trusted_projection_created)
+
+    def test_phishing_quarantines_without_projection(self):
+        staged = self._stage()
+        receipt, projection = decide(staged, signals=["phishing"])
+        self.assertEqual(receipt.decision, "QUARANTINE")
+        self.assertIsNone(projection)
+
+    def test_user_restriction_requires_review(self):
+        staged = self._stage()
+        receipt, projection = decide(staged, signals=["user_review_required"])
+        self.assertEqual(receipt.decision, "REVIEW")
+        self.assertIsNone(projection)
+
+    def test_governance_unavailable_fails_closed(self):
+        staged = self._stage()
+        receipt, projection = decide(staged, signals=[], governance_available=False)
+        self.assertEqual(receipt.decision, "FAIL_CLOSED")
+        self.assertIsNone(projection)
+
+    def test_duplicate_reconciliation_is_idempotent(self):
+        staged = self._stage()
+        receipt, _ = decide(staged, signals=[])
+        self.assertEqual(
+            reconcile_duplicate(staged=staged, prior_receipt=receipt),
+            "ALREADY_EVALUATED",
+        )
+
+    def test_same_provider_id_with_content_drift_fails(self):
+        staged = self._stage(payload="hello")
+        receipt, _ = decide(staged, signals=[])
+        changed = self._stage(payload="changed")
+        with self.assertRaises(EmailIngressError):
+            reconcile_duplicate(staged=changed, prior_receipt=receipt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_email_interlock.py
+++ b/tests/test_email_interlock.py
@@ -1,0 +1,84 @@
+import unittest
+
+from runtime.email_continuity import (
+    EmailMappingError,
+    bind_skap_credential,
+    create_mapping,
+    mark_session_verified,
+    revoke_mapping,
+)
+from runtime.email_interlock import (
+    build_ingress_discovery_request,
+    build_ingress_evaluation_request,
+    build_projection_candidate_request,
+)
+
+
+class EmailInterlockBridgeTests(unittest.TestCase):
+    def _mapped(self):
+        return create_mapping(
+            email_address="user@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+
+    def _verified(self):
+        mapped = self._mapped()
+        bound = bind_skap_credential(mapped, skap_credential_ref="skap://Mail/example/user")
+        return mark_session_verified(bound)
+
+    def test_discovery_request_contains_no_secret_fields(self):
+        request = build_ingress_discovery_request(
+            request_id="req-discover-1",
+            authority_ref="authority://owner/example",
+            mapping=self._mapped(),
+        )
+        encoded = str(request).lower()
+        self.assertEqual(request["operation"], "DISCOVER")
+        self.assertNotIn("password", encoded)
+        self.assertNotIn("access_token", encoded)
+        self.assertNotIn("refresh_token", encoded)
+
+    def test_evaluation_requires_verified_session(self):
+        with self.assertRaises(EmailMappingError):
+            build_ingress_evaluation_request(
+                request_id="req-eval-1",
+                authority_ref="authority://owner/example",
+                mapping=self._mapped(),
+            )
+
+    def test_verified_session_can_request_ingress_evaluation(self):
+        request = build_ingress_evaluation_request(
+            request_id="req-eval-2",
+            authority_ref="authority://owner/example",
+            mapping=self._verified(),
+        )
+        self.assertEqual(request["operation"], "REQUEST")
+        self.assertEqual(request["record_class"], "email-continuity")
+        self.assertEqual(request["disclosure_mode"], "SOURCE_REFERENCE_ONLY")
+
+    def test_projection_is_candidate_only(self):
+        request = build_projection_candidate_request(
+            request_id="req-write-1",
+            authority_ref="authority://owner/example",
+            mapping=self._verified(),
+            payload_ref="sha256:" + ("b" * 64),
+        )
+        self.assertEqual(request["operation"], "COMMIT_CANDIDATE")
+        self.assertEqual(
+            request["candidate_writeback"]["candidate_type"],
+            "email_admitted_projection",
+        )
+        self.assertTrue(request["candidate_writeback"]["payload_ref"].startswith("sha256:"))
+
+    def test_revoked_mapping_cannot_request_interlock(self):
+        with self.assertRaises(EmailMappingError):
+            build_ingress_discovery_request(
+                request_id="req-revoked",
+                authority_ref="authority://owner/example",
+                mapping=revoke_mapping(self._mapped()),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_email_provider_adapter.py
+++ b/tests/test_email_provider_adapter.py
@@ -1,0 +1,68 @@
+import unittest
+
+from runtime.email_continuity import EmailMappingError
+from runtime.email_provider_adapter import ProviderRegistry
+
+
+class ExampleAdapter:
+    provider_id = "example-mail"
+    provider_route = "provider://example/mail"
+
+    def matches_domain(self, domain: str) -> bool:
+        return domain == "example.com"
+
+    def session_descriptor(self, mapping):
+        return {
+            "provider_id": self.provider_id,
+            "provider_route": self.provider_route,
+            "mapping_id": mapping.mapping_id,
+            "skap_credential_ref_required": True,
+            "authority_effect": "NONE",
+        }
+
+
+class SecretLeakingAdapter(ExampleAdapter):
+    provider_id = "bad-mail"
+    provider_route = "provider://bad/mail"
+
+    def matches_domain(self, domain: str) -> bool:
+        return domain == "bad.example"
+
+    def session_descriptor(self, mapping):
+        return {"access_token": "synthetic-prohibited"}
+
+
+class EmailProviderAdapterTests(unittest.TestCase):
+    def test_discovery_creates_credential_required_mapping(self):
+        registry = ProviderRegistry([ExampleAdapter()])
+        mapping = registry.discover("User@Example.com")
+        self.assertEqual(mapping.provider_id, "example-mail")
+        self.assertEqual(mapping.mapping_state, "MAPPED_CREDENTIAL_REQUIRED")
+        self.assertIsNone(mapping.skap_credential_ref)
+
+    def test_unknown_provider_fails_closed(self):
+        registry = ProviderRegistry([ExampleAdapter()])
+        with self.assertRaises(EmailMappingError):
+            registry.discover("user@unknown.example")
+
+    def test_ambiguous_provider_fails_closed(self):
+        registry = ProviderRegistry([ExampleAdapter(), ExampleAdapter()])
+        with self.assertRaises(EmailMappingError):
+            registry.discover("user@example.com")
+
+    def test_session_descriptor_is_secret_free(self):
+        registry = ProviderRegistry([ExampleAdapter()])
+        mapping = registry.discover("user@example.com")
+        descriptor = registry.descriptor_for(mapping)
+        self.assertTrue(descriptor["skap_credential_ref_required"])
+        self.assertEqual(descriptor["authority_effect"], "NONE")
+
+    def test_secret_leaking_adapter_is_rejected(self):
+        registry = ProviderRegistry([SecretLeakingAdapter()])
+        mapping = registry.discover("user@bad.example")
+        with self.assertRaises(EmailMappingError):
+            registry.descriptor_for(mapping)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Advances the merged governed email-ingress source lane beyond account mapping into deterministic pre-admission staging and decision receipts.

### Adds
- `schemas/kv-email-ingress-receipt.schema.json`
- `runtime/email_ingress_pipeline.py`
- deterministic staging/admission/replay tests
- dedicated workflow coverage for the new runtime
- merged-state and runtime-extension reconciliation in `KV_EMAIL_INGRESS_MIRROR_HANDOFF.md`
- `CHANGELOG.md#Unreleased` email-ingress entries

### Behavior
- staged mail is `STAGED_UNTRUSTED`
- only `ADMIT` creates `TRUSTED_ADMITTED` projection
- `REJECT`, `QUARANTINE`, `REVIEW`, and `FAIL_CLOSED` create no trusted projection
- governance receipts retain hashes/decision metadata, not message payload
- duplicate replay is deterministic
- same canonical provider message identity with changed content fails closed

### Release boundary
Persistent VERSION remains `0.1.9`. Successor publication/tagging remains TV/TVC-admitted only. Issue #90 tracks downstream propagation verification after an admitted release.

### Non-claims
No real mailbox is connected, no credentials are installed, and no production provider/spam classifier is activated.