### PR TITLE
Add documented Gmail Outlook and iCloud email provider adapters

### DIFF
--- a/.github/workflows/validate-kv-email-ingress-policy.yml
+++ b/.github/workflows/validate-kv-email-ingress-policy.yml
@@ -6,6 +6,9 @@ on:
       - "schemas/kv-email-ingress-policy.schema.json"
       - "schemas/kv-email-account-mapping.schema.json"
       - "schemas/kv-email-ingress-receipt.schema.json"
+      - "schemas/kv-email-provider-registry.schema.json"
+      - "specs/kv-email-provider-registry.v1.json"
+      - "tools/check_kv_email_provider_registry.py"
       - "specs/kv-email-ingress-policy.v1.json"
       - "tools/check_kv_email_ingress_policy.py"
       - "tests/test_kv_email_ingress_policy.py"
@@ -17,6 +20,8 @@ on:
       - "tests/test_email_ingress_pipeline.py"
       - "tests/test_email_provider_adapter.py"
       - "tests/test_email_interlock.py"
+      - "runtime/documented_email_providers.py"
+      - "tests/test_documented_email_providers.py"
       - "KV_EMAIL_INGRESS_MIRROR_HANDOFF.md"
       - ".github/workflows/validate-kv-email-ingress-policy.yml"
   push:
@@ -43,5 +48,7 @@ jobs:
           python-version: "3.12"
       - name: Validate canonical policy
         run: python tools/check_kv_email_ingress_policy.py
+      - name: Validate documented provider registry
+        run: python tools/check_kv_email_provider_registry.py
       - name: Run deterministic tests
-        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime tests.test_email_ingress_pipeline tests.test_email_provider_adapter tests.test_email_interlock -v
+        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime tests.test_email_ingress_pipeline tests.test_email_provider_adapter tests.test_email_interlock tests.test_documented_email_providers -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 ### Added
 - governed KnowledgeVault email-continuity ingress contract with pre-admission staging, fail-closed admission decisions, SKAP Vault credential-reference binding, deterministic mailbox mapping, and source-ready runtime validation
 - provider-neutral email account mapping runtime that prohibits raw mailbox secrets in KV state and requires `skap://` binding before provider-session verification
+- documented-unverified Gmail, Microsoft Graph/Outlook, and iCloud Mail provider adapter metadata with minimum read access, explicit user authorization, SKAP Vault credential destination, and fail-closed unknown-domain handling
 - fail-closed `KV-INTERLOCK-v1` runtime endpoint core with exact DEVICE→KV InTr admission binding, injected authority/policy/storage boundaries, bounded-context enforcement, deterministic receipts, and candidate-only `COMMIT_CANDIDATE` semantics
 - deterministic runtime endpoint tests and canonical runtime handoff for the Site/KV production backend seam
 

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -49,6 +49,11 @@ The `email-continuity` slot already exists under the 33-service Personal Service
 - `tests/test_email_provider_adapter.py`
 - `runtime/email_interlock.py`
 - `tests/test_email_interlock.py`
+- `schemas/kv-email-provider-registry.schema.json`
+- `specs/kv-email-provider-registry.v1.json`
+- `tools/check_kv_email_provider_registry.py`
+- `runtime/documented_email_providers.py`
+- `tests/test_documented_email_providers.py`
 
 ## Governance invariants
 
@@ -245,11 +250,37 @@ Release state:
 Machine-executable source for provider-neutral discovery, SKAP completion guidance, staged admission, receipts/replay, and KV Interlock specialization is merged.
 
 Remaining work that is not yet proven:
-1. register one or more concrete mail-provider adapters using current provider-specific authorization/session facts;
-2. execute a real owner-authorized mailbox mapping;
+1. execute a real owner-authorized mailbox mapping against one documented/supported provider route;
+2. where the address is outside the documented domains, add a separately evidenced provider adapter rather than guessing;
 3. complete the prompted SKAP Vault credential setup;
 4. verify the provider session using SKAP-backed resolution;
 5. observe one real inbound staged message before trust;
 6. observe at least one real ADMIT and one real governed non-admit outcome;
 7. verify KV projection/readback, receipt chains, duplicate reconciliation, revocation, and interruption recovery;
 8. only then consider `email-continuity` ACTIVE.
+
+
+## Documented concrete provider adapters
+
+A provider-specific metadata set is now implemented as `DOCUMENTED_UNVERIFIED`, not runtime verified:
+
+- `google-gmail` for `gmail.com` / `googlemail.com`
+  - Gmail API message list/get route
+  - delegated OAuth 2.0
+  - minimum read scope `https://www.googleapis.com/auth/gmail.readonly`
+- `microsoft-outlook-graph` for `outlook.com` / `hotmail.com` / `live.com` / `msn.com`
+  - Microsoft Graph mail route
+  - delegated OAuth 2.0
+  - minimum read permission `Mail.Read`
+- `apple-icloud-mail` for `icloud.com` / `me.com` / `mac.com`
+  - IMAP over TLS at `imap.mail.me.com:993`
+  - app-specific password authorization for this documented third-party route
+
+Every provider entry:
+- requires explicit user authorization;
+- maps credential destination to SKAP Vault;
+- prohibits KV secret storage;
+- carries dated provider-documentation evidence;
+- remains `runtime_verified=false` until StegVerse performs a real conformance/activation observation.
+
+Unknown domains remain fail-closed rather than guessing a provider.

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -284,3 +284,18 @@ Every provider entry:
 - remains `runtime_verified=false` until StegVerse performs a real conformance/activation observation.
 
 Unknown domains remain fail-closed rather than guessing a provider.
+
+
+## Documented-provider validation evidence
+
+Provider-adapter PR: `#95`  
+Validated head: `6ef27a1aec2b0c04dd3f0fcd047cba4d1c10a1fd`
+
+Exact-head hosted validation:
+- Validate KV Email Ingress Policy run `33136236584`: PASS
+- Security Baseline run `33136236583`: PASS
+- Repository validation diagnostics run `33136236577`: PASS
+- KV Guardrails run `33136236557`: PASS
+- Release integrity run `33136236581`: PASS
+
+This validates repository source and documented provider metadata only. Gmail, Microsoft Graph mail, and iCloud Mail remain `DOCUMENTED_UNVERIFIED` until real owner-authorized provider sessions are observed.

--- a/runtime/documented_email_providers.py
+++ b/runtime/documented_email_providers.py
@@ -1,0 +1,91 @@
+"""Load documented email-provider metadata into the provider-neutral adapter registry."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from runtime.email_continuity import EmailAccountMapping, EmailMappingError
+from runtime.email_provider_adapter import ProviderRegistry
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REGISTRY = ROOT / "specs" / "kv-email-provider-registry.v1.json"
+
+
+@dataclass(frozen=True)
+class DocumentedProviderAdapter:
+    provider_id: str
+    provider_route: str
+    domains: frozenset[str]
+    auth_mode: str
+    minimum_read_permission: str
+    evidence_state: str
+    evidence_refs: tuple[str, ...]
+
+    def matches_domain(self, domain: str) -> bool:
+        return domain.lower() in self.domains
+
+    def session_descriptor(self, mapping: EmailAccountMapping) -> dict:
+        if mapping.provider_id != self.provider_id or mapping.provider_route != self.provider_route:
+            raise EmailMappingError("provider mapping does not match documented adapter")
+        return {
+            "provider_id": self.provider_id,
+            "provider_route": self.provider_route,
+            "authorization_mode": self.auth_mode,
+            "minimum_read_permission": self.minimum_read_permission,
+            "skap_credential_ref_required": True,
+            "evidence_state": self.evidence_state,
+            "evidence_refs": list(self.evidence_refs),
+            "runtime_verified": False,
+            "authority_effect": "NONE",
+        }
+
+
+def load_documented_provider_registry(path: Path = DEFAULT_REGISTRY) -> ProviderRegistry:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if data.get("schema") != "stegverse.kv.email-provider-registry/v1":
+        raise EmailMappingError("email provider registry schema mismatch")
+    if data.get("state") != "DOCUMENTED_UNVERIFIED":
+        raise EmailMappingError("documented provider loader requires DOCUMENTED_UNVERIFIED state")
+    if data.get("authority_effect") != "NONE":
+        raise EmailMappingError("provider registry may not grant authority")
+
+    adapters: list[DocumentedProviderAdapter] = []
+    seen_domains: set[str] = set()
+    for provider in data.get("providers", []):
+        domains = {str(value).lower() for value in provider.get("domains", [])}
+        if not domains or seen_domains.intersection(domains):
+            raise EmailMappingError("provider domains missing or ambiguous")
+        seen_domains.update(domains)
+
+        if provider.get("credential_destination") != "SKAP_VAULT":
+            raise EmailMappingError("provider credentials must terminate in SKAP Vault")
+        if provider.get("kv_secret_storage") is not False:
+            raise EmailMappingError("provider registry may not permit KV secret storage")
+
+        evidence = provider.get("evidence", {})
+        if evidence.get("state") != "DOCUMENTED" or not evidence.get("source_refs"):
+            raise EmailMappingError("documented provider requires source evidence")
+
+        transport = provider.get("transport", {})
+        authorization = provider.get("authorization", {})
+        if authorization.get("user_authorization_required") is not True:
+            raise EmailMappingError("provider access must require user authorization")
+
+        adapters.append(
+            DocumentedProviderAdapter(
+                provider_id=provider["provider_id"],
+                provider_route=transport["route"],
+                domains=frozenset(domains),
+                auth_mode=authorization["mode"],
+                minimum_read_permission=provider["minimum_read_permission"],
+                evidence_state="DOCUMENTED_UNVERIFIED",
+                evidence_refs=tuple(evidence["source_refs"]),
+            )
+        )
+
+    if not adapters:
+        raise EmailMappingError("provider registry contains no adapters")
+    return ProviderRegistry(adapters)

--- a/schemas/kv-email-provider-registry.schema.json
+++ b/schemas/kv-email-provider-registry.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-email-provider-registry.schema.json",
+  "title": "KnowledgeVault Email Provider Adapter Registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "state", "authority_effect", "providers"],
+  "properties": {
+    "schema": {"const": "stegverse.kv.email-provider-registry/v1"},
+    "state": {"enum": ["DOCUMENTED_UNVERIFIED", "PARTIALLY_VERIFIED", "VERIFIED"]},
+    "authority_effect": {"const": "NONE"},
+    "providers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "provider_id", "domains", "transport", "authorization",
+          "minimum_read_permission", "credential_destination",
+          "kv_secret_storage", "evidence"
+        ],
+        "properties": {
+          "provider_id": {"type": "string", "minLength": 1},
+          "domains": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "transport": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "route"],
+            "properties": {
+              "kind": {"enum": ["REST_API", "IMAP"]},
+              "route": {"type": "string", "minLength": 1}
+            }
+          },
+          "authorization": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["mode", "user_authorization_required"],
+            "properties": {
+              "mode": {"enum": ["OAUTH2_DELEGATED", "APP_SPECIFIC_PASSWORD"]},
+              "user_authorization_required": {"const": true}
+            }
+          },
+          "minimum_read_permission": {"type": "string", "minLength": 1},
+          "credential_destination": {"const": "SKAP_VAULT"},
+          "kv_secret_storage": {"const": false},
+          "evidence": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["state", "source_refs", "observed_on"],
+            "properties": {
+              "state": {"const": "DOCUMENTED"},
+              "source_refs": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {"type": "string", "minLength": 1}
+              },
+              "observed_on": {"type": "string", "format": "date"}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specs/kv-email-provider-registry.v1.json
+++ b/specs/kv-email-provider-registry.v1.json
@@ -1,0 +1,76 @@
+{
+  "schema": "stegverse.kv.email-provider-registry/v1",
+  "state": "DOCUMENTED_UNVERIFIED",
+  "authority_effect": "NONE",
+  "providers": [
+    {
+      "provider_id": "google-gmail",
+      "domains": ["gmail.com", "googlemail.com"],
+      "transport": {
+        "kind": "REST_API",
+        "route": "gmail-api:v1/users.messages.list+get"
+      },
+      "authorization": {
+        "mode": "OAUTH2_DELEGATED",
+        "user_authorization_required": true
+      },
+      "minimum_read_permission": "https://www.googleapis.com/auth/gmail.readonly",
+      "credential_destination": "SKAP_VAULT",
+      "kv_secret_storage": false,
+      "evidence": {
+        "state": "DOCUMENTED",
+        "source_refs": [
+          "https://developers.google.com/identity/protocols/oauth2/scopes",
+          "https://developers.google.com/workspace/gmail/api/guides/list-messages"
+        ],
+        "observed_on": "2026-08-27"
+      }
+    },
+    {
+      "provider_id": "microsoft-outlook-graph",
+      "domains": ["outlook.com", "hotmail.com", "live.com", "msn.com"],
+      "transport": {
+        "kind": "REST_API",
+        "route": "microsoft-graph:v1.0/mail"
+      },
+      "authorization": {
+        "mode": "OAUTH2_DELEGATED",
+        "user_authorization_required": true
+      },
+      "minimum_read_permission": "Mail.Read",
+      "credential_destination": "SKAP_VAULT",
+      "kv_secret_storage": false,
+      "evidence": {
+        "state": "DOCUMENTED",
+        "source_refs": [
+          "https://learn.microsoft.com/en-us/graph/api/resources/mail-api-overview?view=graph-rest-1.0",
+          "https://learn.microsoft.com/en-us/graph/permissions-reference"
+        ],
+        "observed_on": "2026-08-27"
+      }
+    },
+    {
+      "provider_id": "apple-icloud-mail",
+      "domains": ["icloud.com", "me.com", "mac.com"],
+      "transport": {
+        "kind": "IMAP",
+        "route": "imaps://imap.mail.me.com:993"
+      },
+      "authorization": {
+        "mode": "APP_SPECIFIC_PASSWORD",
+        "user_authorization_required": true
+      },
+      "minimum_read_permission": "IMAP_AUTHENTICATED_READ",
+      "credential_destination": "SKAP_VAULT",
+      "kv_secret_storage": false,
+      "evidence": {
+        "state": "DOCUMENTED",
+        "source_refs": [
+          "https://support.apple.com/en-us/102525",
+          "https://support.apple.com/en-us/102654"
+        ],
+        "observed_on": "2026-08-27"
+      }
+    }
+  ]
+}

--- a/tests/test_documented_email_providers.py
+++ b/tests/test_documented_email_providers.py
@@ -1,0 +1,59 @@
+import copy
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from runtime.documented_email_providers import load_documented_provider_registry
+from runtime.email_continuity import EmailMappingError
+
+
+class DocumentedEmailProviderTests(unittest.TestCase):
+    def test_gmail_discovery_is_documented_unverified(self):
+        registry = load_documented_provider_registry()
+        mapping = registry.discover("user@gmail.com")
+        descriptor = registry.descriptor_for(mapping)
+        self.assertEqual(mapping.provider_id, "google-gmail")
+        self.assertEqual(mapping.mapping_state, "MAPPED_CREDENTIAL_REQUIRED")
+        self.assertEqual(descriptor["minimum_read_permission"], "https://www.googleapis.com/auth/gmail.readonly")
+        self.assertEqual(descriptor["evidence_state"], "DOCUMENTED_UNVERIFIED")
+        self.assertFalse(descriptor["runtime_verified"])
+        self.assertTrue(descriptor["skap_credential_ref_required"])
+
+    def test_outlook_discovery_uses_delegated_mail_read(self):
+        registry = load_documented_provider_registry()
+        mapping = registry.discover("user@outlook.com")
+        descriptor = registry.descriptor_for(mapping)
+        self.assertEqual(mapping.provider_id, "microsoft-outlook-graph")
+        self.assertEqual(descriptor["minimum_read_permission"], "Mail.Read")
+        self.assertEqual(descriptor["authorization_mode"], "OAUTH2_DELEGATED")
+
+    def test_icloud_discovery_uses_skap_bound_app_specific_password(self):
+        registry = load_documented_provider_registry()
+        mapping = registry.discover("user@icloud.com")
+        descriptor = registry.descriptor_for(mapping)
+        self.assertEqual(mapping.provider_id, "apple-icloud-mail")
+        self.assertEqual(descriptor["authorization_mode"], "APP_SPECIFIC_PASSWORD")
+        self.assertEqual(mapping.mapping_state, "MAPPED_CREDENTIAL_REQUIRED")
+        self.assertTrue(descriptor["skap_credential_ref_required"])
+
+    def test_unknown_domain_fails_closed(self):
+        registry = load_documented_provider_registry()
+        with self.assertRaises(EmailMappingError):
+            registry.discover("user@example.org")
+
+    def test_overlapping_domains_are_rejected(self):
+        source = Path("specs/kv-email-provider-registry.v1.json")
+        data = json.loads(source.read_text(encoding="utf-8"))
+        duplicate = copy.deepcopy(data["providers"][0])
+        duplicate["provider_id"] = "duplicate-provider"
+        data["providers"].append(duplicate)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "registry.json"
+            path.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaises(EmailMappingError):
+                load_documented_provider_registry(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_kv_email_provider_registry.py
+++ b/tools/check_kv_email_provider_registry.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Validate the documented KnowledgeVault email-provider adapter registry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "specs" / "kv-email-provider-registry.v1.json"
+
+
+def load_registry(path: Path = REGISTRY) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate(data: dict) -> list[str]:
+    errors: list[str] = []
+    if data.get("schema") != "stegverse.kv.email-provider-registry/v1":
+        errors.append("registry schema mismatch")
+    if data.get("state") != "DOCUMENTED_UNVERIFIED":
+        errors.append("initial provider registry must remain DOCUMENTED_UNVERIFIED")
+    if data.get("authority_effect") != "NONE":
+        errors.append("provider registry must not grant authority")
+
+    seen_domains: set[str] = set()
+    providers = data.get("providers")
+    if not isinstance(providers, list) or not providers:
+        errors.append("at least one provider required")
+        return errors
+
+    for provider in providers:
+        provider_id = provider.get("provider_id", "<missing>")
+        domains = provider.get("domains", [])
+        if not isinstance(domains, list) or not domains:
+            errors.append(f"{provider_id}: domains required")
+            continue
+        overlap = seen_domains.intersection(domains)
+        if overlap:
+            errors.append(f"{provider_id}: ambiguous domains {sorted(overlap)}")
+        seen_domains.update(domains)
+
+        if provider.get("credential_destination") != "SKAP_VAULT":
+            errors.append(f"{provider_id}: credential destination must be SKAP_VAULT")
+        if provider.get("kv_secret_storage") is not False:
+            errors.append(f"{provider_id}: KV secret storage must be false")
+
+        authorization = provider.get("authorization", {})
+        if authorization.get("user_authorization_required") is not True:
+            errors.append(f"{provider_id}: explicit user authorization required")
+        if authorization.get("mode") not in {"OAUTH2_DELEGATED", "APP_SPECIFIC_PASSWORD"}:
+            errors.append(f"{provider_id}: unsupported authorization mode")
+
+        permission = provider.get("minimum_read_permission")
+        if not isinstance(permission, str) or not permission:
+            errors.append(f"{provider_id}: minimum read permission required")
+
+        evidence = provider.get("evidence", {})
+        refs = evidence.get("source_refs")
+        if evidence.get("state") != "DOCUMENTED":
+            errors.append(f"{provider_id}: evidence state must be DOCUMENTED")
+        if not isinstance(refs, list) or not refs or not all(
+            isinstance(ref, str) and ref.startswith("https://") for ref in refs
+        ):
+            errors.append(f"{provider_id}: authoritative HTTPS evidence refs required")
+        if not isinstance(evidence.get("observed_on"), str) or not evidence["observed_on"]:
+            errors.append(f"{provider_id}: evidence observation date required")
+
+    return errors
+
+
+def main() -> int:
+    errors = validate(load_registry())
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+    print("PASS: documented KV email-provider registry")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds concrete, documented-but-unverified provider metadata for the first common email routes supported by the governed KV email-ingress architecture.

### Providers
- Google Gmail: delegated OAuth 2.0, `gmail.readonly`
- Microsoft Outlook / Graph: delegated OAuth 2.0, `Mail.Read`
- Apple iCloud Mail: IMAP over TLS, app-specific password route

### Governance
- every provider requires explicit user authorization
- credential destination is SKAP Vault
- KV secret storage remains prohibited
- provider evidence is dated and source-referenced
- unknown/ambiguous domains fail closed
- all concrete provider entries remain `DOCUMENTED_UNVERIFIED` / `runtime_verified=false`

### Source
- provider registry schema/spec
- registry validator
- documented-provider runtime loader
- deterministic provider discovery tests
- dedicated email-ingress workflow coverage
- canonical handoff + Unreleased changelog updates

### Non-claims
No user mailbox or credential is used. No provider route is claimed live or conformance-verified.