### PR TITLE
Add multi-email personal information entry point

### DIFF
--- a/.github/workflows/validate-kv-email-ingress-policy.yml
+++ b/.github/workflows/validate-kv-email-ingress-policy.yml
@@ -7,6 +7,8 @@ on:
       - "schemas/kv-email-account-mapping.schema.json"
       - "schemas/kv-email-ingress-receipt.schema.json"
       - "schemas/kv-email-provider-registry.schema.json"
+      - "schemas/kv-personal-contact-profile.schema.json"
+      - "vault_template/KnowledgeVault/_Entities/Self/Personal_Contact_Profile.json"
       - "specs/kv-email-provider-registry.v1.json"
       - "tools/check_kv_email_provider_registry.py"
       - "specs/kv-email-ingress-policy.v1.json"
@@ -22,6 +24,8 @@ on:
       - "tests/test_email_interlock.py"
       - "runtime/documented_email_providers.py"
       - "tests/test_documented_email_providers.py"
+      - "runtime/personal_contact_profile.py"
+      - "tests/test_personal_contact_profile.py"
       - "KV_EMAIL_INGRESS_MIRROR_HANDOFF.md"
       - ".github/workflows/validate-kv-email-ingress-policy.yml"
   push:
@@ -29,11 +33,27 @@ on:
     paths:
       - "schemas/kv-email-ingress-policy.schema.json"
       - "schemas/kv-email-account-mapping.schema.json"
+      - "schemas/kv-email-ingress-receipt.schema.json"
+      - "schemas/kv-email-provider-registry.schema.json"
+      - "schemas/kv-personal-contact-profile.schema.json"
+      - "vault_template/KnowledgeVault/_Entities/Self/Personal_Contact_Profile.json"
+      - "specs/kv-email-provider-registry.v1.json"
+      - "tools/check_kv_email_provider_registry.py"
       - "specs/kv-email-ingress-policy.v1.json"
       - "tools/check_kv_email_ingress_policy.py"
       - "tests/test_kv_email_ingress_policy.py"
       - "runtime/email_continuity.py"
       - "tests/test_email_continuity_runtime.py"
+      - "runtime/email_ingress_pipeline.py"
+      - "runtime/email_provider_adapter.py"
+      - "runtime/email_interlock.py"
+      - "runtime/documented_email_providers.py"
+      - "runtime/personal_contact_profile.py"
+      - "tests/test_email_ingress_pipeline.py"
+      - "tests/test_email_provider_adapter.py"
+      - "tests/test_email_interlock.py"
+      - "tests/test_documented_email_providers.py"
+      - "tests/test_personal_contact_profile.py"
 
 permissions:
   contents: read
@@ -51,4 +71,4 @@ jobs:
       - name: Validate documented provider registry
         run: python tools/check_kv_email_provider_registry.py
       - name: Run deterministic tests
-        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime tests.test_email_ingress_pipeline tests.test_email_provider_adapter tests.test_email_interlock tests.test_documented_email_providers -v
+        run: python -m unittest tests.test_kv_email_ingress_policy tests.test_email_continuity_runtime tests.test_email_ingress_pipeline tests.test_email_provider_adapter tests.test_email_interlock tests.test_documented_email_providers tests.test_personal_contact_profile -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 - governed KnowledgeVault email-continuity ingress contract with pre-admission staging, fail-closed admission decisions, SKAP Vault credential-reference binding, deterministic mailbox mapping, and source-ready runtime validation
 - provider-neutral email account mapping runtime that prohibits raw mailbox secrets in KV state and requires `skap://` binding before provider-session verification
 - documented-unverified Gmail, Microsoft Graph/Outlook, and iCloud Mail provider adapter metadata with minimum read access, explicit user authorization, SKAP Vault credential destination, and fail-closed unknown-domain handling
+- multi-email personal contact profile under `_Entities/Self`, allowing multiple independently mapped email addresses with one optional primary display address and per-address email-continuity state
 - fail-closed `KV-INTERLOCK-v1` runtime endpoint core with exact DEVICE→KV InTr admission binding, injected authority/policy/storage boundaries, bounded-context enforcement, deterministic receipts, and candidate-only `COMMIT_CANDIDATE` semantics
 - deterministic runtime endpoint tests and canonical runtime handoff for the Site/KV production backend seam
 

--- a/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -19,6 +19,7 @@ Last updated: 2026-08-27
 - Issue #16 remains a separate external activation gate and is not a baseline KnowledgeVault installation requirement.
 - Root user-operation documentation is now consolidated into `README.md` plus `USER_GUIDE.md`; `SECURITY.md` remains the separate repository/deployment security policy.
 - Governed `email-continuity` source is now merged under `KV_EMAIL_INGRESS_MIRROR_HANDOFF.md`: PR #88 established the provider-neutral ingress/SKAP credential-reference contract and mapping runtime; PR #91 added pre-admission staging, governance receipts/replay, provider adapter discovery interface, explicit SKAP completion guidance, and canonical KV Interlock request binding; PR #95 added documented-unverified Gmail, Microsoft Graph/Outlook, and iCloud Mail provider metadata with minimum-read access and SKAP-only credential destination. Live mailbox/provider/SKAP activation remains separately unproven and the service remains inactive.
+- Personal information now has a source-ready multi-email model under `_Entities/Self/Personal_Contact_Profile.json`: multiple addresses are allowed, one may be marked primary, and each address may independently opt into the governed `email-continuity` mapping/SKAP/provider flow without turning ordinary profile data into mailbox authority.
 
 ## Root user-document consolidation completed
 

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -314,3 +314,39 @@ Final exact-head validation:
 - Repository validation diagnostics run `33136267603`: PASS
 - KV Guardrails run `33136267622`: PASS
 - Release integrity run `33136267563`: PASS
+
+
+## Personal-information multi-email entry point
+
+The governed email lane now has a second intuitive entry surface in addition to the dedicated Email/Connect Email flow.
+
+Source:
+- `schemas/kv-personal-contact-profile.schema.json`
+- `vault_template/KnowledgeVault/_Entities/Self/Personal_Contact_Profile.json`
+- `runtime/personal_contact_profile.py`
+- `tests/test_personal_contact_profile.py`
+- `USER_GUIDE.md`
+
+Behavior:
+- personal information may contain zero, one, or multiple email addresses;
+- addresses are normalized and duplicate addresses are rejected case-insensitively;
+- each address has its own owner-selected label;
+- at most one address is marked primary, but primary status does not grant authority;
+- an address may remain ordinary contact information with `email_continuity_enabled=false`;
+- enabling continuity for one address maps only that address into the existing governed email flow;
+- every mapped address has its own deterministic `mapping_id` and connection state;
+- one address may be `SESSION_VERIFIED` while another remains `UNMAPPED`, `MAPPED_CREDENTIAL_REQUIRED`, `CREDENTIAL_BOUND`, or `REVOKED`;
+- mailbox credentials remain SKAP-only and never become personal-profile fields.
+
+Intended UX:
+
+```text
+Personal Information
+ -> Email addresses
+ -> + Add email
+ -> label / optional primary
+ -> [optional] Connect this email
+ -> provider mapping
+ -> Complete setup in SKAP Vault
+ -> governed ingress for that address
+```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -48,6 +48,33 @@ A simple operating loop is:
 
 **Capture → organize lightly → index what matters → preserve enough context to reconstruct later.**
 
+## 3. Personal information and email addresses
+
+Personal information belongs under `_Entities/Self/`. The supplied `Personal_Contact_Profile.json` is the structured contact surface for the vault owner.
+
+A user may enter **more than one email address**. Each address is independent and may have:
+
+- a human-readable label such as personal, work, school, family, or another owner-chosen label;
+- optional primary status for display/contact preference;
+- email-continuity disabled, leaving the address as contact information only; or
+- email-continuity enabled, which starts the governed mailbox-mapping flow for that specific address.
+
+Only one address is marked primary at a time, but there is no one-mailbox limitation.
+
+When email continuity is enabled for an address, the intended progression is:
+
+```text
+Personal information
+ -> add/select email address
+ -> Connect this email
+ -> provider discovery + mailbox mapping
+ -> Complete setup in SKAP Vault
+ -> verify provider session
+ -> governed email ingress
+```
+
+Adding an address to personal information does **not** grant mailbox access. Credentials and provider secrets belong in SKAP Vault, not in `Personal_Contact_Profile.json` or other ordinary KnowledgeVault files. Each mapped email address maintains its own connection state, so one account can be active while another remains unmapped, awaiting SKAP setup, revoked, or otherwise inactive.
+
 ## 3. What the main folders mean
 
 ```text
@@ -73,7 +100,7 @@ KnowledgeVault/
 
 Use the numbered folders for ordinary human content. Use `_Index/` to make important material discoverable. Treat `_System/`, `_Policy/`, `_Meta/`, and other underscore-prefixed areas as structured system surfaces rather than casual storage locations.
 
-## 4. KnowledgeVault and StegVerse
+## 5. KnowledgeVault and StegVerse
 
 KnowledgeVault is the continuity and knowledge state layer. It is not the same thing as secret custody, device execution, or network transport.
 
@@ -97,7 +124,7 @@ In practical terms:
 
 Do not bypass those boundaries merely because direct file or network access is technically possible.
 
-## 5. Sensitive information and secrets
+## 6. Sensitive information and secrets
 
 KnowledgeVault may contain sensitive records, but the baseline file structure is not itself encryption.
 
@@ -107,7 +134,7 @@ Until a SKAP-backed runtime is active for a given deployment, protect sensitive 
 
 For repository and deployment security requirements, see [`SECURITY.md`](./SECURITY.md).
 
-## 6. AI and conversation continuity
+## 7. AI and conversation continuity
 
 AI is optional. KnowledgeVault is designed so AI tools can work with predictable structure without becoming canonical authority over the vault.
 
@@ -127,7 +154,7 @@ See:
 - [`docs/EXAMPLES.md`](./docs/EXAMPLES.md)
 - [`docs/AI_COMPATIBLE.md`](./docs/AI_COMPATIBLE.md)
 
-## 7. Indexing and retrieval
+## 8. Indexing and retrieval
 
 Indexes are what make a growing vault reconstructable.
 
@@ -135,7 +162,7 @@ Use `_Index/Master_Index.md` as the broad map and add topic, timeline, relations
 
 Prefer durable references, clear filenames, dates where useful, and open formats such as Markdown, text, PDF, PNG, and JPEG.
 
-## 8. Backup, migration, and replacement
+## 9. Backup, migration, and replacement
 
 KnowledgeVault is designed to be replaceable and portable.
 
@@ -155,7 +182,7 @@ python3 tools/verify_release.py dist/ContinuityVault_vX.Y.Z.zip
 
 Migration helpers live under `_migration/` and repository tooling under `tools/`.
 
-## 9. Optional sharing and modules
+## 10. Optional sharing and modules
 
 KnowledgeVault may participate in broader StegVerse modules and sharing flows, but sharing must remain explicit and policy-bounded. The existence of data in KV does not imply permission to disclose it.
 
@@ -170,7 +197,7 @@ When module or sharing integrations are active, the user should be able to deter
 
 See [`docs/DATA_SHARING.md`](./docs/DATA_SHARING.md) for the current documented sharing model.
 
-## 10. Troubleshooting
+## 11. Troubleshooting
 
 If setup fails, first determine which stage failed: download, unzip/copy, initialization, verification, permissions, or first use.
 
@@ -178,7 +205,7 @@ For repository-supported onboarding problems, use the structured onboarding-fric
 
 If the vault already exists, do not run a repair process that silently overwrites owner-authored files. Preserve the existing vault and use a new destination or an explicit migration path.
 
-## 11. Deeper technical review
+## 12. Deeper technical review
 
 Most users should not need the internal architecture documents.
 

--- a/runtime/personal_contact_profile.py
+++ b/runtime/personal_contact_profile.py
@@ -1,0 +1,157 @@
+"""Personal-contact profile helpers for multi-email KnowledgeVault identity data."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from runtime.email_continuity import EmailAccountMapping, mapping_id_for
+
+
+class PersonalContactProfileError(ValueError):
+    pass
+
+
+def new_profile() -> dict:
+    return {
+        "schema": "stegverse.kv.personal-contact-profile/v1",
+        "email_addresses": [],
+        "authority_effect": "NONE",
+    }
+
+
+def _normalize(address: str) -> str:
+    value = str(address).strip().lower()
+    if "@" not in value:
+        raise PersonalContactProfileError("valid email address required")
+    local, domain = value.rsplit("@", 1)
+    if not local or not domain or "." not in domain:
+        raise PersonalContactProfileError("valid routable email address required")
+    return value
+
+
+def validate_profile(profile: dict) -> list[str]:
+    errors: list[str] = []
+    if profile.get("schema") != "stegverse.kv.personal-contact-profile/v1":
+        errors.append("profile schema mismatch")
+    if profile.get("authority_effect") != "NONE":
+        errors.append("personal contact profile may not grant authority")
+
+    entries = profile.get("email_addresses")
+    if not isinstance(entries, list):
+        return errors + ["email_addresses must be an array"]
+
+    seen: set[str] = set()
+    primary_count = 0
+    allowed_states = {
+        "UNMAPPED",
+        "MAPPED_CREDENTIAL_REQUIRED",
+        "CREDENTIAL_BOUND",
+        "SESSION_VERIFIED",
+        "REVOKED",
+    }
+
+    for index, entry in enumerate(entries):
+        prefix = f"email_addresses[{index}]"
+        try:
+            address = _normalize(entry.get("address", ""))
+        except PersonalContactProfileError as exc:
+            errors.append(f"{prefix}: {exc}")
+            continue
+        if address in seen:
+            errors.append(f"{prefix}: duplicate email address")
+        seen.add(address)
+
+        if not isinstance(entry.get("label"), str) or not entry["label"].strip():
+            errors.append(f"{prefix}: label required")
+        if entry.get("primary") is True:
+            primary_count += 1
+        elif entry.get("primary") is not False:
+            errors.append(f"{prefix}: primary must be boolean")
+
+        if entry.get("email_continuity_enabled") not in {True, False}:
+            errors.append(f"{prefix}: email_continuity_enabled must be boolean")
+
+        state = entry.get("connection_state")
+        mapping_id = entry.get("mapping_id")
+        if state not in allowed_states:
+            errors.append(f"{prefix}: invalid connection_state")
+        if state == "UNMAPPED":
+            if mapping_id is not None:
+                errors.append(f"{prefix}: UNMAPPED address may not have mapping_id")
+        else:
+            expected = mapping_id_for(address)
+            if mapping_id != expected:
+                errors.append(f"{prefix}: mapped state requires deterministic mapping_id")
+            if entry.get("email_continuity_enabled") is not True:
+                errors.append(f"{prefix}: mapped state requires email_continuity_enabled=true")
+
+    if primary_count > 1:
+        errors.append("at most one primary email address is allowed")
+    return errors
+
+
+def add_email(
+    profile: dict,
+    *,
+    address: str,
+    label: str = "personal",
+    primary: bool = False,
+    enable_email_continuity: bool = False,
+) -> dict:
+    updated = deepcopy(profile)
+    normalized = _normalize(address)
+    if any(_normalize(item.get("address", "")) == normalized for item in updated.get("email_addresses", [])):
+        raise PersonalContactProfileError("email address already exists")
+
+    if primary:
+        for item in updated.get("email_addresses", []):
+            item["primary"] = False
+
+    updated.setdefault("email_addresses", []).append(
+        {
+            "address": normalized,
+            "label": label.strip() or "personal",
+            "primary": bool(primary),
+            "email_continuity_enabled": bool(enable_email_continuity),
+            "mapping_id": None,
+            "connection_state": "UNMAPPED",
+        }
+    )
+    errors = validate_profile(updated)
+    if errors:
+        raise PersonalContactProfileError("; ".join(errors))
+    return updated
+
+
+def map_email_entry(profile: dict, mapping: EmailAccountMapping) -> dict:
+    updated = deepcopy(profile)
+    matches = [
+        item for item in updated.get("email_addresses", [])
+        if _normalize(item.get("address", "")) == mapping.email_address
+    ]
+    if len(matches) != 1:
+        raise PersonalContactProfileError("mapped email must already exist exactly once in personal profile")
+    item = matches[0]
+    item["email_continuity_enabled"] = True
+    item["mapping_id"] = mapping.mapping_id
+    item["connection_state"] = mapping.mapping_state
+
+    errors = validate_profile(updated)
+    if errors:
+        raise PersonalContactProfileError("; ".join(errors))
+    return updated
+
+
+def sync_mapping_state(profile: dict, mapping: EmailAccountMapping) -> dict:
+    updated = deepcopy(profile)
+    for item in updated.get("email_addresses", []):
+        if item.get("mapping_id") == mapping.mapping_id:
+            if _normalize(item.get("address", "")) != mapping.email_address:
+                raise PersonalContactProfileError("mapping_id/email address binding mismatch")
+            item["email_continuity_enabled"] = True
+            item["connection_state"] = mapping.mapping_state
+            errors = validate_profile(updated)
+            if errors:
+                raise PersonalContactProfileError("; ".join(errors))
+            return updated
+    raise PersonalContactProfileError("mapping_id not found in personal profile")

--- a/schemas/kv-personal-contact-profile.schema.json
+++ b/schemas/kv-personal-contact-profile.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-personal-contact-profile.schema.json",
+  "title": "KnowledgeVault Personal Contact Profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "email_addresses", "authority_effect"],
+  "properties": {
+    "schema": {"const": "stegverse.kv.personal-contact-profile/v1"},
+    "email_addresses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "address",
+          "label",
+          "primary",
+          "email_continuity_enabled",
+          "mapping_id",
+          "connection_state"
+        ],
+        "properties": {
+          "address": {"type": "string", "format": "email"},
+          "label": {"type": "string", "minLength": 1},
+          "primary": {"type": "boolean"},
+          "email_continuity_enabled": {"type": "boolean"},
+          "mapping_id": {
+            "type": ["string", "null"],
+            "pattern": "^kv-email:[a-f0-9]{64}$"
+          },
+          "connection_state": {
+            "enum": [
+              "UNMAPPED",
+              "MAPPED_CREDENTIAL_REQUIRED",
+              "CREDENTIAL_BOUND",
+              "SESSION_VERIFIED",
+              "REVOKED"
+            ]
+          }
+        }
+      }
+    },
+    "authority_effect": {"const": "NONE"}
+  }
+}

--- a/tests/test_personal_contact_profile.py
+++ b/tests/test_personal_contact_profile.py
@@ -1,0 +1,95 @@
+import unittest
+
+from runtime.email_continuity import (
+    bind_skap_credential,
+    create_mapping,
+    mark_session_verified,
+)
+from runtime.personal_contact_profile import (
+    PersonalContactProfileError,
+    add_email,
+    map_email_entry,
+    new_profile,
+    sync_mapping_state,
+    validate_profile,
+)
+
+
+class PersonalContactProfileTests(unittest.TestCase):
+    def test_multiple_email_addresses_are_supported(self):
+        profile = new_profile()
+        profile = add_email(profile, address="one@example.com", label="personal", primary=True)
+        profile = add_email(profile, address="two@example.com", label="work")
+        self.assertEqual(len(profile["email_addresses"]), 2)
+        self.assertEqual(validate_profile(profile), [])
+
+    def test_only_one_primary_is_preserved(self):
+        profile = new_profile()
+        profile = add_email(profile, address="one@example.com", primary=True)
+        profile = add_email(profile, address="two@example.com", primary=True)
+        primaries = [item for item in profile["email_addresses"] if item["primary"]]
+        self.assertEqual([item["address"] for item in primaries], ["two@example.com"])
+
+    def test_duplicate_address_is_rejected_case_insensitively(self):
+        profile = add_email(new_profile(), address="User@Example.com")
+        with self.assertRaises(PersonalContactProfileError):
+            add_email(profile, address="user@example.com")
+
+    def test_address_can_exist_without_mailbox_monitoring(self):
+        profile = add_email(new_profile(), address="user@example.com")
+        item = profile["email_addresses"][0]
+        self.assertFalse(item["email_continuity_enabled"])
+        self.assertIsNone(item["mapping_id"])
+        self.assertEqual(item["connection_state"], "UNMAPPED")
+
+    def test_mapping_existing_profile_address_enables_email_continuity(self):
+        profile = add_email(new_profile(), address="user@example.com")
+        mapping = create_mapping(
+            email_address="user@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        profile = map_email_entry(profile, mapping)
+        item = profile["email_addresses"][0]
+        self.assertTrue(item["email_continuity_enabled"])
+        self.assertEqual(item["mapping_id"], mapping.mapping_id)
+        self.assertEqual(item["connection_state"], "MAPPED_CREDENTIAL_REQUIRED")
+
+    def test_each_address_has_independent_connection_state(self):
+        profile = add_email(new_profile(), address="one@example.com", primary=True)
+        profile = add_email(profile, address="two@example.com", label="work")
+
+        one = create_mapping(
+            email_address="one@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        two = create_mapping(
+            email_address="two@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        profile = map_email_entry(profile, one)
+        profile = map_email_entry(profile, two)
+
+        one_bound = bind_skap_credential(one, skap_credential_ref="skap://Mail/example/one")
+        one_verified = mark_session_verified(one_bound)
+        profile = sync_mapping_state(profile, one_verified)
+
+        states = {item["address"]: item["connection_state"] for item in profile["email_addresses"]}
+        self.assertEqual(states["one@example.com"], "SESSION_VERIFIED")
+        self.assertEqual(states["two@example.com"], "MAPPED_CREDENTIAL_REQUIRED")
+
+    def test_mapping_unknown_profile_address_is_rejected(self):
+        profile = add_email(new_profile(), address="one@example.com")
+        mapping = create_mapping(
+            email_address="two@example.com",
+            provider_id="example-mail",
+            provider_route="provider://example/mail",
+        )
+        with self.assertRaises(PersonalContactProfileError):
+            map_email_entry(profile, mapping)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vault_template/KnowledgeVault/_Entities/Self/Personal_Contact_Profile.json
+++ b/vault_template/KnowledgeVault/_Entities/Self/Personal_Contact_Profile.json
@@ -1,0 +1,5 @@
+{
+  "schema": "stegverse.kv.personal-contact-profile/v1",
+  "email_addresses": [],
+  "authority_effect": "NONE"
+}


### PR DESCRIPTION
## Summary

Adds an intuitive personal-information entry surface for governed email continuity.

### Behavior
- `_Entities/Self/Personal_Contact_Profile.json` supports multiple email addresses
- each address has its own label, optional primary flag, email-continuity opt-in, deterministic mapping ID, and connection state
- duplicate addresses fail closed case-insensitively
- only one address may be primary at a time
- adding an email to personal info does not grant mailbox access
- each address may independently enter the existing provider mapping -> SKAP Vault -> provider session -> governed ingress flow
- one address may be active while another remains unmapped, awaiting SKAP setup, or revoked

### Source
- personal-contact schema/template
- runtime profile helpers
- deterministic tests
- expanded email-ingress CI coverage
- USER_GUIDE personal-information flow
- email/root handoff + changelog reconciliation

### Non-claims
No mailbox or credentials are activated by this source change.