### PR TITLE
Retire hosted KV format-branch mutation authority

### DIFF
--- a/.github/workflows/kv-format-branch.yml
+++ b/.github/workflows/kv-format-branch.yml
@@ -1,4 +1,4 @@
-name: KV Format Branch (Auto-footer)
+name: KV Format Branch - Validation Only
 
 on:
   push:
@@ -7,41 +7,73 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  auto_footer_format_branch:
+  format_candidate:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 10
     steps:
-      - name: Checkout (format branch)
+      - name: Checkout exact branch without credential persistence
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Auto-label footers (format branch only)
+      - name: Build formatted candidate outside repository
+        shell: bash
         run: |
-          python3 tools/kv_layer_check.py --mode auto-label
+          set -euo pipefail
+          CANDIDATE="$RUNNER_TEMP/kv-format-candidate"
+          REPORT="$RUNNER_TEMP/kv-format-report"
+          rm -rf "$CANDIDATE" "$REPORT"
+          mkdir -p "$CANDIDATE" "$REPORT"
+          rsync -a --exclude '.git' ./ "$CANDIDATE/"
+          (
+            cd "$CANDIDATE"
+            python3 tools/kv_layer_check.py --mode auto-label
+            python3 tools/kv_layer_check.py --mode validate
+          )
+          diff -ruN --exclude '.git' "$GITHUB_WORKSPACE" "$CANDIDATE" > "$REPORT/kv-format.patch" || true
+          CANDIDATE="$CANDIDATE" REPORT="$REPORT" python3 - <<'PY'
+          import hashlib, json, os
+          from datetime import datetime, timezone
+          from pathlib import Path
+          candidate=Path(os.environ["CANDIDATE"])
+          report=Path(os.environ["REPORT"])
+          rows=[]
+          for p in sorted(x for x in candidate.rglob("*") if x.is_file()):
+              data=p.read_bytes()
+              rows.append({"path":str(p.relative_to(candidate)),"sha256":hashlib.sha256(data).hexdigest(),"bytes":len(data)})
+          patch=(report/"kv-format.patch").read_text(encoding="utf-8",errors="replace")
+          payload={
+              "schema":"stegverse.kv.format-candidate-observation/v1",
+              "candidate_file_count":len(rows),
+              "candidate_inventory":rows,
+              "change_required":bool(patch.strip()),
+              "repository_mutation_performed":False,
+              "git_commit_performed":False,
+              "git_push_performed":False,
+              "github_actions_role":"VALIDATION_TRANSPORT_ONLY",
+              "canonical_next_transition":"NON_HOSTED_FORMAT_PATCH_APPLICATION" if patch.strip() else "NONE",
+              "authority_effect":"NONE",
+              "observed_utc":datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z"),
+          }
+          (report/"observation.json").write_text(json.dumps(payload,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(json.dumps({k:payload[k] for k in ("candidate_file_count","change_required","canonical_next_transition")},sort_keys=True))
+          PY
 
-      - name: Commit changes (if any)
-        run: |
-          if git diff --quiet; then
-            echo "No formatting changes."
-            exit 0
-          fi
-
-          git config user.name "stegverse-bot"
-          git config user.email "stegverse-bot@users.noreply.github.com"
-
-          git add -A
-          git commit -m "chore(kv): auto-add layer footer"
-          git push
-
-      - name: Validate after auto-label
-        run: |
-          python3 tools/kv_layer_check.py --mode validate
+      - name: Upload non-authorizing formatting candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: kv-format-candidate-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/kv-format-report/observation.json
+            ${{ runner.temp }}/kv-format-report/kv-format.patch
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -17,10 +17,12 @@ on:
       - "tests/test_production_provider_hosted_authority_retirement.py"
       - "tests/test_release_reconciliation_hosted_authority_retirement.py"
       - "tests/test_stegdb_overlay_hosted_writeback_retirement.py"
+      - "tests/test_kv_format_hosted_mutation_retirement.py"
       - "tests/test_hosted_onboarding_control_plane_retirement.py"
       - "tests/test_production_provider_hosted_authority_retirement.py"
       - "tests/test_release_reconciliation_hosted_authority_retirement.py"
       - "tests/test_stegdb_overlay_hosted_writeback_retirement.py"
+      - "tests/test_kv_format_hosted_mutation_retirement.py"
       - "vault_template/**"
       - "automation/**"
       - "evidence/onboarding-friction/**"
@@ -100,6 +102,9 @@ jobs:
 
       - name: Validate StegDB overlay hosted writeback retirement
         run: python3 -m unittest tests.test_stegdb_overlay_hosted_writeback_retirement -v
+
+      - name: Validate KV format hosted mutation retirement
+        run: python3 -m unittest tests.test_kv_format_hosted_mutation_retirement -v
 
       - name: Rebuild release evidence
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 - retired GitHub-OIDC production-provider activation authority; hosted provider workflow now validates IaC source only and defers cloud identity/provisioning/apply to TVC-admitted resident execution
 - retired residual hosted release reconciliation/downstream mutation and retry-dispatch authority; release/downstream workflows now emit non-authorizing observations and defer canonical transitions to TV/TVC/non-hosted owners
 - retired hosted StegDB overlay writeback; scheduled/manual overlay workflows now build hash-verifiable candidate trees and patches as artifacts without committing or pushing canonical CVK state
+- retired hosted KV format-branch writeback; auto-footer formatting now produces a validated candidate patch artifact without branch commits or pushes
 - preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
 
 ### Notes

--- a/KV_FORMAT_HOSTED_MUTATION_RETIREMENT_MIRROR_HANDOFF.md
+++ b/KV_FORMAT_HOSTED_MUTATION_RETIREMENT_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-08-27
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #99
 Branch: `fix/kv-format-hosted-mutation`
-State: CLAIMED_FOR_IMPLEMENTATION
+State: IMPLEMENTED_ON_BRANCH_VALIDATION_PENDING
 
 ## Goal
 
@@ -31,6 +31,24 @@ The formatter must operate on a temporary copy so the checked-out branch remains
 
 No branch mutation, merge, release, deployment, runtime activation, or authority transfer is produced.
 
+## Implemented source state
+
+```text
+workflow: KV Format Branch - Validation Only
+contents: read
+persist-credentials: false
+formatter execution: temporary candidate copy only
+candidate validation: retained
+patch artifact: retained
+repository mutation: false
+git commit/push: false
+canonical_next_transition: NON_HOSTED_FORMAT_PATCH_APPLICATION
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+authority_effect: NONE
+```
+
+Regression is installed in automation contracts, a dedicated unit test, and Release Integrity.
+
 ## Next executable boundary
 
-Implement candidate formatting + patch artifact generation, add regression enforcement, validate exact head, merge only on green evidence, then perform a full workflow authority audit for any remaining write/credential/production surfaces.
+Run exact-head validation and merge only if green. Then perform a complete live workflow audit for any residual write, token, OIDC, production, release, or repository-mutation authority.

--- a/KV_FORMAT_HOSTED_MUTATION_RETIREMENT_MIRROR_HANDOFF.md
+++ b/KV_FORMAT_HOSTED_MUTATION_RETIREMENT_MIRROR_HANDOFF.md
@@ -1,0 +1,36 @@
+# KV Format Hosted Mutation Retirement Mirror Handoff
+
+Updated: 2026-08-27
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #99
+Branch: `fix/kv-format-hosted-mutation`
+State: CLAIMED_FOR_IMPLEMENTATION
+
+## Goal
+
+Retire hosted branch writeback from `.github/workflows/kv-format-branch.yml` while keeping formatter output machine-generated and reviewable.
+
+## Required state
+
+```text
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+contents: read
+persist-credentials: false
+formatter candidate generation: allowed
+candidate validation: allowed
+patch artifact: allowed
+git commit/push: false
+repository mutation: false
+canonical_next_transition: NON_HOSTED_FORMAT_PATCH_APPLICATION
+authority_effect: NONE
+```
+
+The formatter must operate on a temporary copy so the checked-out branch remains unchanged.
+
+## Non-claims
+
+No branch mutation, merge, release, deployment, runtime activation, or authority transfer is produced.
+
+## Next executable boundary
+
+Implement candidate formatting + patch artifact generation, add regression enforcement, validate exact head, merge only on green evidence, then perform a full workflow authority audit for any remaining write/credential/production surfaces.

--- a/tests/test_kv_format_hosted_mutation_retirement.py
+++ b/tests/test_kv_format_hosted_mutation_retirement.py
@@ -1,0 +1,17 @@
+"""Regression guard for hosted KV format branch mutation retirement."""
+from pathlib import Path
+import unittest
+
+ROOT=Path(__file__).resolve().parents[1]
+WORKFLOW=ROOT/".github/workflows/kv-format-branch.yml"
+
+class KVFormatHostedMutationRetirementTests(unittest.TestCase):
+    def test_format_workflow_is_candidate_only(self):
+        text=WORKFLOW.read_text(encoding="utf-8")
+        for token in ("contents: write","git push","git commit","github.token","GH_TOKEN:","${{ secrets."):
+            self.assertNotIn(token,text,token)
+        for token in ("contents: read","persist-credentials: false","VALIDATION_TRANSPORT_ONLY","NON_HOSTED_FORMAT_PATCH_APPLICATION","repository_mutation_performed","git_push_performed","actions/upload-artifact@v4","authority_effect","NONE"):
+            self.assertIn(token,text,token)
+
+if __name__=="__main__":
+    unittest.main()

--- a/tools/test_automation_contracts.py
+++ b/tools/test_automation_contracts.py
@@ -111,6 +111,14 @@ WORKFLOWS = {
         "TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION",
         "actions/upload-artifact@v4",
     },
+    "kv-format-branch.yml": {
+        "name: KV Format Branch - Validation Only",
+        "contents: read",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_FORMAT_PATCH_APPLICATION",
+        "actions/upload-artifact@v4",
+    },
     "sync-knowledgevault-overlay-from-stegdb.yml": {
         "contents: read",
         "persist-credentials: false",
@@ -284,6 +292,36 @@ def validate_release_cycle_outcome() -> None:
 
 
 
+
+
+
+def validate_kv_format_hosted_boundary() -> None:
+    workflow = read_text(REPO_ROOT / ".github" / "workflows" / "kv-format-branch.yml")
+    forbidden = {
+        "contents: write",
+        "git push",
+        "git commit",
+        "github.token",
+        "GH_TOKEN:",
+        "${{ secrets.",
+    }
+    present = sorted(token for token in forbidden if token in workflow)
+    if present:
+        fail("kv-format branch reintroduces hosted repository mutation: " + ", ".join(present))
+    required = {
+        "contents: read",
+        "persist-credentials: false",
+        "VALIDATION_TRANSPORT_ONLY",
+        "NON_HOSTED_FORMAT_PATCH_APPLICATION",
+        "repository_mutation_performed",
+        "git_push_performed",
+        "actions/upload-artifact@v4",
+        "authority_effect",
+        "NONE",
+    }
+    missing = sorted(token for token in required if token not in workflow)
+    if missing:
+        fail("kv-format branch missing validation-only formatting tokens: " + ", ".join(missing))
 
 
 def validate_stegdb_overlay_hosted_boundary() -> None:
@@ -569,6 +607,7 @@ def main() -> int:
         validate_release_cycle,
         validate_hosted_release_cycle_boundary,
         validate_release_cycle_outcome,
+        validate_kv_format_hosted_boundary,
         validate_stegdb_overlay_hosted_boundary,
         validate_release_reconciliation_hosted_boundary,
         validate_production_provider_hosted_boundary,


### PR DESCRIPTION
Closes issue #99.

Converts `kv-format-branch.yml` to validation-only candidate formatting:
- read-only checkout with no credential persistence;
- formatter runs against a temporary candidate copy;
- candidate is validated;
- exact patch and candidate inventory evidence are uploaded;
- no commit/push or branch mutation.

Adds fail-closed automation-contract and dedicated regression coverage in Release Integrity.

Non-claims: no branch is mutated, formatting is not canonically applied, and no runtime/release/credential authority is granted.