### PR TITLE
Retire hosted release reconciliation and downstream mutation authority

### DIFF
--- a/.github/workflows/downstream-propagation.yml
+++ b/.github/workflows/downstream-propagation.yml
@@ -1,4 +1,4 @@
-name: Downstream release propagation
+name: Downstream release propagation - Validation Only
 
 on:
   release:
@@ -11,179 +11,70 @@ on:
         type: string
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
 
 concurrency:
-  group: downstream-release-propagation
+  group: downstream-release-propagation-validation
   cancel-in-progress: false
 
 jobs:
-  determine:
+  observe:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-
     steps:
-      - name: Check out source repository
+      - name: Check out source repository without credential persistence
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Resolve release tag
-        id: release
+      - name: Project downstream review requirement
         env:
           EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.release_tag }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          tag="${EVENT_TAG:-${INPUT_TAG:-}}"
-          if [ -z "$tag" ]; then
-            tag=$(git tag --sort=-version:refname | head -n 1)
-          fi
-          if [ -z "$tag" ]; then
-            echo "No release tag is available; propagation is not actionable."
-            exit 1
-          fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Inspect downstream repositories
-        id: inspect
-        env:
-          SOURCE_REPOSITORY: ${{ github.repository }}
-          SOURCE_TAG: ${{ steps.release.outputs.tag }}
-        run: |
+          mkdir -p reports/downstream_propagation
           python3 - <<'PY'
-          import json
-          import os
-          import subprocess
+          import json, os, subprocess
           from datetime import datetime, timezone
           from pathlib import Path
-
-          root = Path.cwd()
-          registry = json.loads((root / "automation/downstream-propagation.json").read_text(encoding="utf-8"))
-          workspace = root / ".downstream-scan"
-          workspace.mkdir(exist_ok=True)
-          results = []
-
+          tag=os.environ.get("EVENT_TAG") or os.environ.get("INPUT_TAG") or ""
+          if not tag:
+              tags=subprocess.run(["git","tag","--sort=-version:refname"],text=True,capture_output=True,check=False).stdout.splitlines()
+              tag=tags[0] if tags else ""
+          registry=json.loads(Path("automation/downstream-propagation.json").read_text(encoding="utf-8"))
+          results=[]
           for destination in registry["destinations"]:
-              repo = destination["repository"]
-              clone_dir = workspace / repo.replace("/", "__")
-              clone_url = f"https://github.com/{repo}.git"
-              clone = subprocess.run(
-                  ["git", "clone", "--depth", "1", "--branch", destination.get("default_branch", "main"), clone_url, str(clone_dir)],
-                  text=True,
-                  capture_output=True,
-                  check=False,
-              )
-              if clone.returncode != 0:
-                  results.append({
-                      "repository": repo,
-                      "determination": "repository unavailable or renamed",
-                      "rationale": clone.stderr.strip()[-500:] or "clone failed",
-                      "matches": [],
-                  })
-                  continue
-
-              matches = []
-              excluded = {".git"}
-              for path in clone_dir.rglob("*"):
-                  if not path.is_file() or any(part in excluded for part in path.parts):
-                      continue
-                  try:
-                      text = path.read_text(encoding="utf-8")
-                  except (UnicodeDecodeError, OSError):
-                      continue
-                  lowered = text.lower()
-                  hit_terms = [term for term in destination["search_terms"] if term.lower() in lowered]
-                  if hit_terms:
-                      matches.append({
-                          "path": str(path.relative_to(clone_dir)),
-                          "terms": sorted(hit_terms),
-                      })
-
-              if matches:
-                  determination = "update required"
-                  rationale = "Existing repository-specific references require review against the new release."
-              else:
-                  determination = "no update required"
-                  rationale = "No direct Continuity Vault Kit release, install, download, compatibility, or mirror reference was found."
-
               results.append({
-                  "repository": repo,
-                  "determination": determination,
-                  "rationale": rationale,
-                  "matches": matches,
+                  "repository":destination["repository"],
+                  "default_branch":destination.get("default_branch","main"),
+                  "search_terms":destination["search_terms"],
+                  "determination":"NON_HOSTED_REVIEW_REQUIRED",
               })
-
-          tag = os.environ["SOURCE_TAG"]
-          now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-          payload = {
-              "schema_version": "1.0",
-              "source_repository": os.environ["SOURCE_REPOSITORY"],
-              "source_release": tag,
-              "checked_utc": now,
-              "results": results,
+          payload={
+              "schema":"stegverse.kv.downstream-propagation-observation/v1",
+              "source_repository":os.environ["REPOSITORY"],
+              "source_release":tag or None,
+              "configured_destination_count":len(results),
+              "results":results,
+              "repository_mutation_performed":False,
+              "issue_mutation_performed":False,
+              "downstream_mutation_performed":False,
+              "github_actions_role":"VALIDATION_TRANSPORT_ONLY",
+              "canonical_next_transition":"NON_HOSTED_DOWNSTREAM_PROPAGATION_REVIEW",
+              "authority_effect":"NONE",
+              "observed_utc":datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
           }
-          out_dir = root / "evidence" / "downstream-propagation"
-          out_dir.mkdir(parents=True, exist_ok=True)
-          (out_dir / "latest.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-
-          lines = [
-              "# Downstream Propagation Determination",
-              "",
-              f"- Source release: `{tag}`",
-              f"- Checked UTC: `{now}`",
-              "",
-          ]
-          for result in results:
-              lines.extend([
-                  f"## {result['repository']}",
-                  "",
-                  f"**Determination:** {result['determination']}",
-                  "",
-                  result["rationale"],
-                  "",
-              ])
-              if result["matches"]:
-                  lines.append("Matched publication surfaces:")
-                  lines.append("")
-                  for match in result["matches"]:
-                      lines.append(f"- `{match['path']}` — {', '.join(match['terms'])}")
-                  lines.append("")
-          (out_dir / "latest.md").write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
-
-          actionable = [r for r in results if r["determination"] != "no update required"]
-          output = Path(os.environ["GITHUB_OUTPUT"])
-          with output.open("a", encoding="utf-8") as handle:
-              handle.write(f"actionable_count={len(actionable)}\n")
-              handle.write("summary=" + json.dumps({"tag": tag, "results": results}, separators=(",", ":")) + "\n")
+          Path("reports/downstream_propagation/observation.json").write_text(json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps(payload,sort_keys=True))
           PY
 
-      - name: Commit durable propagation receipt
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add evidence/downstream-propagation/latest.json evidence/downstream-propagation/latest.md
-          if git diff --cached --quiet; then
-            echo "Propagation receipt is unchanged."
-          else
-            git commit -m "evidence: record downstream propagation for ${{ steps.release.outputs.tag }}"
-            git push origin HEAD:main
-          fi
-
-      - name: Record determination and close completed gate
-        if: steps.inspect.outputs.actionable_count == '0'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          gh issue comment 10 --body "Automated downstream propagation completed for \`${{ steps.release.outputs.tag }}\`. All configured destinations were determined to require no update because no direct kit release, install, download, compatibility, or mirror reference was found. Durable receipt: \`evidence/downstream-propagation/latest.md\`. Workflow: ${RUN_URL}."
-          gh issue close 10 --reason completed
-
-      - name: Record actionable propagation findings
-        if: steps.inspect.outputs.actionable_count != '0'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          gh issue comment 10 --body "Automated downstream propagation found ${{ steps.inspect.outputs.actionable_count }} actionable or unavailable destinations for \`${{ steps.release.outputs.tag }}\`. Exact files and rationales are preserved in \`evidence/downstream-propagation/latest.md\`. Workflow: ${RUN_URL}. Issue #10 remains open until automation can apply or conclusively classify those destinations."
+      - name: Upload non-authorizing downstream observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: downstream-propagation-observation-${{ github.run_id }}
+          path: reports/downstream_propagation/observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/reconcile-published-release.yml
+++ b/.github/workflows/reconcile-published-release.yml
@@ -1,6 +1,5 @@
-name: Reconcile published release evidence
+name: Reconcile published release evidence - Validation Only
 
-# This workflow may be activated by changing this file or dispatched manually.
 on:
   push:
     branches: ["main"]
@@ -9,238 +8,70 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing published release tag to reconcile
+        description: Existing release tag expected by retained evidence
         required: false
         type: string
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
 
 concurrency:
-  group: reconcile-published-release
+  group: reconcile-published-release-validation
   cancel-in-progress: false
 
 jobs:
-  reconcile:
+  observe:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
-      - name: Check out current main
+      - name: Check out current main without credential persistence
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 1
+          persist-credentials: false
 
-      - name: Resolve existing release
-        id: release
+      - name: Validate retained release evidence without mutation
         env:
           INPUT_TAG: ${{ inputs.release_tag }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          tag="${INPUT_TAG:-v$(cat VERSION)}"
-          gh release view "$tag" >/dev/null
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Download and verify published assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.release.outputs.tag }}
-          VERSION_VALUE: ${{ steps.release.outputs.version }}
-        run: |
-          rm -rf .release-reconciliation
-          mkdir .release-reconciliation
-          gh release download "$TAG" --dir .release-reconciliation
-          cd .release-reconciliation
-          zip="ContinuityVault_v${VERSION_VALUE}.zip"
-          test -f "$zip"
-          test -f "${zip}.sha256"
-          test -f "${zip}.manifest.json"
-          expected=$(awk '{print $1}' "${zip}.sha256")
-          actual=$(sha256sum "$zip" | awk '{print $1}')
-          test "$expected" = "$actual"
-          cd ..
-          python3 tools/verify_release.py ".release-reconciliation/ContinuityVault_v${VERSION_VALUE}.zip"
-
-      - name: Reconstruct release and downstream receipts
-        env:
-          TAG: ${{ steps.release.outputs.tag }}
-          VERSION_VALUE: ${{ steps.release.outputs.version }}
-          GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
         run: |
+          mkdir -p reports/release_reconciliation
           python3 - <<'PY'
-          import hashlib
-          import json
-          import os
-          import re
-          import shutil
-          import subprocess
+          import json, os
           from datetime import datetime, timezone
           from pathlib import Path
-
-          root = Path.cwd()
-          tag = os.environ["TAG"]
-          version = os.environ["VERSION_VALUE"]
-          assets = root / ".release-reconciliation"
-          zip_path = assets / f"ContinuityVault_v{version}.zip"
-          checksum = hashlib.sha256(zip_path.read_bytes()).hexdigest()
-          sidecar = zip_path.with_suffix(zip_path.suffix + ".sha256").read_text(encoding="utf-8").split()[0]
-          if checksum != sidecar:
-              raise SystemExit("published checksum mismatch")
-          manifest_path = zip_path.with_suffix(zip_path.suffix + ".manifest.json")
-          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-          release_commit = subprocess.check_output(["git", "rev-list", "-n", "1", tag], text=True).strip()
-          published = subprocess.check_output(
-              ["gh", "release", "view", tag, "--json", "publishedAt", "--jq", ".publishedAt"], text=True
-          ).strip()
-          now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-          run_url = f"https://github.com/{os.environ['REPOSITORY']}/actions/runs/{os.environ['RUN_ID']}"
-          release_url = f"https://github.com/{os.environ['REPOSITORY']}/releases/tag/{tag}"
-
-          receipt = {
-              "schema_version": "1.1",
-              "result": "PUBLISHED",
-              "repository": os.environ["REPOSITORY"],
-              "version": version,
-              "tag": tag,
-              "release_commit": release_commit,
-              "workflow_run_url": run_url,
-              "release_url": release_url,
-              "release_artifact": zip_path.name,
-              "release_sha256": checksum,
-              "manifest_schema_version": manifest["schema_version"],
-              "manifest_file_count": manifest["file_count"],
-              "release_assets": [zip_path.name, zip_path.name + ".sha256", zip_path.name + ".manifest.json"],
-              "builder_verifier_self_test": "PASS",
-              "initializer_self_test": "PASS",
-              "automation_contract_test": "PASS",
-              "published_utc": published,
-              "reconciled_utc": now,
-              "reconciliation_reason": "Published assets existed but the original final receipt commit failed after publication.",
-              "scope": "package integrity and installer copy verification only",
+          version=Path("VERSION").read_text(encoding="utf-8").strip()
+          release_path=Path("docs/release_evidence/latest_release.json")
+          release=json.loads(release_path.read_text(encoding="utf-8")) if release_path.exists() else {}
+          retained_tag=release.get("tag")
+          requested=os.environ.get("INPUT_TAG") or None
+          consistent=(not requested or requested==retained_tag)
+          payload={
+              "schema":"stegverse.kv.release-reconciliation-observation/v1",
+              "repository":os.environ["REPOSITORY"],
+              "persistent_version":version,
+              "retained_release_tag":retained_tag,
+              "requested_release_tag":requested,
+              "retained_evidence_consistent_with_request":consistent,
+              "canonical_release_evidence_mutation_performed":False,
+              "repository_mutation_performed":False,
+              "issue_mutation_performed":False,
+              "release_publication_performed":False,
+              "github_actions_role":"VALIDATION_TRANSPORT_ONLY",
+              "credential_authority":"TV/TVC",
+              "canonical_next_transition":"TVC_ADMITTED_RELEASE_RECONCILIATION" if requested and not consistent else "NONE",
+              "authority_effect":"NONE",
+              "observed_utc":datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
           }
-          evidence = root / "docs" / "release_evidence"
-          evidence.mkdir(parents=True, exist_ok=True)
-          (evidence / "latest_release.json").write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
-          (evidence / "latest_release.md").write_text(
-              "# Latest Published Release\n\n"
-              f"- **Result:** PUBLISHED\n- **Version:** `{version}`\n- **Tag:** `{tag}`\n"
-              f"- **Release commit:** `{release_commit}`\n- **Release:** {release_url}\n"
-              f"- **Artifact:** `{zip_path.name}`\n- **SHA-256:** `{checksum}`\n"
-              f"- **Manifest files:** `{manifest['file_count']}`\n- **Published UTC:** `{published}`\n"
-              f"- **Reconciled UTC:** `{now}`\n- **Reconciliation workflow:** {run_url}\n\n"
-              "The published assets were independently downloaded and verified. This receipt verifies package integrity and installer copy behavior only.\n",
-              encoding="utf-8",
-          )
-
-          registry = json.loads((root / "automation" / "downstream-propagation.json").read_text(encoding="utf-8"))
-          workspace = root / ".downstream-reconciliation"
-          shutil.rmtree(workspace, ignore_errors=True)
-          workspace.mkdir()
-          results = []
-          for destination in registry["destinations"]:
-              repo = destination["repository"]
-              clone_dir = workspace / repo.replace("/", "__")
-              clone = subprocess.run(
-                  ["git", "clone", "--depth", "1", "--branch", destination.get("default_branch", "main"), f"https://github.com/{repo}.git", str(clone_dir)],
-                  text=True, capture_output=True, check=False,
-              )
-              if clone.returncode != 0:
-                  results.append({"repository": repo, "determination": "repository unavailable or renamed", "rationale": clone.stderr.strip()[-500:] or "clone failed", "matches": []})
-                  continue
-              matches = []
-              for path in clone_dir.rglob("*"):
-                  if not path.is_file() or ".git" in path.parts:
-                      continue
-                  try:
-                      text = path.read_text(encoding="utf-8").lower()
-                  except (UnicodeDecodeError, OSError):
-                      continue
-                  terms = sorted(term for term in destination["search_terms"] if term.lower() in text)
-                  if terms:
-                      matches.append({"path": str(path.relative_to(clone_dir)), "terms": terms})
-              results.append({
-                  "repository": repo,
-                  "determination": "update required" if matches else "no update required",
-                  "rationale": "Existing repository-specific references require review against the new release." if matches else "No direct Continuity Vault Kit release, install, download, compatibility, or mirror reference was found.",
-                  "matches": matches,
-              })
-
-          downstream = root / "evidence" / "downstream-propagation"
-          downstream.mkdir(parents=True, exist_ok=True)
-          payload = {"schema_version": "1.0", "source_repository": os.environ["REPOSITORY"], "source_release": tag, "checked_utc": now, "results": results}
-          (downstream / "latest.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          lines = ["# Downstream Propagation Determination", "", f"- Source release: `{tag}`", f"- Checked UTC: `{now}`", ""]
-          for result in results:
-              lines.extend([f"## {result['repository']}", "", f"**Determination:** {result['determination']}", "", result["rationale"], ""])
-              for match in result["matches"]:
-                  lines.append(f"- `{match['path']}` — {', '.join(match['terms'])}")
-              if result["matches"]:
-                  lines.append("")
-          (downstream / "latest.md").write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
-
-          cycle = {
-              "schema_version": "1.0",
-              "outcome": "RECONCILED",
-              "reason": f"Existing {tag} publication and assets were verified and its missing final receipt was reconstructed without creating a new release.",
-              "repository": os.environ["REPOSITORY"],
-              "source_workflow": "Reconcile published release evidence",
-              "source_workflow_conclusion": "success",
-              "source_workflow_run_id": os.environ["RUN_ID"],
-              "source_workflow_run_url": run_url,
-              "source_head_sha": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
-              "current_version": version,
-              "release_required_after_run": False,
-              "generated_utc": now,
-              "scope": "repository release-cycle outcome only; no certification of user-authored content",
-          }
-          (evidence / "latest_cycle.json").write_text(json.dumps(cycle, indent=2) + "\n", encoding="utf-8")
-          (evidence / "latest_cycle.md").write_text(
-              "# Latest Release-Cycle Outcome\n\n"
-              f"- **Outcome:** RECONCILED\n- **Version:** `{version}`\n- **Reason:** {cycle['reason']}\n"
-              f"- **Workflow:** {run_url}\n- **Generated UTC:** `{now}`\n\n"
-              "This outcome records repository release evidence only and does not certify user-authored content.\n",
-              encoding="utf-8",
-          )
-
-          handoff_path = root / "docs" / "CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md"
-          handoff = handoff_path.read_text(encoding="utf-8")
-          handoff = re.sub(r"\*\*Current published version:\*\* `[^`]+`", f"**Current published version:** `{version}`", handoff, count=1)
-          handoff = handoff.replace("PR state: draft pending current-head verification after changelog and handoff updates", "PR state: merged; release evidence reconciled")
-          marker = "## 10. Archive note"
-          reconciliation = (
-              "## 10. Release reconciliation\n\n"
-              f"- `{tag}` assets were downloaded and independently verified.\n"
-              "- `latest_release.json`, `latest_cycle.json`, and downstream propagation receipts now agree.\n"
-              "- Issue #24 owns no remaining work after the reconciliation workflow closes it.\n"
-              "- The next integration candidate is storage-budget and adaptive-capture policy.\n\n"
-              "## 11. Archive note"
-          )
-          if "## 10. Release reconciliation" not in handoff:
-              handoff = handoff.replace(marker, reconciliation, 1)
-          handoff_path.write_text(handoff, encoding="utf-8")
+          Path("reports/release_reconciliation/observation.json").write_text(json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps(payload,sort_keys=True))
           PY
 
-      - name: Commit reconciled evidence
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/release_evidence/latest_release.md docs/release_evidence/latest_release.json \
-            docs/release_evidence/latest_cycle.md docs/release_evidence/latest_cycle.json \
-            evidence/downstream-propagation/latest.md evidence/downstream-propagation/latest.json \
-            docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
-          git commit -m "evidence: reconcile published release ${{ steps.release.outputs.tag }} [skip ci]"
-          git pull --rebase origin main
-          git push origin HEAD:main
-
-      - name: Close reconciliation issue
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.release.outputs.tag }}
-          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          gh issue comment 24 --body "Reconciliation completed for \`${TAG}\`. Published assets were downloaded and verified; authoritative release, cycle, handoff, and four-destination determination receipts were committed. Workflow: ${RUN_URL}."
-          gh issue close 24 --reason completed
+      - name: Upload non-authorizing release reconciliation observation
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-reconciliation-observation-${{ github.run_id }}
+          path: reports/release_reconciliation/observation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/reconcile-release-activation.yml
+++ b/.github/workflows/reconcile-release-activation.yml
@@ -1,4 +1,4 @@
-name: Activate release reconciliation
+name: Activate release reconciliation - Validation Only
 
 on:
   push:
@@ -8,14 +8,33 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  actions: write
   contents: read
 
 jobs:
-  dispatch:
+  observe:
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch idempotent reconciliation
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run reconcile-published-release.yml -f release_tag=v0.1.4
+      - name: Emit non-authorizing reconciliation request
+        run: |
+          mkdir -p reports/release_reconciliation
+          cat > reports/release_reconciliation/activation-request.json <<'JSON'
+          {
+            "schema": "stegverse.kv.release-reconciliation-request/v1",
+            "state": "TVC_ADMITTED_RELEASE_RECONCILIATION_REQUIRED",
+            "workflow_dispatch_performed": false,
+            "repository_mutation_performed": false,
+            "release_mutation_performed": false,
+            "github_actions_role": "VALIDATION_TRANSPORT_ONLY",
+            "credential_authority": "TV/TVC",
+            "canonical_next_transition": "TVC_ADMITTED_RELEASE_RECONCILIATION",
+            "authority_effect": "NONE"
+          }
+          JSON
+
+      - name: Upload non-authorizing reconciliation request
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-reconciliation-request-${{ github.run_id }}
+          path: reports/release_reconciliation/activation-request.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -15,8 +15,10 @@ on:
       - "tests/test_hosted_candidate_authority_retirement.py"
       - "tests/test_hosted_onboarding_control_plane_retirement.py"
       - "tests/test_production_provider_hosted_authority_retirement.py"
+      - "tests/test_release_reconciliation_hosted_authority_retirement.py"
       - "tests/test_hosted_onboarding_control_plane_retirement.py"
       - "tests/test_production_provider_hosted_authority_retirement.py"
+      - "tests/test_release_reconciliation_hosted_authority_retirement.py"
       - "vault_template/**"
       - "automation/**"
       - "evidence/onboarding-friction/**"
@@ -90,6 +92,9 @@ jobs:
 
       - name: Validate production provider hosted authority retirement
         run: python3 -m unittest tests.test_production_provider_hosted_authority_retirement -v
+
+      - name: Validate release reconciliation hosted authority retirement
+        run: python3 -m unittest tests.test_release_reconciliation_hosted_authority_retirement -v
 
       - name: Rebuild release evidence
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 - retired `automation-candidate-implementation.yml` hosted issue/repository/workflow-dispatch mutation authority; merged-PR candidate references are now emitted only as non-authorizing observation evidence
 - retired the coupled onboarding-friction triage/maintenance/bootstrap and candidate-lifecycle hosted control plane; classification and threshold projections now emit non-authorizing artifacts without issue, label, repository, workflow-dispatch, or token authority
 - retired GitHub-OIDC production-provider activation authority; hosted provider workflow now validates IaC source only and defers cloud identity/provisioning/apply to TVC-admitted resident execution
+- retired residual hosted release reconciliation/downstream mutation and retry-dispatch authority; release/downstream workflows now emit non-authorizing observations and defer canonical transitions to TV/TVC/non-hosted owners
 - preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
 
 ### Notes

--- a/RELEASE_RECONCILIATION_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
+++ b/RELEASE_RECONCILIATION_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-08-27
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #94
 Branch: `fix/release-reconciliation-hosted-authority`
-State: CLAIMED_FOR_IMPLEMENTATION
+State: IMPLEMENTED_ON_BRANCH_VALIDATION_PENDING
 
 ## Goal
 
@@ -38,6 +38,23 @@ Hosted scans may clone/read public downstream repositories and compare retained 
 
 No release is published/reconciled, no downstream repo is modified, no issue is closed/commented, and no retry is dispatched by this source repair.
 
+## Implemented source state
+
+```text
+downstream-propagation.yml: read-only registry projection + artifact
+reconcile-published-release.yml: retained-evidence consistency observation + artifact
+reconcile-release-activation.yml: TVC reconciliation request artifact only
+repository mutation: removed
+issue mutation: removed
+workflow dispatch: removed
+GitHub token/release API authority: removed
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+canonical release authority: TV/TVC
+authority_effect: NONE
+```
+
+Regression is installed in the automation-contract checker, a dedicated unit test, and Release Integrity.
+
 ## Next executable boundary
 
-Convert the three workflows to read-only observations, add fail-closed regression coverage, validate exact head, merge on green evidence, then inspect remaining repository-mutation workflows separately.
+Run exact-head validation, merge only if green, then inspect remaining hosted repository-mutation workflows (StegDB overlay sync and format-branch automation are known candidates).

--- a/RELEASE_RECONCILIATION_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
+++ b/RELEASE_RECONCILIATION_HOSTED_AUTHORITY_RETIREMENT_MIRROR_HANDOFF.md
@@ -1,0 +1,43 @@
+# Release Reconciliation Hosted Authority Retirement Mirror Handoff
+
+Updated: 2026-08-27
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #94
+Branch: `fix/release-reconciliation-hosted-authority`
+State: CLAIMED_FOR_IMPLEMENTATION
+
+## Goal
+
+Retire residual hosted release/downstream mutation authority without reopening the completed release-publication retirement.
+
+## Affected surfaces
+
+- `.github/workflows/downstream-propagation.yml`
+- `.github/workflows/reconcile-published-release.yml`
+- `.github/workflows/reconcile-release-activation.yml`
+
+## Required authority state
+
+```text
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+contents: read
+credential persistence: false where checkout exists
+GitHub token authority: NONE
+repository mutation: false
+issue mutation: false
+workflow dispatch: false
+release publication/reconciliation authority: NONE
+downstream mutation authority: NONE
+canonical release authority: TV/TVC
+authority_effect: NONE
+```
+
+Hosted scans may clone/read public downstream repositories and compare retained release evidence, then emit short-lived artifacts. They may not create canonical release/downstream state.
+
+## Non-claims
+
+No release is published/reconciled, no downstream repo is modified, no issue is closed/commented, and no retry is dispatched by this source repair.
+
+## Next executable boundary
+
+Convert the three workflows to read-only observations, add fail-closed regression coverage, validate exact head, merge on green evidence, then inspect remaining repository-mutation workflows separately.

--- a/tests/test_release_reconciliation_hosted_authority_retirement.py
+++ b/tests/test_release_reconciliation_hosted_authority_retirement.py
@@ -1,0 +1,28 @@
+"""Regression guard for hosted release/downstream reconciliation retirement."""
+from pathlib import Path
+import unittest
+
+ROOT=Path(__file__).resolve().parents[1]
+FILES=(
+ ".github/workflows/downstream-propagation.yml",
+ ".github/workflows/reconcile-published-release.yml",
+ ".github/workflows/reconcile-release-activation.yml",
+)
+
+class ReleaseReconciliationHostedAuthorityRetirementTests(unittest.TestCase):
+    def test_workflows_are_read_only(self):
+        forbidden=("contents: write","actions: write","issues: write","git push","git commit","gh issue ","gh workflow run","github.token","GH_TOKEN:","${{ secrets.","gh release ")
+        for rel in FILES:
+            text=(ROOT/rel).read_text(encoding="utf-8")
+            for token in forbidden:
+                self.assertNotIn(token,text,rel)
+            self.assertIn("contents: read",text,rel)
+            self.assertIn("VALIDATION_TRANSPORT_ONLY",text,rel)
+            self.assertIn("actions/upload-artifact@v4",text,rel)
+            self.assertIn("authority_effect",text,rel)
+            self.assertIn("NONE",text,rel)
+            if "actions/checkout@v4" in text:
+                self.assertIn("persist-credentials: false",text,rel)
+
+if __name__=="__main__":
+    unittest.main()

--- a/tools/test_automation_contracts.py
+++ b/tools/test_automation_contracts.py
@@ -36,6 +36,21 @@ WORKFLOWS = {
         "canonical_evidence_transition_performed",
         "actions/upload-artifact@v4",
     },
+    "reconcile-published-release.yml": {
+        "name: Reconcile published release evidence - Validation Only",
+        "contents: read",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "TVC_ADMITTED_RELEASE_RECONCILIATION",
+        "actions/upload-artifact@v4",
+    },
+    "reconcile-release-activation.yml": {
+        "name: Activate release reconciliation - Validation Only",
+        "contents: read",
+        "VALIDATION_TRANSPORT_ONLY",
+        "TVC_ADMITTED_RELEASE_RECONCILIATION_REQUIRED",
+        "actions/upload-artifact@v4",
+    },
     "release-cycle-recovery.yml": {
         "name: Release cycle recovery - Validation Only",
         'workflows: ["Release cycle outcome - Validation Only"]',
@@ -44,7 +59,14 @@ WORKFLOWS = {
         "workflow_dispatch_performed",
         "actions/upload-artifact@v4",
     },
-    "downstream-propagation.yml": {"release:", "evidence/downstream-propagation"},
+    "downstream-propagation.yml": {
+        "name: Downstream release propagation - Validation Only",
+        "contents: read",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_DOWNSTREAM_PROPAGATION_REVIEW",
+        "actions/upload-artifact@v4",
+    },
     "onboarding-friction-bootstrap.yml": {
         "name: Onboarding friction bootstrap - Validation Only",
         "workflow_dispatch:",
@@ -246,6 +268,46 @@ def validate_release_cycle_outcome() -> None:
         fail("release-cycle outcome scope must preserve the content-certification boundary")
     read_text(REPO_ROOT / "docs" / "release_evidence" / "latest_cycle.md")
 
+
+
+
+def validate_release_reconciliation_hosted_boundary() -> None:
+    workflow_root = REPO_ROOT / ".github" / "workflows"
+    files = (
+        "downstream-propagation.yml",
+        "reconcile-published-release.yml",
+        "reconcile-release-activation.yml",
+    )
+    forbidden = {
+        "contents: write",
+        "actions: write",
+        "issues: write",
+        "git push",
+        "git commit",
+        "gh issue ",
+        "gh workflow run",
+        "github.token",
+        "GH_TOKEN:",
+        "${{ secrets.",
+        "gh release ",
+    }
+    for filename in files:
+        text = read_text(workflow_root / filename)
+        present = sorted(token for token in forbidden if token in text)
+        if present:
+            fail(f"{filename} reintroduces hosted release/downstream authority: {', '.join(present)}")
+        required = {
+            "contents: read",
+            "VALIDATION_TRANSPORT_ONLY",
+            "authority_effect",
+            "NONE",
+            "actions/upload-artifact@v4",
+        }
+        if "actions/checkout@v4" in text:
+            required.add("persist-credentials: false")
+        missing = sorted(token for token in required if token not in text)
+        if missing:
+            fail(f"{filename} missing validation-only reconciliation tokens: {', '.join(missing)}")
 
 
 def validate_production_provider_hosted_boundary() -> None:
@@ -461,6 +523,7 @@ def main() -> int:
         validate_release_cycle,
         validate_hosted_release_cycle_boundary,
         validate_release_cycle_outcome,
+        validate_release_reconciliation_hosted_boundary,
         validate_production_provider_hosted_boundary,
         validate_candidate_implementation_boundary,
         validate_hosted_onboarding_control_plane_boundary,


### PR DESCRIPTION
Closes issue #94.

Converts `downstream-propagation.yml`, `reconcile-published-release.yml`, and `reconcile-release-activation.yml` to read-only validation/evidence transport.

Removed hosted repository writes, issue mutation, workflow dispatch, GitHub-token/release API authority, and canonical release/downstream state mutation. Preserved configured downstream registry/search terms and retained-release consistency checks as non-authorizing artifacts only.

Adds fail-closed automation-contract and dedicated regression coverage in Release Integrity.

Non-claims: no release is published/reconciled, no downstream repository is changed, no issue is closed/commented, and no retry is dispatched.