### PR TITLE
Reconcile governed email ingress into canonical handoffs

### DIFF
--- a/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -18,6 +18,7 @@ Last updated: 2026-08-27
 - Issue #68 transport-neutral receiver-acceptance persistence is IMPLEMENTED, VALIDATED, and MERGED through PR #69 at merge `08011eea59ad2b7613102c032f6fe25035b8f765`; actual bearer-generated receiver acceptance in the connected Drive-backed vault remains separately unproven.
 - Issue #16 remains a separate external activation gate and is not a baseline KnowledgeVault installation requirement.
 - Root user-operation documentation is now consolidated into `README.md` plus `USER_GUIDE.md`; `SECURITY.md` remains the separate repository/deployment security policy.
+- Governed `email-continuity` source is now merged under `KV_EMAIL_INGRESS_MIRROR_HANDOFF.md`: PR #88 established the provider-neutral ingress/SKAP credential-reference contract and mapping runtime; PR #91 added pre-admission staging, governance receipts/replay, provider adapter discovery interface, explicit SKAP completion guidance, and canonical KV Interlock request binding. Live mailbox/provider/SKAP activation remains separately unproven and the service remains inactive.
 
 ## Root user-document consolidation completed
 

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -1,8 +1,8 @@
 # KV Governed Email Ingress Mirror Handoff
 
-Status: SOURCE_READY_VALIDATED_MERGED_RUNTIME_EXTENSION_ACTIVE  
+Status: SOURCE_READY_VALIDATED_MERGED / LIVE_ACTIVATION_PENDING  
 Repository: StegVerse-Labs/continuity-vault-kit  
-Branch: `kv-email-ingress-runtime-v2`  
+Branch: `main`  
 Updated: 2026-08-27
 
 ## Purpose
@@ -220,3 +220,36 @@ When this lane becomes validated and release-worthy, verify pertinent contract/s
 - stegguardian-wiki.
 
 Do not propagate an activation claim before live provider and KV evidence exists.
+
+
+## Runtime-extension merge evidence
+
+- PR: `#91`
+- exact validated head: `9f685e0480a039c53c29a7e74cadc5722b756d7a`
+- merge: `ef285d5ed03bd92657e23c085734ea8c41b9bf6a`
+
+Exact-head validation:
+- Validate KV Email Ingress Policy run `33136048073`: PASS
+- Security Baseline run `33136048069`: PASS
+- Repository validation diagnostics run `33136048085`: PASS
+- KV Guardrails run `33136048087`: PASS
+- Release integrity run `33136048075`: PASS
+
+Release state:
+- persistent VERSION remains `0.1.9`;
+- successor release/tag/publication remains TV/TVC-admitted only;
+- issue `#90` tracks downstream propagation verification after the next admitted release.
+
+## Current remaining boundary
+
+Machine-executable source for provider-neutral discovery, SKAP completion guidance, staged admission, receipts/replay, and KV Interlock specialization is merged.
+
+Remaining work that is not yet proven:
+1. register one or more concrete mail-provider adapters using current provider-specific authorization/session facts;
+2. execute a real owner-authorized mailbox mapping;
+3. complete the prompted SKAP Vault credential setup;
+4. verify the provider session using SKAP-backed resolution;
+5. observe one real inbound staged message before trust;
+6. observe at least one real ADMIT and one real governed non-admit outcome;
+7. verify KV projection/readback, receipt chains, duplicate reconciliation, revocation, and interruption recovery;
+8. only then consider `email-continuity` ACTIVE.


### PR DESCRIPTION
## Summary

Post-merge continuity reconciliation for governed KnowledgeVault email ingress.

### Updates
- records PR #91 exact-head validation and merge evidence in `KV_EMAIL_INGRESS_MIRROR_HANDOFF.md`
- changes specialized handoff state to merged / live activation pending
- records persistent release boundary at v0.1.9 with TV/TVC-only successor publication
- records issue #90 as the downstream propagation verification task
- surfaces the governed email-ingress lane in `CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`

### Non-claims
No live mailbox, provider session, SKAP credential, Interlock transport activation, or email review activation is claimed.