### PR TITLE
Retire hosted StegDB overlay writeback authority

### DIFF
--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -16,9 +16,11 @@ on:
       - "tests/test_hosted_onboarding_control_plane_retirement.py"
       - "tests/test_production_provider_hosted_authority_retirement.py"
       - "tests/test_release_reconciliation_hosted_authority_retirement.py"
+      - "tests/test_stegdb_overlay_hosted_writeback_retirement.py"
       - "tests/test_hosted_onboarding_control_plane_retirement.py"
       - "tests/test_production_provider_hosted_authority_retirement.py"
       - "tests/test_release_reconciliation_hosted_authority_retirement.py"
+      - "tests/test_stegdb_overlay_hosted_writeback_retirement.py"
       - "vault_template/**"
       - "automation/**"
       - "evidence/onboarding-friction/**"
@@ -95,6 +97,9 @@ jobs:
 
       - name: Validate release reconciliation hosted authority retirement
         run: python3 -m unittest tests.test_release_reconciliation_hosted_authority_retirement -v
+
+      - name: Validate StegDB overlay hosted writeback retirement
+        run: python3 -m unittest tests.test_stegdb_overlay_hosted_writeback_retirement -v
 
       - name: Rebuild release evidence
         run: |

--- a/.github/workflows/sync-knowledgevault-overlay-from-stegdb.yml
+++ b/.github/workflows/sync-knowledgevault-overlay-from-stegdb.yml
@@ -1,58 +1,98 @@
-name: Sync KnowledgeVault overlay from StegDB
+name: Sync KnowledgeVault overlay from StegDB - Validation Only
 
 on:
   workflow_dispatch:
     inputs:
       stegdb_ref:
-        description: "StegDB ref (tag/branch/SHA). Use a release tag or merge SHA when possible."
+        description: "StegDB ref (tag/branch/SHA) to evaluate."
         required: false
         default: "main"
   schedule:
-    - cron: "11 3 * * *" # daily 03:11 UTC
+    - cron: "11 3 * * *"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  sync:
+  observe:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Checkout continuity-vault-kit
+      - name: Checkout continuity-vault-kit without credential persistence
         uses: actions/checkout@v4
+        with:
+          path: _cvk
+          persist-credentials: false
 
-      - name: Checkout StegDB
+      - name: Checkout StegDB without credential persistence
         uses: actions/checkout@v4
         with:
           repository: stegverse-labs/stegdb
-          ref: ${{ inputs.stegdb_ref }}
+          ref: ${{ inputs.stegdb_ref || 'main' }}
           path: _stegdb
+          persist-credentials: false
 
-      - name: Sync KnowledgeVaultOverlay into _Canon (fail loud)
+      - name: Build deterministic overlay sync candidate
         shell: bash
         run: |
           set -euo pipefail
           SRC="_stegdb/canonical/overlays/KnowledgeVaultOverlay/canon"
-          test -d "$SRC" || (echo "::error::Missing overlay folder: $SRC"; exit 3)
+          test -d "$SRC"
+          REPORT="_cvk/reports/stegdb_overlay_sync"
+          CANDIDATE="$REPORT/candidate"
+          rm -rf "$REPORT"
+          mkdir -p "$CANDIDATE"
+          rsync -a --delete "$SRC/" "$CANDIDATE/"
+          test -n "$(ls -A "$CANDIDATE")"
+          TARGET="_cvk/vault_template/KnowledgeVault/_Canon"
+          mkdir -p "$REPORT"
+          diff -ruN "$TARGET" "$CANDIDATE" > "$REPORT/overlay.patch" || true
+          python3 - <<'PY'
+          import hashlib, json, os
+          from datetime import datetime, timezone
+          from pathlib import Path
+          report=Path("_cvk/reports/stegdb_overlay_sync")
+          candidate=report/"candidate"
+          target=Path("_cvk/vault_template/KnowledgeVault/_Canon")
+          def inventory(root):
+              rows=[]
+              if not root.exists():
+                  return rows
+              for p in sorted(x for x in root.rglob("*") if x.is_file()):
+                  data=p.read_bytes()
+                  rows.append({"path":str(p.relative_to(root)),"sha256":hashlib.sha256(data).hexdigest(),"bytes":len(data)})
+              return rows
+          before=inventory(target)
+          after=inventory(candidate)
+          payload={
+              "schema":"stegverse.kv.stegdb-overlay-sync-observation/v1",
+              "stegdb_ref":"${{ inputs.stegdb_ref || 'main' }}",
+              "target":"vault_template/KnowledgeVault/_Canon",
+              "current_file_count":len(before),
+              "candidate_file_count":len(after),
+              "current_inventory":before,
+              "candidate_inventory":after,
+              "change_required":before!=after,
+              "repository_mutation_performed":False,
+              "stegdb_mutation_performed":False,
+              "git_commit_performed":False,
+              "git_push_performed":False,
+              "github_actions_role":"VALIDATION_TRANSPORT_ONLY",
+              "canonical_next_transition":"NON_HOSTED_REPOSITORY_SYNC_REQUIRED" if before!=after else "NONE",
+              "authority_effect":"NONE",
+              "observed_utc":datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
+          }
+          (report/"observation.json").write_text(json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps({k:payload[k] for k in ("target","current_file_count","candidate_file_count","change_required","canonical_next_transition")},sort_keys=True))
+          PY
 
-          DST="vault_template/KnowledgeVault/_Canon"
-          mkdir -p "$DST"
-
-          rsync -a --delete "$SRC/" "$DST/"
-
-          test -n "$(ls -A "$DST")" || (echo "::error::Overlay sync produced empty $DST"; exit 4)
-
-          rm -rf _stegdb
-
-      - name: Commit overlay changes
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --quiet; then
-            echo "No changes"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add vault_template/KnowledgeVault/_Canon
-          git commit -m "chore: sync KnowledgeVaultOverlay from StegDB @ ${{ inputs.stegdb_ref }}"
-          git push
+      - name: Upload non-authorizing overlay candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: stegdb-overlay-sync-vault_template-KnowledgeVault-_Canon-${{ github.run_id }}
+          path: |
+            _cvk/reports/stegdb_overlay_sync/observation.json
+            _cvk/reports/stegdb_overlay_sync/overlay.patch
+            _cvk/reports/stegdb_overlay_sync/candidate/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/sync-overlay-from-stegdb.yml
+++ b/.github/workflows/sync-overlay-from-stegdb.yml
@@ -1,56 +1,98 @@
-name: Sync overlay from StegDB
+name: Sync overlay from StegDB - Validation Only
 
 on:
   workflow_dispatch:
     inputs:
       stegdb_ref:
-        description: "StegDB ref (tag/branch/SHA)."
+        description: "StegDB ref (tag/branch/SHA) to evaluate."
         required: false
         default: "main"
   schedule:
-    - cron: "35 3 * * *" # daily 03:35 UTC
+    - cron: "35 3 * * *"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  sync:
+  observe:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Checkout KnowledgeVault
+      - name: Checkout continuity-vault-kit without credential persistence
         uses: actions/checkout@v4
+        with:
+          path: _cvk
+          persist-credentials: false
 
-      - name: Checkout StegDB
+      - name: Checkout StegDB without credential persistence
         uses: actions/checkout@v4
         with:
           repository: stegverse-labs/stegdb
-          ref: ${{ inputs.stegdb_ref }}
+          ref: ${{ inputs.stegdb_ref || 'main' }}
           path: _stegdb
+          persist-credentials: false
 
-      - name: Sync KnowledgeVault overlay into canon/ (fail loud)
+      - name: Build deterministic overlay sync candidate
         shell: bash
         run: |
           set -euo pipefail
           SRC="_stegdb/canonical/overlays/KnowledgeVaultOverlay/canon"
-          test -d "$SRC" || (echo "::error::Missing overlay folder: $SRC"; exit 3)
+          test -d "$SRC"
+          REPORT="_cvk/reports/stegdb_overlay_sync"
+          CANDIDATE="$REPORT/candidate"
+          rm -rf "$REPORT"
+          mkdir -p "$CANDIDATE"
+          rsync -a --delete "$SRC/" "$CANDIDATE/"
+          test -n "$(ls -A "$CANDIDATE")"
+          TARGET="_cvk/canon"
+          mkdir -p "$REPORT"
+          diff -ruN "$TARGET" "$CANDIDATE" > "$REPORT/overlay.patch" || true
+          python3 - <<'PY'
+          import hashlib, json, os
+          from datetime import datetime, timezone
+          from pathlib import Path
+          report=Path("_cvk/reports/stegdb_overlay_sync")
+          candidate=report/"candidate"
+          target=Path("_cvk/canon")
+          def inventory(root):
+              rows=[]
+              if not root.exists():
+                  return rows
+              for p in sorted(x for x in root.rglob("*") if x.is_file()):
+                  data=p.read_bytes()
+                  rows.append({"path":str(p.relative_to(root)),"sha256":hashlib.sha256(data).hexdigest(),"bytes":len(data)})
+              return rows
+          before=inventory(target)
+          after=inventory(candidate)
+          payload={
+              "schema":"stegverse.kv.stegdb-overlay-sync-observation/v1",
+              "stegdb_ref":"${{ inputs.stegdb_ref || 'main' }}",
+              "target":"canon",
+              "current_file_count":len(before),
+              "candidate_file_count":len(after),
+              "current_inventory":before,
+              "candidate_inventory":after,
+              "change_required":before!=after,
+              "repository_mutation_performed":False,
+              "stegdb_mutation_performed":False,
+              "git_commit_performed":False,
+              "git_push_performed":False,
+              "github_actions_role":"VALIDATION_TRANSPORT_ONLY",
+              "canonical_next_transition":"NON_HOSTED_REPOSITORY_SYNC_REQUIRED" if before!=after else "NONE",
+              "authority_effect":"NONE",
+              "observed_utc":datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
+          }
+          (report/"observation.json").write_text(json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps({k:payload[k] for k in ("target","current_file_count","candidate_file_count","change_required","canonical_next_transition")},sort_keys=True))
+          PY
 
-          mkdir -p canon
-          rsync -a --delete "$SRC/" "canon/"
-
-          test -n "$(ls -A canon)" || (echo "::error::Overlay sync produced empty canon/"; exit 4)
-
-          rm -rf _stegdb
-
-      - name: Commit overlay changes
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --quiet; then
-            echo "No changes"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add canon
-          git commit -m "chore: sync KnowledgeVault overlay from StegDB @ ${{ inputs.stegdb_ref }}"
-          git push
+      - name: Upload non-authorizing overlay candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: stegdb-overlay-sync-canon-${{ github.run_id }}
+          path: |
+            _cvk/reports/stegdb_overlay_sync/observation.json
+            _cvk/reports/stegdb_overlay_sync/overlay.patch
+            _cvk/reports/stegdb_overlay_sync/candidate/
+          if-no-files-found: error
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 - retired the coupled onboarding-friction triage/maintenance/bootstrap and candidate-lifecycle hosted control plane; classification and threshold projections now emit non-authorizing artifacts without issue, label, repository, workflow-dispatch, or token authority
 - retired GitHub-OIDC production-provider activation authority; hosted provider workflow now validates IaC source only and defers cloud identity/provisioning/apply to TVC-admitted resident execution
 - retired residual hosted release reconciliation/downstream mutation and retry-dispatch authority; release/downstream workflows now emit non-authorizing observations and defer canonical transitions to TV/TVC/non-hosted owners
+- retired hosted StegDB overlay writeback; scheduled/manual overlay workflows now build hash-verifiable candidate trees and patches as artifacts without committing or pushing canonical CVK state
 - preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
 
 ### Notes

--- a/STEGDB_OVERLAY_HOSTED_WRITEBACK_RETIREMENT_MIRROR_HANDOFF.md
+++ b/STEGDB_OVERLAY_HOSTED_WRITEBACK_RETIREMENT_MIRROR_HANDOFF.md
@@ -1,0 +1,42 @@
+# StegDB Overlay Hosted Writeback Retirement Mirror Handoff
+
+Updated: 2026-08-27
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #97
+Branch: `fix/stegdb-overlay-hosted-writeback`
+State: CLAIMED_FOR_IMPLEMENTATION
+
+## Goal
+
+Retire hosted canonical repository writeback from both StegDB overlay sync workflows while preserving exact machine-generated sync candidates.
+
+## Affected workflows
+
+- `.github/workflows/sync-knowledgevault-overlay-from-stegdb.yml`
+- `.github/workflows/sync-overlay-from-stegdb.yml`
+
+## Required state
+
+```text
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+contents: read
+persist-credentials: false
+repository mutation: false
+git commit/push: false
+StegDB mutation: false
+candidate overlay generation: allowed
+candidate hash inventory: allowed
+candidate patch artifact: allowed
+canonical_next_transition: NON_HOSTED_REPOSITORY_SYNC_REQUIRED
+authority_effect: NONE
+```
+
+The hosted workflows may build deterministic candidate trees in temporary/report directories and compare them with current canonical targets. They must not make those candidate trees canonical.
+
+## Non-claims
+
+No canonical overlay sync, repository mutation, deployment, runtime activation, or credential authority is produced.
+
+## Next executable boundary
+
+Convert both workflows to read-only delta/patch generation, add regression enforcement, validate exact head, merge only on green evidence, then inspect KV format-branch mutation separately.

--- a/STEGDB_OVERLAY_HOSTED_WRITEBACK_RETIREMENT_MIRROR_HANDOFF.md
+++ b/STEGDB_OVERLAY_HOSTED_WRITEBACK_RETIREMENT_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-08-27
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #97
 Branch: `fix/stegdb-overlay-hosted-writeback`
-State: CLAIMED_FOR_IMPLEMENTATION
+State: IMPLEMENTED_ON_BRANCH_VALIDATION_PENDING
 
 ## Goal
 
@@ -37,6 +37,24 @@ The hosted workflows may build deterministic candidate trees in temporary/report
 
 No canonical overlay sync, repository mutation, deployment, runtime activation, or credential authority is produced.
 
+## Implemented source state
+
+```text
+both workflows: contents read
+CVK checkout credential persistence: false
+StegDB checkout credential persistence: false
+candidate overlay tree: generated in report directory
+SHA-256 inventories: generated
+overlay patch: generated
+repository mutation: false
+git commit/push: false
+canonical_next_transition: NON_HOSTED_REPOSITORY_SYNC_REQUIRED
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+authority_effect: NONE
+```
+
+Regression is installed in automation contracts, a dedicated unit test, and Release Integrity.
+
 ## Next executable boundary
 
-Convert both workflows to read-only delta/patch generation, add regression enforcement, validate exact head, merge only on green evidence, then inspect KV format-branch mutation separately.
+Run exact-head validation and merge only if green. Then inspect and retire the remaining KV format-branch hosted mutation surface.

--- a/tests/test_stegdb_overlay_hosted_writeback_retirement.py
+++ b/tests/test_stegdb_overlay_hosted_writeback_retirement.py
@@ -1,0 +1,21 @@
+"""Regression guard for hosted StegDB overlay writeback retirement."""
+from pathlib import Path
+import unittest
+
+ROOT=Path(__file__).resolve().parents[1]
+FILES=(
+ ".github/workflows/sync-knowledgevault-overlay-from-stegdb.yml",
+ ".github/workflows/sync-overlay-from-stegdb.yml",
+)
+
+class StegDBOverlayHostedWritebackRetirementTests(unittest.TestCase):
+    def test_overlay_sync_is_candidate_only(self):
+        for rel in FILES:
+            text=(ROOT/rel).read_text(encoding="utf-8")
+            for token in ("contents: write","git push","git commit","github.token","GH_TOKEN:","${{ secrets."):
+                self.assertNotIn(token,text,rel)
+            for token in ("contents: read","persist-credentials: false","VALIDATION_TRANSPORT_ONLY","NON_HOSTED_REPOSITORY_SYNC_REQUIRED","repository_mutation_performed","git_push_performed","actions/upload-artifact@v4","authority_effect","NONE"):
+                self.assertIn(token,text,rel)
+
+if __name__=="__main__":
+    unittest.main()

--- a/tools/test_automation_contracts.py
+++ b/tools/test_automation_contracts.py
@@ -111,6 +111,20 @@ WORKFLOWS = {
         "TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION",
         "actions/upload-artifact@v4",
     },
+    "sync-knowledgevault-overlay-from-stegdb.yml": {
+        "contents: read",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_REPOSITORY_SYNC_REQUIRED",
+        "actions/upload-artifact@v4",
+    },
+    "sync-overlay-from-stegdb.yml": {
+        "contents: read",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_REPOSITORY_SYNC_REQUIRED",
+        "actions/upload-artifact@v4",
+    },
     "automation-candidate-implementation.yml": {
         "name: Automation candidate implementation - Validation Only",
         "pull_request:",
@@ -269,6 +283,38 @@ def validate_release_cycle_outcome() -> None:
     read_text(REPO_ROOT / "docs" / "release_evidence" / "latest_cycle.md")
 
 
+
+
+
+def validate_stegdb_overlay_hosted_boundary() -> None:
+    workflow_root = REPO_ROOT / ".github" / "workflows"
+    for filename in ("sync-knowledgevault-overlay-from-stegdb.yml", "sync-overlay-from-stegdb.yml"):
+        text = read_text(workflow_root / filename)
+        forbidden = {
+            "contents: write",
+            "git push",
+            "git commit",
+            "github.token",
+            "GH_TOKEN:",
+            "${{ secrets.",
+        }
+        present = sorted(token for token in forbidden if token in text)
+        if present:
+            fail(f"{filename} reintroduces hosted StegDB overlay writeback: {', '.join(present)}")
+        required = {
+            "contents: read",
+            "persist-credentials: false",
+            "VALIDATION_TRANSPORT_ONLY",
+            "NON_HOSTED_REPOSITORY_SYNC_REQUIRED",
+            "repository_mutation_performed",
+            "git_push_performed",
+            "actions/upload-artifact@v4",
+            "authority_effect",
+            "NONE",
+        }
+        missing = sorted(token for token in required if token not in text)
+        if missing:
+            fail(f"{filename} missing validation-only overlay tokens: {', '.join(missing)}")
 
 
 def validate_release_reconciliation_hosted_boundary() -> None:
@@ -523,6 +569,7 @@ def main() -> int:
         validate_release_cycle,
         validate_hosted_release_cycle_boundary,
         validate_release_cycle_outcome,
+        validate_stegdb_overlay_hosted_boundary,
         validate_release_reconciliation_hosted_boundary,
         validate_production_provider_hosted_boundary,
         validate_candidate_implementation_boundary,


### PR DESCRIPTION
Closes issue #97.

Converts both StegDB overlay sync workflows to read-only candidate generation:
- no `contents: write`;
- no commit/push;
- no credential persistence;
- deterministic candidate overlay tree;
- SHA-256 before/after inventories;
- generated patch against current canonical target;
- non-authorizing artifact only.

Adds fail-closed automation-contract and dedicated regression coverage in Release Integrity.

Canonical repository sync remains a separate non-hosted transition. No StegDB/CVK mutation, deployment, or activation is claimed.