### PR TITLE
Reconcile connected KV parity for multi-email personal profile

### DIFF
--- a/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -119,7 +119,7 @@ current main template tree:             7d8be8b13be05c239d332e028d0ede95cfce4b58
 current source census:                  133 files / 53 directories / 97,071 bytes
 ```
 
-The previously reconciled source addition `_Entities/Self/StegID/Continuity/README.md` is present in the connected Drive at the exact 1,520-byte source size. Current `main` now adds `_Entities/Self/Personal_Contact_Profile.json` (114 bytes) for the multi-email personal-information model. That file has not yet been re-proven present in the connected Drive in this lane, so the earlier full-parity closure remains historical evidence for tree `f37978fcde3c7622ceef33d92c6aa19c8171b4ef` rather than a claim about current tree `7d8be8b13be05c239d332e028d0ede95cfce4b58`.
+The previously reconciled `_Entities/Self/StegID/Continuity/README.md` remains present. The current-main addition `_Entities/Self/Personal_Contact_Profile.json` (114 bytes) is also now installed and directly verified in `_Entities/Self` as unconverted `text/plain`. Current-tree parity is therefore restored.
 
 Connected destination remains:
 
@@ -210,11 +210,11 @@ Drive-only runtime/user state is preserved and excluded from source-template par
 
 The connected receipt `_System/installation.receipt.json` (Drive id `1475U1vTyKKvo0l5F3YOgZqZttHMXAh_i`) was replaced in place with schema v1.1 and now records the current tree SHA, 132/53 census, accepted manifest exception, repaired paths, Drive-only exclusions, `full_template_parity=VALIDATED`, `authority_effect=NONE`, and `activation_effect=false`.
 
-**Full recursive KnowledgeVault source-template parity remains VALIDATED / COMPLETE for historical tree `f37978fcde3c7622ceef33d92c6aa19c8171b4ef`. Current tree `7d8be8b13be05c239d332e028d0ede95cfce4b58` is SOURCE-AHEAD-BY-ONE-FILE until the new personal-contact profile is installed/reconciled in the connected Drive.**
+**Full recursive KnowledgeVault source-template parity is VALIDATED / COMPLETE for current tree `7d8be8b13be05c239d332e028d0ede95cfce4b58`. The prior one-file source-ahead delta is closed.**
 
 This completion is file/template parity only. It does not activate InTr, SKAP provider credentials, identity authority, device authority, governance authority, or provider execution.
 
-Current user action for file-parity work: **NONE**. Remaining parity work is machine-executable once the connected Drive write path is used for the 114-byte profile file and the installation receipt is refreshed.
+Current user action for file-parity work: **NONE**. `_Entities/Self/Personal_Contact_Profile.json` is installed in the connected Drive as exact 114-byte unconverted `text/plain`, and `_System/installation.receipt.json` is refreshed to current tree `7d8be8b13be05c239d332e028d0ede95cfce4b58`.
 
 ## Recoverable execution and communication-extension host
 
@@ -778,3 +778,28 @@ authority_effect: NONE
 The global workflow regression now fails closed on future write permissions, repository mutation, GitHub token/secrets authority, OIDC/cloud identity, Terraform/Kubernetes/Helm mutation, hosted release/workflow dispatch, and repository-dispatch authority. Hosted-authority source cleanup for the current workflow set is COMPLETE.
 
 Remaining KnowledgeVault activation work is separate: deploy the merged KV Interlock endpoint behind authentic DEVICE→KV InTr verification and durable receipts; observe canonical Site readback; complete TVC resident recipient/key/liveness/owner-ingress/Gateway evidence; execute TVC-admitted provider activation; and publish any successor release only through admitted TV/TVC release authority.
+
+
+## Personal multi-email connected-KV parity closure — 2026-08-28
+
+The one-file delta introduced by PR #103 is now installed and reconciled in the connected KnowledgeVault.
+
+Observed live state:
+
+```text
+source template tree: 7d8be8b13be05c239d332e028d0ede95cfce4b58
+source census:        133 files / 53 directories / 97,071 bytes
+installed path:       _Entities/Self/Personal_Contact_Profile.json
+source size:          114 bytes
+installed size:       114 bytes
+installed MIME:       text/plain
+conversion:           none
+```
+
+Connected Drive evidence:
+
+- profile file id: `1vv0ivVe0G0_hkx1vXlBMLHgLuuICkN05`
+- refreshed installation receipt id: `14wHQ6OyiDwFtn_ElQL8l-XpC8bz_9HE8`
+- machine-readable repository evidence: `evidence/kv/2026-08-28-personal-contact-profile-connected-installation.json`
+
+The previous installation receipt was retired only after the refreshed current-tree receipt was verified. This parity closure has `authority_effect=NONE` and `activation_effect=false`; no provider credential, SKAP capability, Interlock transport, or email-monitoring activation occurred.

--- a/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_EMAIL_INGRESS_MIRROR_HANDOFF.md
@@ -372,3 +372,24 @@ Merged behavior:
 - each address can independently opt into governed email continuity;
 - each mapped address has its own mapping/session state and SKAP completion path;
 - ordinary profile-only addresses remain `UNMAPPED` and require no provider credentials.
+
+
+## Connected-KV personal-profile installation evidence
+
+The personal-information multi-email entry surface is no longer source-only.
+
+Observed connected-KV state on 2026-08-28:
+
+- `_Entities/Self/Personal_Contact_Profile.json` installed;
+- exact installed size: `114` bytes;
+- MIME: `text/plain`;
+- native Google Workspace conversion: `false`;
+- source tree: `7d8be8b13be05c239d332e028d0ede95cfce4b58`;
+- source census: `133` files / `53` directories / `97,071` bytes;
+- connected profile file id: `1vv0ivVe0G0_hkx1vXlBMLHgLuuICkN05`;
+- refreshed `_System/installation.receipt.json` id: `14wHQ6OyiDwFtn_ElQL8l-XpC8bz_9HE8`;
+- parity state: `VALIDATED`.
+
+Repository evidence: `evidence/kv/2026-08-28-personal-contact-profile-connected-installation.json`.
+
+This proves that the multi-email personal-information data surface exists in the connected KnowledgeVault. It still does not prove that any mailbox is mapped, any SKAP credential is installed, or governed mail ingress is active.

--- a/evidence/kv/2026-08-28-personal-contact-profile-connected-installation.json
+++ b/evidence/kv/2026-08-28-personal-contact-profile-connected-installation.json
@@ -1,0 +1,42 @@
+{
+  "schema": "stegverse.kv.connected-installation-evidence/v1",
+  "observed_utc": "2026-08-28T05:23:44Z",
+  "repository": "StegVerse-Labs/continuity-vault-kit",
+  "source_branch": "main",
+  "source_template_tree_sha": "7d8be8b13be05c239d332e028d0ede95cfce4b58",
+  "source_census": {
+    "files": 133,
+    "directories": 53,
+    "total_source_bytes": 97071
+  },
+  "destination": {
+    "kind": "GOOGLE_DRIVE",
+    "vault_path": "/KnowledgeVault",
+    "vault_folder_id": "1c8OdhJeLD6E4ALmi-aR7dXvG8PjDLSfi"
+  },
+  "installed_delta": {
+    "path": "_Entities/Self/Personal_Contact_Profile.json",
+    "source_size": 114,
+    "installed_size": 114,
+    "mime_type": "text/plain",
+    "converted": false,
+    "drive_file_id": "1vv0ivVe0G0_hkx1vXlBMLHgLuuICkN05",
+    "verified_present": true
+  },
+  "installation_receipt": {
+    "path": "_System/installation.receipt.json",
+    "drive_file_id": "14wHQ6OyiDwFtn_ElQL8l-XpC8bz_9HE8",
+    "mime_type": "text/plain",
+    "verified_tree_sha": "7d8be8b13be05c239d332e028d0ede95cfce4b58",
+    "full_template_parity": "VALIDATED"
+  },
+  "authority_effect": "NONE",
+  "activation_effect": false,
+  "email_provider_activation_performed": false,
+  "skap_credential_used": false,
+  "notes": [
+    "The previous installation receipt was retired after the current-tree receipt was verified.",
+    "This evidence proves connected-KV template parity for the personal contact profile addition only.",
+    "It does not activate email provider access, SKAP credentials, Interlock transport, or mailbox monitoring."
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the one-file connected-KV parity delta introduced by PR #103.

### Live connected-KV evidence
- installed `_Entities/Self/Personal_Contact_Profile.json`
- exact source/install size: 114 bytes
- stored MIME: `text/plain`
- Google-native conversion: none
- current template tree: `7d8be8b13be05c239d332e028d0ede95cfce4b58`
- current census: 133 files / 53 directories / 97,071 bytes
- refreshed connected `_System/installation.receipt.json`

### Repository evidence
- `evidence/kv/2026-08-28-personal-contact-profile-connected-installation.json`
- root mirror handoff updated from SOURCE-AHEAD-BY-ONE-FILE to current-tree parity VALIDATED
- email-ingress handoff records connected personal-profile presence

### Non-claims
This does not map a mailbox, install a SKAP credential, authorize a provider session, activate Interlock, or start email monitoring.