### PR TITLE
Enforce repository-wide hosted workflow non-authority

### DIFF
--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -18,11 +18,13 @@ on:
       - "tests/test_release_reconciliation_hosted_authority_retirement.py"
       - "tests/test_stegdb_overlay_hosted_writeback_retirement.py"
       - "tests/test_kv_format_hosted_mutation_retirement.py"
+      - "tests/test_global_hosted_workflow_authority.py"
       - "tests/test_hosted_onboarding_control_plane_retirement.py"
       - "tests/test_production_provider_hosted_authority_retirement.py"
       - "tests/test_release_reconciliation_hosted_authority_retirement.py"
       - "tests/test_stegdb_overlay_hosted_writeback_retirement.py"
       - "tests/test_kv_format_hosted_mutation_retirement.py"
+      - "tests/test_global_hosted_workflow_authority.py"
       - "vault_template/**"
       - "automation/**"
       - "evidence/onboarding-friction/**"
@@ -105,6 +107,9 @@ jobs:
 
       - name: Validate KV format hosted mutation retirement
         run: python3 -m unittest tests.test_kv_format_hosted_mutation_retirement -v
+
+      - name: Validate repository-wide hosted workflow authority
+        run: python3 -m unittest tests.test_global_hosted_workflow_authority -v
 
       - name: Rebuild release evidence
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
       - "VERSION"
       - ".github/workflows/release.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 - retired residual hosted release reconciliation/downstream mutation and retry-dispatch authority; release/downstream workflows now emit non-authorizing observations and defer canonical transitions to TV/TVC/non-hosted owners
 - retired hosted StegDB overlay writeback; scheduled/manual overlay workflows now build hash-verifiable candidate trees and patches as artifacts without committing or pushing canonical CVK state
 - retired hosted KV format-branch writeback; auto-footer formatting now produces a validated candidate patch artifact without branch commits or pushes
+- added a repository-wide hosted workflow non-authority invariant across all 38 workflows; every workflow must declare explicit permissions and any write/token/OIDC/cloud-mutation marker fails validation
 - preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
 
 ### Notes

--- a/HOSTED_WORKFLOW_AUTHORITY_AUDIT_MIRROR_HANDOFF.md
+++ b/HOSTED_WORKFLOW_AUTHORITY_AUDIT_MIRROR_HANDOFF.md
@@ -1,0 +1,66 @@
+# Hosted Workflow Authority Audit Mirror Handoff
+
+Updated: 2026-08-27
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #101
+Branch: `hardening/global-hosted-workflow-authority`
+State: CLAIMED_FOR_IMPLEMENTATION
+
+## Live audit result
+
+Current workflow count: 38.
+
+Explicit hosted-authority marker scan result:
+
+```text
+contents: write: 0
+actions: write: 0
+issues: write: 0
+pull-requests: write: 0
+id-token: write: 0
+packages: write: 0
+deployments: write: 0
+git push: 0
+git commit: 0
+git tag: 0
+gh release: 0
+gh workflow run: 0
+github.token: 0
+GH_TOKEN: 0
+secrets.*: 0
+aws-actions/configure-aws-credentials: 0
+terraform apply: 0
+kubectl apply: 0
+helm upgrade: 0
+repository_dispatch: 0
+```
+
+One explicit-permissions gap remains:
+
+```text
+.github/workflows/release.yml -> no permissions block
+```
+
+## Required invariant
+
+Every hosted workflow:
+- declares explicit permissions;
+- grants no write/OIDC/cloud/provider/repository/release authority;
+- uses Actions only for validation/evidence transport;
+- may not reintroduce forbidden hosted mutation/credential markers.
+
+## Planned source
+
+- `.github/workflows/release.yml`
+- `tools/test_automation_contracts.py`
+- dedicated repository-wide workflow authority regression
+- Release Integrity execution
+- root handoff/change record
+
+## Non-claims
+
+No runtime activation, deployment, release, provider mutation, or credential authority is produced.
+
+## Next executable boundary
+
+Make release.yml explicitly read-only, install repository-wide enforcement, validate exact head, merge if green, then re-run the 38-workflow audit and record the completed invariant.

--- a/HOSTED_WORKFLOW_AUTHORITY_AUDIT_MIRROR_HANDOFF.md
+++ b/HOSTED_WORKFLOW_AUTHORITY_AUDIT_MIRROR_HANDOFF.md
@@ -4,7 +4,7 @@ Updated: 2026-08-27
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #101
 Branch: `hardening/global-hosted-workflow-authority`
-State: CLAIMED_FOR_IMPLEMENTATION
+State: IMPLEMENTED_ON_BRANCH_VALIDATION_PENDING
 
 ## Live audit result
 
@@ -61,6 +61,19 @@ Every hosted workflow:
 
 No runtime activation, deployment, release, provider mutation, or credential authority is produced.
 
+## Implemented source state
+
+```text
+release.yml explicit permissions: contents read
+repository-wide workflow scan: installed
+workflow count assertion: 38
+explicit permissions required for every workflow
+forbidden hosted authority markers: fail closed globally
+workflow-specific regressions: retained
+GitHub Actions role: VALIDATION_TRANSPORT_ONLY
+authority_effect: NONE
+```
+
 ## Next executable boundary
 
-Make release.yml explicitly read-only, install repository-wide enforcement, validate exact head, merge if green, then re-run the 38-workflow audit and record the completed invariant.
+Run exact-head validation, merge only on green evidence, then re-run the live 38-workflow scan on main and record the audit as COMPLETE.

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -1,0 +1,27 @@
+"""Repository-wide hosted workflow authority invariant."""
+from pathlib import Path
+import unittest
+
+ROOT=Path(__file__).resolve().parents[1]
+WORKFLOW_ROOT=ROOT/".github/workflows"
+
+class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
+    def test_all_workflows_declare_permissions_and_no_authority_markers(self):
+        forbidden=(
+            "contents: write","actions: write","issues: write","pull-requests: write",
+            "id-token: write","packages: write","deployments: write",
+            "git push","git commit","git tag","gh release ","gh workflow run",
+            "github.token","GH_TOKEN:","${{ secrets.",
+            "aws-actions/configure-aws-credentials","terraform apply","kubectl apply",
+            "helm upgrade","repository_dispatch",
+        )
+        workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
+        self.assertEqual(len(workflows),38)
+        for path in workflows:
+            text=path.read_text(encoding="utf-8")
+            self.assertIn("permissions:",text,path.name)
+            for token in forbidden:
+                self.assertNotIn(token,text,path.name)
+
+if __name__=="__main__":
+    unittest.main()

--- a/tools/test_automation_contracts.py
+++ b/tools/test_automation_contracts.py
@@ -295,6 +295,43 @@ def validate_release_cycle_outcome() -> None:
 
 
 
+
+def validate_all_hosted_workflows_non_authorizing() -> None:
+    workflow_root = REPO_ROOT / ".github" / "workflows"
+    forbidden = {
+        "contents: write",
+        "actions: write",
+        "issues: write",
+        "pull-requests: write",
+        "id-token: write",
+        "packages: write",
+        "deployments: write",
+        "git push",
+        "git commit",
+        "git tag",
+        "gh release ",
+        "gh workflow run",
+        "github.token",
+        "GH_TOKEN:",
+        "${{ secrets.",
+        "aws-actions/configure-aws-credentials",
+        "terraform apply",
+        "kubectl apply",
+        "helm upgrade",
+        "repository_dispatch",
+    }
+    workflows = sorted(workflow_root.glob("*.yml"))
+    if len(workflows) < 1:
+        fail("no hosted workflows found for authority audit")
+    for path in workflows:
+        text = read_text(path)
+        if "permissions:" not in text:
+            fail(f"{path.name} must declare explicit permissions")
+        present = sorted(token for token in forbidden if token in text)
+        if present:
+            fail(f"{path.name} reintroduces hosted authority: {', '.join(present)}")
+
+
 def validate_kv_format_hosted_boundary() -> None:
     workflow = read_text(REPO_ROOT / ".github" / "workflows" / "kv-format-branch.yml")
     forbidden = {
@@ -607,6 +644,7 @@ def main() -> int:
         validate_release_cycle,
         validate_hosted_release_cycle_boundary,
         validate_release_cycle_outcome,
+        validate_all_hosted_workflows_non_authorizing,
         validate_kv_format_hosted_boundary,
         validate_stegdb_overlay_hosted_boundary,
         validate_release_reconciliation_hosted_boundary,


### PR DESCRIPTION
Closes issue #101.

Hardens the completed hosted-authority retirement across every current CVK workflow:
- `release.yml` now declares explicit `contents: read`;
- all workflows must declare an explicit permissions block;
- repository-wide automation-contract validation rejects write permissions, git mutation, GitHub token/secrets authority, OIDC/cloud identity, Terraform/Kubernetes/Helm mutation, release/workflow dispatch authority markers, and repository dispatch;
- dedicated regression covers the full current workflow set.

Existing workflow-specific regressions remain in place. No runtime/release/provider/repository authority is granted.