### PR TITLE
Retire hosted production-provider activation authority

### DIFF
--- a/.github/workflows/production-provider-activation.yml
+++ b/.github/workflows/production-provider-activation.yml
@@ -1,35 +1,23 @@
-name: Production Provider Activation
+name: Production Provider Activation - Validation Only
 
 on:
   workflow_dispatch:
     inputs:
-      action:
-        description: Terraform operation
-        required: true
-        type: choice
-        options:
-          - plan
-          - apply
-      confirm_apply:
-        description: Type APPLY to authorize infrastructure mutation
-        required: false
-        type: string
       spiffe_identity:
-        description: Configured SPIFFE workload identity
+        description: Expected SPIFFE workload identity for future resident activation
         required: true
         type: string
       ecosystem_chat_endpoint:
-        description: Authenticated Ecosystem Chat HTTPS endpoint
+        description: Expected authenticated Ecosystem Chat HTTPS endpoint
         required: true
         type: string
       master_records_endpoint:
-        description: Authenticated Master-Records HTTPS endpoint
+        description: Expected authenticated Master-Records HTTPS endpoint
         required: true
         type: string
 
 permissions:
   contents: read
-  id-token: write
 
 env:
   TF_IN_AUTOMATION: "true"
@@ -37,45 +25,28 @@ env:
   TF_WORKING_DIR: infra/production-providers
 
 jobs:
-  activate:
-    name: Plan or apply protected providers
+  validate:
+    name: Validate provider activation source only
     runs-on: ubuntu-latest
-    environment: production-provider-activation
-    concurrency:
-      group: production-provider-activation
-      cancel-in-progress: false
-    steps:
-      - name: Check out exact repository state
-        uses: actions/checkout@v4
+    timeout-minutes: 15
 
-      - name: Reject incomplete or unsafe inputs
+    steps:
+      - name: Check out exact repository state without credential persistence
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Reject incomplete activation metadata
         shell: bash
         env:
-          REQUESTED_ACTION: ${{ inputs.action }}
-          CONFIRM_APPLY: ${{ inputs.confirm_apply }}
           SPIFFE_IDENTITY: ${{ inputs.spiffe_identity }}
           CHAT_ENDPOINT: ${{ inputs.ecosystem_chat_endpoint }}
           MASTER_RECORDS_ENDPOINT: ${{ inputs.master_records_endpoint }}
-          AWS_ROLE_ARN: ${{ vars.PROVIDER_ACTIVATION_AWS_ROLE_ARN }}
-          AWS_REGION: ${{ vars.PROVIDER_ACTIVATION_AWS_REGION }}
         run: |
           set -euo pipefail
-          test -n "$AWS_ROLE_ARN"
-          test -n "$AWS_REGION"
           [[ "$SPIFFE_IDENTITY" == spiffe://* ]]
           [[ "$CHAT_ENDPOINT" == https://* ]]
           [[ "$MASTER_RECORDS_ENDPOINT" == https://* ]]
-          if [[ "$REQUESTED_ACTION" == "apply" && "$CONFIRM_APPLY" != "APPLY" ]]; then
-            echo "Apply requires exact confirmation token APPLY" >&2
-            exit 1
-          fi
-
-      - name: Configure AWS identity through GitHub OIDC
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.PROVIDER_ACTIVATION_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.PROVIDER_ACTIVATION_AWS_REGION }}
-          role-session-name: continuity-vault-provider-activation
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
@@ -86,75 +57,60 @@ jobs:
         working-directory: ${{ env.TF_WORKING_DIR }}
         run: terraform fmt -check -recursive
 
-      - name: Initialize Terraform
+      - name: Initialize Terraform without backend
         working-directory: ${{ env.TF_WORKING_DIR }}
-        run: terraform init -input=false
+        run: terraform init -backend=false -input=false
 
-      - name: Validate Terraform
+      - name: Validate Terraform source
         working-directory: ${{ env.TF_WORKING_DIR }}
         run: terraform validate
 
-      - name: Create immutable execution plan
-        working-directory: ${{ env.TF_WORKING_DIR }}
-        run: terraform plan -input=false -out=provider-activation.tfplan
-
-      - name: Apply approved execution plan
-        if: ${{ inputs.action == 'apply' }}
-        working-directory: ${{ env.TF_WORKING_DIR }}
-        run: terraform apply -input=false -auto-approve provider-activation.tfplan
-
-      - name: Export configured provider identifiers
-        if: ${{ inputs.action == 'apply' }}
-        working-directory: ${{ env.TF_WORKING_DIR }}
-        run: terraform output -json > provider-outputs.json
-
-      - name: Assemble fail-closed activation input artifact
-        if: ${{ inputs.action == 'apply' }}
+      - name: Emit non-authorizing resident activation request
         shell: bash
         env:
           SPIFFE_IDENTITY: ${{ inputs.spiffe_identity }}
           CHAT_ENDPOINT: ${{ inputs.ecosystem_chat_endpoint }}
           MASTER_RECORDS_ENDPOINT: ${{ inputs.master_records_endpoint }}
-          AWS_REGION: ${{ vars.PROVIDER_ACTIVATION_AWS_REGION }}
           SOURCE_COMMIT: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          set -euo pipefail
           python3 - <<'PY'
-          import json
-          import os
+          import json, os
+          from datetime import datetime, timezone
           from pathlib import Path
-
-          outputs = json.loads(Path("infra/production-providers/provider-outputs.json").read_text())
-          def value(name):
-              item = outputs.get(name)
-              if not isinstance(item, dict) or not item.get("value"):
-                  raise SystemExit(f"missing Terraform output: {name}")
-              return item["value"]
-
-          artifact = {
-              "schema": "stegverse.production-provider-inputs.v1",
-              "decision": "FAIL_CLOSED",
+          payload = {
+              "schema": "stegverse.production-provider-activation-request/v1",
+              "state": "TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION_REQUIRED",
+              "repository": os.environ["REPOSITORY"],
               "source_commit": os.environ["SOURCE_COMMIT"],
-              "providers": {
-                  "steg-id-signature": {"identity_ref": value("stegid_kms_key_arn"), "region": os.environ["AWS_REGION"]},
-                  "key-custody": {"identity_ref": value("custody_kms_key_arn"), "region": os.environ["AWS_REGION"]},
-                  "replicated-state": {"identity_ref": value("state_table_arn"), "region": os.environ["AWS_REGION"]},
-                  "ai-entity-attestation": {"identity_ref": os.environ["SPIFFE_IDENTITY"], "region": "global"},
-                  "ecosystem-chat": {"identity_ref": os.environ["CHAT_ENDPOINT"], "region": "global"},
-                  "master-records": {"identity_ref": os.environ["MASTER_RECORDS_ENDPOINT"], "region": "global"},
+              "workflow_run_id": os.environ["RUN_ID"],
+              "requested_provider_metadata": {
+                  "spiffe_identity": os.environ["SPIFFE_IDENTITY"],
+                  "ecosystem_chat_endpoint": os.environ["CHAT_ENDPOINT"],
+                  "master_records_endpoint": os.environ["MASTER_RECORDS_ENDPOINT"],
               },
-              "next_gate": "execute all six live probes and assemble signed deployment receipt",
+              "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+              "cloud_identity_acquired": False,
+              "oidc_token_requested": False,
+              "terraform_plan_against_production_performed": False,
+              "terraform_apply_performed": False,
+              "provider_mutation_performed": False,
+              "credential_authority": "TV/TVC",
+              "canonical_next_transition": "TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION",
+              "authority_effect": "NONE",
+              "generated_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
           }
-          Path("activation-provider-inputs.json").write_text(json.dumps(artifact, sort_keys=True, indent=2) + "\n")
+          out=Path("reports/production_provider_activation")
+          out.mkdir(parents=True,exist_ok=True)
+          (out/"activation-request.json").write_text(json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps(payload,sort_keys=True))
           PY
 
-      - name: Upload plan and provider evidence inputs
+      - name: Upload non-authorizing provider activation request
         uses: actions/upload-artifact@v4
         with:
-          name: production-provider-activation-${{ github.run_id }}
-          path: |
-            infra/production-providers/provider-activation.tfplan
-            infra/production-providers/provider-outputs.json
-            activation-provider-inputs.json
+          name: production-provider-activation-request-${{ github.run_id }}
+          path: reports/production_provider_activation/activation-request.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -14,7 +14,9 @@ on:
       - "tests/test_hosted_release_authority_retirement.py"
       - "tests/test_hosted_candidate_authority_retirement.py"
       - "tests/test_hosted_onboarding_control_plane_retirement.py"
+      - "tests/test_production_provider_hosted_authority_retirement.py"
       - "tests/test_hosted_onboarding_control_plane_retirement.py"
+      - "tests/test_production_provider_hosted_authority_retirement.py"
       - "vault_template/**"
       - "automation/**"
       - "evidence/onboarding-friction/**"
@@ -85,6 +87,9 @@ jobs:
 
       - name: Validate hosted onboarding control-plane retirement
         run: python3 -m unittest tests.test_hosted_onboarding_control_plane_retirement -v
+
+      - name: Validate production provider hosted authority retirement
+        run: python3 -m unittest tests.test_production_provider_hosted_authority_retirement -v
 
       - name: Rebuild release evidence
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 - retired residual `release-integrity.yml` evidence writeback and `automated-release.yml` VERSION/changelog/tag/GitHub-release mutation authority; hosted release workflows now validate and transport non-secret evidence only
 - retired `automation-candidate-implementation.yml` hosted issue/repository/workflow-dispatch mutation authority; merged-PR candidate references are now emitted only as non-authorizing observation evidence
 - retired the coupled onboarding-friction triage/maintenance/bootstrap and candidate-lifecycle hosted control plane; classification and threshold projections now emit non-authorizing artifacts without issue, label, repository, workflow-dispatch, or token authority
+- retired GitHub-OIDC production-provider activation authority; hosted provider workflow now validates IaC source only and defers cloud identity/provisioning/apply to TVC-admitted resident execution
 - preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
 
 ### Notes

--- a/PRODUCTION_PROVIDER_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
+++ b/PRODUCTION_PROVIDER_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-08-27
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Canonical activation issue: #16
 Branch: `fix/production-provider-hosted-authority-16`
-State: CORRECTIVE_SUBLANE_CLAIMED
+State: IMPLEMENTED_ON_BRANCH_VALIDATION_PENDING
 
 ## Purpose
 
@@ -77,6 +77,29 @@ Do not create a second provider activation architecture, credential path, AWS br
 
 This source repair does not deploy AWS resources, create an IAM role, establish OIDC trust, activate production providers, execute live probes, or satisfy issue #16.
 
+## Implemented source state
+
+```text
+workflow: Production Provider Activation - Validation Only
+permissions: contents: read
+persist-credentials: false
+GitHub OIDC: removed
+AWS role assumption: removed
+Terraform production plan: removed
+Terraform apply: removed
+cloud identity acquisition: false
+provider mutation: false
+Terraform fmt/init -backend=false/validate: retained
+non-authorizing activation-request artifact: retained
+canonical_next_transition: TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION
+authority_effect: NONE
+```
+
+Regression:
+- `tools/test_automation_contracts.py` rejects reintroduced OIDC/AWS/apply authority.
+- `tests/test_production_provider_hosted_authority_retirement.py` enforces the hosted boundary.
+- Release Integrity runs the dedicated regression.
+
 ## Next executable boundary
 
-Convert the hosted workflow to validation-only, add fail-closed regression coverage, validate exact head, merge, then update issue #16 and canonical handoff so the next operator/runtime step points to TVC-admitted resident execution instead of GitHub OIDC apply.
+Validate exact head and merge only on green evidence. Then update issue #16 to remove GitHub OIDC/apply operator instructions and point the remaining live activation gates to TVC-admitted resident execution.

--- a/PRODUCTION_PROVIDER_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
+++ b/PRODUCTION_PROVIDER_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
@@ -1,0 +1,82 @@
+# Production Provider Hosted Authority Retirement Mirror Handoff
+
+Updated: 2026-08-27
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Canonical activation issue: #16
+Branch: `fix/production-provider-hosted-authority-16`
+State: CORRECTIVE_SUBLANE_CLAIMED
+
+## Purpose
+
+Correct the authority model of the existing Production Provider Activation lane without creating a duplicate activation owner.
+
+Issue #16 remains the canonical activation lane. This handoff is the source-correction authority for the hosted workflow only.
+
+## Live contradiction
+
+Current `.github/workflows/production-provider-activation.yml` grants:
+
+```text
+id-token: write
+GitHub OIDC -> AWS production role
+Terraform plan against production providers
+Terraform apply -auto-approve
+provider identifier export after apply
+GitHub-hosted activation evidence assembly
+```
+
+That conflicts with the current StegVerse execution contract:
+
+```text
+GitHub Actions production authority: NONE
+GitHub Actions runtime authority: NONE
+GitHub Actions control-plane authority: NONE
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+credential/secret/token authority: TV/TVC ONLY
+production infrastructure mutation: sovereign resident / TVC-admitted execution only
+```
+
+A GitHub environment approval or typed `APPLY` token does not change the authority class of the hosted runner.
+
+## Required corrected state
+
+```text
+workflow name: Production Provider Activation - Validation Only
+permissions: contents: read
+id-token: write: REMOVED
+AWS role assumption: REMOVED
+Terraform apply: REMOVED
+production plan requiring cloud credentials: REMOVED
+provider mutation: false
+credential acquisition: false
+GitHub-hosted activation: false
+source/IaC validation: retained
+non-secret activation-request artifact: retained
+canonical_next_transition: TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION
+authority_effect: NONE
+```
+
+The hosted workflow may validate Terraform formatting/configuration and emit a non-authorizing activation-request/readiness artifact. It may not acquire AWS credentials, mutate infrastructure, or claim provider deployment.
+
+## Canonical runtime continuation
+
+Issue #16 remains open until a non-hosted admitted runtime performs and proves:
+1. TVC-authorized provider identity/capability admission.
+2. Sovereign execution of provider provisioning/mutation.
+3. Six live probes against actual configured services.
+4. Master-Records acknowledgement.
+5. rollback/revocation evidence.
+6. signed deployment receipt.
+7. repository readback of non-secret runtime evidence where admitted.
+
+## Collision boundary
+
+Do not create a second provider activation architecture, credential path, AWS broker, or provider authority. Existing Terraform source may remain as deployment intent/source, but hosted Actions may only validate it.
+
+## Non-claims
+
+This source repair does not deploy AWS resources, create an IAM role, establish OIDC trust, activate production providers, execute live probes, or satisfy issue #16.
+
+## Next executable boundary
+
+Convert the hosted workflow to validation-only, add fail-closed regression coverage, validate exact head, merge, then update issue #16 and canonical handoff so the next operator/runtime step points to TVC-admitted resident execution instead of GitHub OIDC apply.

--- a/tests/test_production_provider_hosted_authority_retirement.py
+++ b/tests/test_production_provider_hosted_authority_retirement.py
@@ -1,0 +1,41 @@
+"""Regression guard for hosted production-provider authority retirement."""
+from pathlib import Path
+import unittest
+
+ROOT=Path(__file__).resolve().parents[1]
+WORKFLOW=ROOT/".github/workflows/production-provider-activation.yml"
+
+class ProductionProviderHostedAuthorityRetirementTests(unittest.TestCase):
+    def test_hosted_workflow_cannot_acquire_or_apply_production_authority(self):
+        text=WORKFLOW.read_text(encoding="utf-8")
+        for token in (
+            "id-token: write",
+            "aws-actions/configure-aws-credentials",
+            "role-to-assume:",
+            "terraform plan",
+            "terraform apply",
+            "confirm_apply",
+            "PROVIDER_ACTIVATION_AWS_ROLE_ARN",
+            "github.token",
+            "GH_TOKEN:",
+            "${{ secrets.",
+        ):
+            self.assertNotIn(token,text,token)
+        for token in (
+            "contents: read",
+            "persist-credentials: false",
+            "terraform init -backend=false",
+            "terraform validate",
+            "VALIDATION_TRANSPORT_ONLY",
+            "TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION",
+            "cloud_identity_acquired",
+            "terraform_apply_performed",
+            "provider_mutation_performed",
+            "actions/upload-artifact@v4",
+            "authority_effect",
+            "NONE",
+        ):
+            self.assertIn(token,text,token)
+
+if __name__=="__main__":
+    unittest.main()

--- a/tools/test_automation_contracts.py
+++ b/tools/test_automation_contracts.py
@@ -81,6 +81,14 @@ WORKFLOWS = {
         "NON_HOSTED_CANDIDATE_RECONCILIATION",
         "actions/upload-artifact@v4",
     },
+    "production-provider-activation.yml": {
+        "name: Production Provider Activation - Validation Only",
+        "contents: read",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION",
+        "actions/upload-artifact@v4",
+    },
     "automation-candidate-implementation.yml": {
         "name: Automation candidate implementation - Validation Only",
         "pull_request:",
@@ -237,6 +245,43 @@ def validate_release_cycle_outcome() -> None:
     if "no certification of user-authored content" not in scope:
         fail("release-cycle outcome scope must preserve the content-certification boundary")
     read_text(REPO_ROOT / "docs" / "release_evidence" / "latest_cycle.md")
+
+
+
+def validate_production_provider_hosted_boundary() -> None:
+    workflow = read_text(REPO_ROOT / ".github" / "workflows" / "production-provider-activation.yml")
+    forbidden = {
+        "id-token: write",
+        "aws-actions/configure-aws-credentials",
+        "role-to-assume:",
+        "terraform plan",
+        "terraform apply",
+        "confirm_apply",
+        "PROVIDER_ACTIVATION_AWS_ROLE_ARN",
+        "github.token",
+        "GH_TOKEN:",
+        "${{ secrets.",
+    }
+    present = sorted(token for token in forbidden if token in workflow)
+    if present:
+        fail("production-provider activation reintroduces hosted production authority: " + ", ".join(present))
+    required = {
+        "contents: read",
+        "persist-credentials: false",
+        "terraform init -backend=false",
+        "terraform validate",
+        "VALIDATION_TRANSPORT_ONLY",
+        "TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION",
+        "cloud_identity_acquired",
+        "terraform_apply_performed",
+        "provider_mutation_performed",
+        "authority_effect",
+        "NONE",
+        "actions/upload-artifact@v4",
+    }
+    missing = sorted(token for token in required if token not in workflow)
+    if missing:
+        fail("production-provider activation missing validation-only boundary tokens: " + ", ".join(missing))
 
 
 def validate_candidate_implementation_boundary() -> None:
@@ -416,6 +461,7 @@ def main() -> int:
         validate_release_cycle,
         validate_hosted_release_cycle_boundary,
         validate_release_cycle_outcome,
+        validate_production_provider_hosted_boundary,
         validate_candidate_implementation_boundary,
         validate_hosted_onboarding_control_plane_boundary,
         validate_friction_registry,


### PR DESCRIPTION
Corrects the existing issue #16 activation lane without creating a duplicate owner.

The Production Provider Activation workflow is converted to validation/evidence transport only:
- removes `id-token: write`;
- removes GitHub OIDC AWS role assumption;
- removes production Terraform plan/apply;
- removes hosted provider mutation;
- retains Terraform fmt/init `-backend=false`/validate;
- emits a non-authorizing `TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION` request artifact.

Adds automation-contract and dedicated regression enforcement in Release Integrity.

Non-claims: no AWS identity, IAM trust, provider resource, live probe, deployment receipt, runtime activation, or issue #16 completion is produced by this PR.