### PR TITLE
Add governed personal finance tracking to KnowledgeVault

### DIFF
--- a/.github/workflows/kv-personal-finance.yml
+++ b/.github/workflows/kv-personal-finance.yml
@@ -1,0 +1,29 @@
+name: Validate KV Personal Finance
+
+on:
+  pull_request:
+    paths:
+      - "KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md"
+      - "schemas/kv-personal-finance-snapshot.schema.json"
+      - "vault_template/KnowledgeVault/_Entities/Self/Personal_Finance.json"
+      - "runtime/personal_finance.py"
+      - "tests/test_personal_finance.py"
+      - "tools/check_kv_personal_finance.py"
+      - ".github/workflows/kv-personal-finance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Static finance boundary checks
+        run: python tools/check_kv_personal_finance.py
+      - name: Personal finance unit tests
+        run: python -m unittest tests.test_personal_finance

--- a/KV_CONTINUITY_DIRECTORY_TAXONOMY_MIRROR_HANDOFF.md
+++ b/KV_CONTINUITY_DIRECTORY_TAXONOMY_MIRROR_HANDOFF.md
@@ -43,6 +43,14 @@ KnowledgeVault/
       Personal_Finance.json
 ```
 
+## Direct-source population rule
+
+Data used to populate continuity-domain directories should come from the direct authoritative provider/source using owner-authorized access with reusable credentials resolved through SKAP Vault, under `KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md`.
+
+Examples include financial institutions for Finance/Assets/Liabilities, mailbox providers for Email, photo/media providers or owner-controlled storage for Pictures, and music providers or owner-controlled libraries for Music.
+
+The directory taxonomy is the durable destination/navigation layer; it is not itself a source connector.
+
 ## Navigation semantics
 
 - human-facing directory cards may link to these canonical paths;

--- a/KV_CONTINUITY_DIRECTORY_TAXONOMY_MIRROR_HANDOFF.md
+++ b/KV_CONTINUITY_DIRECTORY_TAXONOMY_MIRROR_HANDOFF.md
@@ -1,0 +1,96 @@
+# KV Continuity Directory Taxonomy Mirror Handoff
+
+Status: SOURCE_IMPLEMENTED_ON_BRANCH / VALIDATION_PENDING  
+Repository: `StegVerse-Labs/continuity-vault-kit`  
+Branch: `feature/kv-personal-finance-106`  
+Updated: 2026-08-28  
+Authority effect: NONE  
+Activation effect: false
+
+## Purpose
+
+Add human-navigable continuity-domain directories to the Personal KnowledgeVault so a user-facing My KV surface can link directly to the places where major continuity classes are stored.
+
+This is a storage/navigation taxonomy layer. It does not replace canonical schemas, provider adapters, admission policy, or credential boundaries.
+
+## Initial directory map
+
+```text
+KnowledgeVault/
+  02_Research/
+  03_Records/
+    Email/
+      README.md
+    Finance/
+      Finance_Overview.md
+      Accounts/
+      Spending/
+      Savings/
+      Retirement/
+      Taxes/
+  04_Media/
+    Pictures/
+    Music/
+  05_Projects/
+  06_Archive/
+  _Entities/
+    Self/
+      Personal_Contact_Profile.json
+      Personal_Finance.json
+```
+
+## Navigation semantics
+
+- human-facing directory cards may link to these canonical paths;
+- machine-readable profile/state files may remain under `_Entities/Self`;
+- domain directories hold human-readable continuity documents, exports, summaries, and admitted records;
+- a directory link does not imply that every file type is publicly browser-readable;
+- Site directory browsing must use a canonical private KV bridge and fail closed when absent.
+
+## Finance overview contract
+
+`03_Records/Finance/Finance_Overview.md` is the top-level human-readable finance index.
+
+Its canonical sections are:
+
+1. Accounts
+2. Spending habits and analysis
+3. Savings analysis
+4. Retirement analysis
+5. Federal income tax analysis
+6. State income tax analysis
+7. Rewards, yield, and collateral
+8. Analysis provenance
+
+The document summarizes private finance state; machine-readable normalized state remains in `_Entities/Self/Personal_Finance.json`.
+
+## Email boundary
+
+`03_Records/Email` is a governed persistence destination only for content admitted by the canonical email-ingress pipeline. Provider credentials never belong there.
+
+## Media boundary
+
+`04_Media/Pictures` and `04_Media/Music` are continuity-domain directories under the existing media root. Binary/media storage and metadata remain subject to KnowledgeVault media policy.
+
+## Current files
+
+- `vault_template/KnowledgeVault/03_Records/Email/README.md`
+- `vault_template/KnowledgeVault/03_Records/Finance/Finance_Overview.md`
+- `vault_template/KnowledgeVault/03_Records/Finance/Accounts/README.md`
+- `vault_template/KnowledgeVault/03_Records/Finance/Spending/README.md`
+- `vault_template/KnowledgeVault/03_Records/Finance/Savings/README.md`
+- `vault_template/KnowledgeVault/03_Records/Finance/Retirement/README.md`
+- `vault_template/KnowledgeVault/03_Records/Finance/Taxes/README.md`
+- `vault_template/KnowledgeVault/04_Media/Pictures/README.md`
+- `vault_template/KnowledgeVault/04_Media/Music/README.md`
+
+## Remaining gates
+
+- source validation;
+- finance schema/runtime validation;
+- current-tree parity census update;
+- merge;
+- private connected-KV installation/parity restoration;
+- Site directory landing readback proof.
+
+No live private user data is present in these public source templates.

--- a/KV_CONTINUITY_DIRECTORY_TAXONOMY_MIRROR_HANDOFF.md
+++ b/KV_CONTINUITY_DIRECTORY_TAXONOMY_MIRROR_HANDOFF.md
@@ -66,13 +66,15 @@ These directories are intentionally separate from `03_Records/Finance`: Finance 
 Its canonical sections are:
 
 1. Accounts
-2. Spending habits and analysis
-3. Savings analysis
-4. Retirement analysis
-5. Federal income tax analysis
-6. State income tax analysis
-7. Rewards, yield, and collateral
-8. Analysis provenance
+2. Assets
+3. Liabilities
+4. Spending habits and analysis
+5. Savings analysis
+6. Retirement analysis
+7. Federal income tax analysis
+8. State income tax analysis
+9. Rewards, yield, and collateral
+10. Analysis provenance
 
 The document summarizes private finance state; machine-readable normalized state remains in `_Entities/Self/Personal_Finance.json`.
 

--- a/KV_CONTINUITY_DIRECTORY_TAXONOMY_MIRROR_HANDOFF.md
+++ b/KV_CONTINUITY_DIRECTORY_TAXONOMY_MIRROR_HANDOFF.md
@@ -19,6 +19,10 @@ This is a storage/navigation taxonomy layer. It does not replace canonical schem
 KnowledgeVault/
   02_Research/
   03_Records/
+    Assets/
+      README.md
+    Liabilities/
+      README.md
     Email/
       README.md
     Finance/
@@ -47,6 +51,14 @@ KnowledgeVault/
 - a directory link does not imply that every file type is publicly browser-readable;
 - Site directory browsing must use a canonical private KV bridge and fail closed when absent.
 
+## Assets and liabilities boundaries
+
+`03_Records/Assets` is the human-readable continuity directory for owned resources such as property, investments, cash-equivalents, business interests, valuables, and other owner-controlled assets.
+
+`03_Records/Liabilities` is the human-readable continuity directory for obligations such as credit cards, auto loans, mortgages, student loans, personal loans, taxes owed, and other debts.
+
+These directories are intentionally separate from `03_Records/Finance`: Finance is the analytical overview and planning layer; Assets and Liabilities are first-class continuity domains that may also be referenced by Finance analysis.
+
 ## Finance overview contract
 
 `03_Records/Finance/Finance_Overview.md` is the top-level human-readable finance index.
@@ -74,6 +86,8 @@ The document summarizes private finance state; machine-readable normalized state
 
 ## Current files
 
+- `vault_template/KnowledgeVault/03_Records/Assets/README.md`
+- `vault_template/KnowledgeVault/03_Records/Liabilities/README.md`
 - `vault_template/KnowledgeVault/03_Records/Email/README.md`
 - `vault_template/KnowledgeVault/03_Records/Finance/Finance_Overview.md`
 - `vault_template/KnowledgeVault/03_Records/Finance/Accounts/README.md`

--- a/KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md
+++ b/KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md
@@ -1,0 +1,91 @@
+# KV Personal Finance Mirror Handoff
+
+Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS  
+Repository: `StegVerse-Labs/continuity-vault-kit`  
+Issue: `#106`  
+Branch: `feature/kv-personal-finance-106`  
+Updated: 2026-08-28
+
+## Purpose
+
+Add a bounded Personal KnowledgeVault finance-tracking model that can represent accounts, balances, liabilities, transactions, recurring activity, rewards/yield, and collateral relationships without turning KnowledgeVault into a credential store or provider authority.
+
+This lane begins the canonical source contract for:
+
+```text
+Financial provider / owner entry
+ -> governed account reference
+ -> normalized finance snapshot
+ -> private Personal KV persistence
+ -> optional governed analysis/readback
+```
+
+## Privacy and authority invariants
+
+1. Real user financial values belong only in the user's private connected KnowledgeVault or an admitted private runtime; they must never be committed to this public repository.
+2. Ordinary KV finance records must not contain passwords, OAuth tokens, refresh tokens, private keys, recovery codes, card PANs, CVVs, full bank-account numbers, or equivalent reusable secrets.
+3. Provider/account connection credentials belong behind SKAP Vault or another explicitly admitted credential boundary.
+4. A provider/account reference grants no payment, trading, transfer, borrowing, card-spending, or account-management authority.
+5. Read access to finance records does not imply transaction execution authority.
+6. Imported provider data must preserve source/as-of provenance.
+7. Ambiguous provider state or absent canonical KV persistence fails closed.
+8. Rewards/yield metadata is descriptive and may change; persisted rates must carry observation timestamps.
+9. Locked/collateral balances must remain distinguishable from liquid/available balances.
+10. Liabilities must remain distinguishable from assets and cash-equivalents.
+11. Historical finance records are user-controlled private data, not repository fixtures.
+12. Repository tests may use synthetic values only.
+
+## Initial normalized model
+
+The first schema slice supports:
+
+- account identity/reference metadata;
+- account class/subtype and masked display identifier;
+- current / available balance and credit limit;
+- liabilities and amount owed;
+- transactions and recurring activity;
+- reward/yield positions such as USDC APY and card-spend BTC rewards;
+- locked/collateral relationships;
+- observation timestamp / provider/source metadata;
+- user labels and notes without authority effect.
+
+## Planned source files
+
+- `KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md`
+- `schemas/kv-personal-finance-snapshot.schema.json`
+- `vault_template/KnowledgeVault/_Entities/Self/Personal_Finance.json`
+- `runtime/personal_finance.py`
+- `tests/test_personal_finance.py`
+- `tools/check_kv_personal_finance.py`
+- `CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`
+- optional downstream Site projection after canonical KV contract stabilizes
+
+## Connected-KV destination
+
+Canonical private destination candidate:
+
+```text
+/KnowledgeVault/_Entities/Self/Personal_Finance.json
+```
+
+The repository template contains only an empty/synthetic initialization shape. Real values are installed or updated only through a private owner-authorized KV path.
+
+## Completion gates
+
+- finance-specific handoff exists before implementation;
+- schema validates synthetic account/balance/liability/reward/collateral examples;
+- secret-bearing fields fail closed;
+- real provider credentials are absent from ordinary KV;
+- runtime normalizer produces deterministic account identities and snapshot hashes;
+- collateral/locked and available balances remain distinct;
+- transaction execution authority remains false;
+- tests use synthetic values only;
+- connected-KV write/readback is separately verified before claiming live tracking;
+- downstream Site / Publisher / admissibility / stegguardian propagation is checked when release-worthy.
+
+## Current live boundary
+
+Issue #106 and this source lane establish the finance-tracking contract only.
+
+No real financial values have been written to the public repository.
+No provider connector, payment authority, trading authority, transfer authority, borrowing authority, or credential capability is activated by this source work.

--- a/KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md
+++ b/KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md
@@ -20,6 +20,14 @@ Financial provider / owner entry
  -> optional governed analysis/readback
 ```
 
+## Direct-source ingestion dependency
+
+Canonical live population must conform to `KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md` (issue #108).
+
+For finance, assets, and liabilities, canonical imports should originate from the direct institution/provider source using an owner-authorized provider session whose reusable credential material is resolved through SKAP Vault. An intermediary may be admitted only as explicit transport/convenience and may not silently replace the underlying source in provenance.
+
+Default access is READ_ONLY / minimum-necessary. Provider login/session verification, source/account binding, normalization, admission, and KV persistence receipts are required before imported state is treated as current direct-source data.
+
 ## Privacy and authority invariants
 
 1. Real user financial values belong only in the user's private connected KnowledgeVault or an admitted private runtime; they must never be committed to this public repository.
@@ -107,7 +115,7 @@ Required validation before merge:
 - transaction execution authority remains false: IMPLEMENTED / VALIDATION_PENDING;
 - tests use synthetic values only: SATISFIED_ON_BRANCH;
 - connected-KV write/readback: NOT YET PERFORMED;
-- automatic/provider import adapter: NOT YET IMPLEMENTED;
+- direct-source SKAP-backed provider import adapter: governed by issue #108 / NOT YET LIVE-ACTIVATED;
 - Site / My KV finance projection: NOT YET IMPLEMENTED;
 - downstream Publisher / admissibility / stegguardian propagation: NOT YET DUE.
 

--- a/KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md
+++ b/KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Personal Finance Mirror Handoff
 
-Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS  
+Status: SOURCE_IMPLEMENTED_ON_BRANCH / VALIDATION_PENDING  
 Repository: `StegVerse-Labs/continuity-vault-kit`  
 Issue: `#106`  
 Branch: `feature/kv-personal-finance-106`  
@@ -10,7 +10,7 @@ Updated: 2026-08-28
 
 Add a bounded Personal KnowledgeVault finance-tracking model that can represent accounts, balances, liabilities, transactions, recurring activity, rewards/yield, and collateral relationships without turning KnowledgeVault into a credential store or provider authority.
 
-This lane begins the canonical source contract for:
+This lane establishes the canonical source contract for:
 
 ```text
 Financial provider / owner entry
@@ -23,7 +23,7 @@ Financial provider / owner entry
 ## Privacy and authority invariants
 
 1. Real user financial values belong only in the user's private connected KnowledgeVault or an admitted private runtime; they must never be committed to this public repository.
-2. Ordinary KV finance records must not contain passwords, OAuth tokens, refresh tokens, private keys, recovery codes, card PANs, CVVs, full bank-account numbers, or equivalent reusable secrets.
+2. Ordinary KV finance records must not contain passwords, OAuth tokens, refresh tokens, private keys, recovery codes, card PANs, CVVs, full bank-account numbers, routing numbers, or equivalent reusable secrets.
 3. Provider/account connection credentials belong behind SKAP Vault or another explicitly admitted credential boundary.
 4. A provider/account reference grants no payment, trading, transfer, borrowing, card-spending, or account-management authority.
 5. Read access to finance records does not imply transaction execution authority.
@@ -35,6 +35,15 @@ Financial provider / owner entry
 11. Historical finance records are user-controlled private data, not repository fixtures.
 12. Repository tests may use synthetic values only.
 
+## Implemented source
+
+- `KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md` — canonical lane handoff.
+- `schemas/kv-personal-finance-snapshot.schema.json` — normalized finance snapshot contract.
+- `vault_template/KnowledgeVault/_Entities/Self/Personal_Finance.json` — empty/private-KV initialization shape with no real values.
+- `runtime/personal_finance.py` — deterministic IDs, canonical snapshot hashing, secret-field rejection, execution-authority fail-closed enforcement.
+- `tests/test_personal_finance.py` — synthetic-only tests for normalization, deterministic IDs, secret rejection, authority rejection, rewards, and collateral.
+- `tools/check_kv_personal_finance.py` — source-presence/static boundary checker.
+
 ## Initial normalized model
 
 The first schema slice supports:
@@ -44,21 +53,24 @@ The first schema slice supports:
 - current / available balance and credit limit;
 - liabilities and amount owed;
 - transactions and recurring activity;
-- reward/yield positions such as USDC APY and card-spend BTC rewards;
+- reward/yield positions such as USDC APY and card-spend crypto rewards;
 - locked/collateral relationships;
 - observation timestamp / provider/source metadata;
 - user labels and notes without authority effect.
 
-## Planned source files
+The model intentionally separates:
 
-- `KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md`
-- `schemas/kv-personal-finance-snapshot.schema.json`
-- `vault_template/KnowledgeVault/_Entities/Self/Personal_Finance.json`
-- `runtime/personal_finance.py`
-- `tests/test_personal_finance.py`
-- `tools/check_kv_personal_finance.py`
-- `CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`
-- optional downstream Site projection after canonical KV contract stabilizes
+```text
+current balance
+available balance
+credit limit
+amount owed
+earning balance
+locked/collateral balance
+earned reward value
+```
+
+so collateral, debt, liquidity, and rewards cannot silently collapse into one value.
 
 ## Connected-KV destination
 
@@ -68,24 +80,51 @@ Canonical private destination candidate:
 /KnowledgeVault/_Entities/Self/Personal_Finance.json
 ```
 
-The repository template contains only an empty/synthetic initialization shape. Real values are installed or updated only through a private owner-authorized KV path.
+The repository template contains only an empty initialization shape. Real values are installed or updated only through a private owner-authorized KV path.
+
+## Validation state
+
+Implemented-on-branch source exists, but hosted/exact-head validation has not yet been observed.
+
+Required validation before merge:
+
+- schema parse/validation against synthetic finance fixtures;
+- `tests/test_personal_finance.py`;
+- `tools/check_kv_personal_finance.py`;
+- existing Security Baseline;
+- existing KV Guardrails;
+- existing Release Integrity / repository diagnostics as applicable;
+- current-main reconciliation if main advances.
 
 ## Completion gates
 
-- finance-specific handoff exists before implementation;
-- schema validates synthetic account/balance/liability/reward/collateral examples;
-- secret-bearing fields fail closed;
-- real provider credentials are absent from ordinary KV;
-- runtime normalizer produces deterministic account identities and snapshot hashes;
-- collateral/locked and available balances remain distinct;
-- transaction execution authority remains false;
-- tests use synthetic values only;
-- connected-KV write/readback is separately verified before claiming live tracking;
-- downstream Site / Publisher / admissibility / stegguardian propagation is checked when release-worthy.
+- finance-specific handoff exists before implementation: SATISFIED;
+- schema/source/template/runtime/tests/static checker installed: SATISFIED_ON_BRANCH;
+- secret-bearing fields fail closed: IMPLEMENTED / VALIDATION_PENDING;
+- real provider credentials absent from ordinary KV: IMPLEMENTED / VALIDATION_PENDING;
+- runtime normalizer produces deterministic account identities and snapshot hashes: IMPLEMENTED / VALIDATION_PENDING;
+- collateral/locked and available balances remain distinct: IMPLEMENTED / VALIDATION_PENDING;
+- transaction execution authority remains false: IMPLEMENTED / VALIDATION_PENDING;
+- tests use synthetic values only: SATISFIED_ON_BRANCH;
+- connected-KV write/readback: NOT YET PERFORMED;
+- automatic/provider import adapter: NOT YET IMPLEMENTED;
+- Site / My KV finance projection: NOT YET IMPLEMENTED;
+- downstream Publisher / admissibility / stegguardian propagation: NOT YET DUE.
+
+## Remaining source/integration work
+
+1. run deterministic source validation and repair any failures;
+2. merge the canonical KV contract only after exact-head validation;
+3. install the empty `Personal_Finance.json` template into the connected private KnowledgeVault and restore source-template parity;
+4. add an owner-authorized read-only finance-ingress adapter that maps connected finance-provider data into this schema without storing credentials;
+5. add My KV / Site finance display and consent controls as a downstream projection, not a competing schema authority;
+6. verify readback from the private KV;
+7. only then begin writing real owner financial observations into the private KV.
 
 ## Current live boundary
 
-Issue #106 and this source lane establish the finance-tracking contract only.
+Issue #106 and this branch establish the finance-tracking source contract only.
 
 No real financial values have been written to the public repository.
-No provider connector, payment authority, trading authority, transfer authority, borrowing authority, or credential capability is activated by this source work.
+No real financial values have yet been written to the connected KnowledgeVault by this lane.
+No provider connector, payment authority, trading authority, transfer authority, borrowing authority, card-spending authority, or credential capability is activated by this source work.

--- a/runtime/personal_finance.py
+++ b/runtime/personal_finance.py
@@ -1,0 +1,139 @@
+"""Personal KnowledgeVault finance helpers.
+
+This module normalizes user-controlled finance snapshots without creating payment,
+trading, transfer, borrowing, or provider authority. It intentionally rejects
+secret-bearing fields from ordinary KV finance content.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from typing import Any, Dict
+
+SCHEMA_VERSION = "stegverse.kv.personal-finance/v1"
+
+FORBIDDEN_KEY_FRAGMENTS = {
+    "password",
+    "passcode",
+    "pin",
+    "cvv",
+    "cvc",
+    "card_number",
+    "pan",
+    "account_number",
+    "routing_number",
+    "private_key",
+    "recovery_code",
+    "refresh_token",
+    "access_token",
+    "oauth_token",
+    "api_key",
+    "secret",
+}
+
+SAFE_TOP_LEVEL_ARRAYS = (
+    "accounts",
+    "liabilities",
+    "transactions",
+    "recurring_activity",
+    "rewards",
+    "collateral_relationships",
+    "provenance",
+)
+
+
+class PersonalFinanceError(ValueError):
+    """Raised when a finance payload violates the bounded KV contract."""
+
+
+def _normalized_key(key: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", key.lower()).strip("_")
+
+
+def reject_secret_fields(value: Any, path: str = "$") -> None:
+    """Fail closed when an ordinary KV payload contains a secret-bearing field."""
+
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized = _normalized_key(str(key))
+            if any(fragment == normalized or fragment in normalized for fragment in FORBIDDEN_KEY_FRAGMENTS):
+                raise PersonalFinanceError(f"forbidden secret-bearing field at {path}.{key}")
+            reject_secret_fields(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_secret_fields(child, f"{path}[{index}]")
+
+
+def deterministic_id(namespace: str, *parts: Any) -> str:
+    """Create a stable non-secret identifier from already-bounded reference metadata."""
+
+    material = "|".join("" if part is None else str(part).strip().lower() for part in parts)
+    digest = hashlib.sha256(f"{namespace}|{material}".encode("utf-8")).hexdigest()[:24]
+    return f"kvfin_{namespace}_{digest}"
+
+
+def _ensure_account_ids(snapshot: Dict[str, Any]) -> None:
+    for account in snapshot["accounts"]:
+        if not account.get("account_id"):
+            source = account.get("source") or {}
+            account["account_id"] = deterministic_id(
+                "acct",
+                source.get("provider_name"),
+                source.get("external_reference"),
+                account.get("display_name"),
+                account.get("mask"),
+            )
+
+
+def canonical_snapshot_hash(snapshot: Dict[str, Any]) -> str:
+    """Hash canonical finance state without including the hash field itself."""
+
+    material = copy.deepcopy(snapshot)
+    material["snapshot_hash"] = None
+    encoded = json.dumps(material, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def normalize_snapshot(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a Personal KV finance snapshot and compute its integrity hash."""
+
+    if not isinstance(payload, dict):
+        raise PersonalFinanceError("finance snapshot must be an object")
+
+    reject_secret_fields(payload)
+    snapshot = copy.deepcopy(payload)
+
+    schema_version = snapshot.get("schema_version", SCHEMA_VERSION)
+    if schema_version != SCHEMA_VERSION:
+        raise PersonalFinanceError(f"unsupported schema_version: {schema_version}")
+    snapshot["schema_version"] = SCHEMA_VERSION
+
+    for field in SAFE_TOP_LEVEL_ARRAYS:
+        value = snapshot.setdefault(field, [])
+        if not isinstance(value, list):
+            raise PersonalFinanceError(f"{field} must be a list")
+
+    if snapshot.get("execution_authority") not in (None, False):
+        raise PersonalFinanceError("finance snapshot cannot grant execution authority")
+    snapshot["execution_authority"] = False
+    snapshot.setdefault("updated_at", None)
+
+    _ensure_account_ids(snapshot)
+    snapshot["snapshot_hash"] = canonical_snapshot_hash(snapshot)
+    return snapshot
+
+
+def assert_read_only_finance_contract(snapshot: Dict[str, Any]) -> None:
+    """Re-check the most important authority and credential invariants."""
+
+    reject_secret_fields(snapshot)
+    if snapshot.get("schema_version") != SCHEMA_VERSION:
+        raise PersonalFinanceError("unexpected finance schema version")
+    if snapshot.get("execution_authority") is not False:
+        raise PersonalFinanceError("execution_authority must remain false")
+    for field in SAFE_TOP_LEVEL_ARRAYS:
+        if not isinstance(snapshot.get(field), list):
+            raise PersonalFinanceError(f"{field} must be a list")

--- a/schemas/kv-personal-finance-snapshot.schema.json
+++ b/schemas/kv-personal-finance-snapshot.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-personal-finance-snapshot.schema.json",
+  "title": "KnowledgeVault Personal Finance Snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "updated_at",
+    "accounts",
+    "liabilities",
+    "transactions",
+    "recurring_activity",
+    "rewards",
+    "collateral_relationships",
+    "provenance",
+    "execution_authority"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "stegverse.kv.personal-finance/v1"
+    },
+    "updated_at": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "accounts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/account" }
+    },
+    "liabilities": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/liability" }
+    },
+    "transactions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/transaction" }
+    },
+    "recurring_activity": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/recurring" }
+    },
+    "rewards": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/reward" }
+    },
+    "collateral_relationships": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/collateral" }
+    },
+    "provenance": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/provenance" }
+    },
+    "snapshot_hash": {
+      "type": ["string", "null"],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "execution_authority": {
+      "const": false
+    }
+  },
+  "$defs": {
+    "money": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["amount", "currency"],
+      "properties": {
+        "amount": { "type": "number" },
+        "currency": { "type": "string", "minLength": 2, "maxLength": 16 }
+      }
+    },
+    "account": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["account_id", "display_name", "type", "balances", "source"],
+      "properties": {
+        "account_id": { "type": "string", "minLength": 8, "maxLength": 128 },
+        "display_name": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "type": {
+          "enum": ["depository", "credit", "loan", "investment", "crypto", "cash", "other"]
+        },
+        "subtype": { "type": ["string", "null"], "maxLength": 80 },
+        "mask": { "type": ["string", "null"], "pattern": "^[A-Za-z0-9*•-]{1,8}$" },
+        "balances": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["current", "available", "limit", "currency", "as_of"],
+          "properties": {
+            "current": { "type": ["number", "null"] },
+            "available": { "type": ["number", "null"] },
+            "limit": { "type": ["number", "null"] },
+            "currency": { "type": "string", "minLength": 2, "maxLength": 16 },
+            "as_of": { "type": ["string", "null"], "format": "date-time" }
+          }
+        },
+        "source": { "$ref": "#/$defs/source" },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 80 },
+          "uniqueItems": true
+        },
+        "notes": { "type": ["string", "null"], "maxLength": 2000 }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "provider_name"],
+      "properties": {
+        "kind": { "enum": ["owner_entry", "provider_import", "derived"] },
+        "provider_name": { "type": ["string", "null"], "maxLength": 120 },
+        "external_reference": { "type": ["string", "null"], "maxLength": 256 },
+        "connection_state": {
+          "enum": ["UNCONNECTED", "REFERENCE_ONLY", "CONNECTED_READ_ONLY", "REVOKED", "NOT_APPLICABLE"]
+        }
+      }
+    },
+    "liability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["liability_id", "account_id", "kind", "amount_owed", "as_of"],
+      "properties": {
+        "liability_id": { "type": "string", "minLength": 8, "maxLength": 128 },
+        "account_id": { "type": "string", "minLength": 8, "maxLength": 128 },
+        "kind": { "enum": ["credit_card", "auto_loan", "mortgage", "student_loan", "personal_loan", "other"] },
+        "amount_owed": { "$ref": "#/$defs/money" },
+        "apr_percent": { "type": ["number", "null"], "minimum": 0 },
+        "minimum_payment": { "anyOf": [{ "$ref": "#/$defs/money" }, { "type": "null" }] },
+        "due_date": { "type": ["string", "null"], "format": "date" },
+        "as_of": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "transaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transaction_id", "account_id", "posted_at", "amount", "description", "status"],
+      "properties": {
+        "transaction_id": { "type": "string", "minLength": 8, "maxLength": 160 },
+        "account_id": { "type": "string", "minLength": 8, "maxLength": 128 },
+        "posted_at": { "type": "string", "format": "date-time" },
+        "amount": { "$ref": "#/$defs/money" },
+        "description": { "type": "string", "maxLength": 512 },
+        "category": { "type": ["string", "null"], "maxLength": 120 },
+        "status": { "enum": ["posted", "pending", "reversed"] },
+        "transfer_link": { "type": ["string", "null"], "maxLength": 160 }
+      }
+    },
+    "recurring": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["recurring_id", "name", "flow_type", "active"],
+      "properties": {
+        "recurring_id": { "type": "string", "minLength": 8, "maxLength": 160 },
+        "name": { "type": "string", "maxLength": 160 },
+        "flow_type": { "enum": ["inflow", "outflow"] },
+        "frequency": { "type": ["string", "null"], "maxLength": 80 },
+        "last_amount": { "anyOf": [{ "$ref": "#/$defs/money" }, { "type": "null" }] },
+        "active": { "type": "boolean" }
+      }
+    },
+    "reward": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reward_id", "kind", "source_account_id", "asset", "as_of"],
+      "properties": {
+        "reward_id": { "type": "string", "minLength": 8, "maxLength": 160 },
+        "kind": { "enum": ["apy", "apr", "cashback", "crypto_back", "points", "other"] },
+        "source_account_id": { "type": "string", "minLength": 8, "maxLength": 128 },
+        "asset": { "type": "string", "minLength": 1, "maxLength": 32 },
+        "rate_percent": { "type": ["number", "null"], "minimum": 0 },
+        "earning_balance": { "anyOf": [{ "$ref": "#/$defs/money" }, { "type": "null" }] },
+        "earned_value": { "anyOf": [{ "$ref": "#/$defs/money" }, { "type": "null" }] },
+        "as_of": { "type": ["string", "null"], "format": "date-time" },
+        "notes": { "type": ["string", "null"], "maxLength": 1000 }
+      }
+    },
+    "collateral": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["relationship_id", "collateral_account_id", "secured_account_id", "asset", "locked_amount", "as_of"],
+      "properties": {
+        "relationship_id": { "type": "string", "minLength": 8, "maxLength": 160 },
+        "collateral_account_id": { "type": "string", "minLength": 8, "maxLength": 128 },
+        "secured_account_id": { "type": "string", "minLength": 8, "maxLength": 128 },
+        "asset": { "type": "string", "minLength": 1, "maxLength": 32 },
+        "locked_amount": { "$ref": "#/$defs/money" },
+        "purpose": { "type": ["string", "null"], "maxLength": 240 },
+        "as_of": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_kind", "observed_at"],
+      "properties": {
+        "source_kind": { "enum": ["owner_entry", "provider_import", "derived"] },
+        "provider_name": { "type": ["string", "null"], "maxLength": 120 },
+        "observed_at": { "type": ["string", "null"], "format": "date-time" },
+        "coverage_note": { "type": ["string", "null"], "maxLength": 512 }
+      }
+    }
+  }
+}

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),38)
+        self.assertEqual(len(workflows),39)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tests/test_personal_finance.py
+++ b/tests/test_personal_finance.py
@@ -1,0 +1,96 @@
+import unittest
+
+from runtime.personal_finance import (
+    PersonalFinanceError,
+    assert_read_only_finance_contract,
+    deterministic_id,
+    normalize_snapshot,
+)
+
+
+class PersonalFinanceTests(unittest.TestCase):
+    def test_empty_snapshot_normalizes(self):
+        snapshot = normalize_snapshot({})
+        self.assertEqual(snapshot["schema_version"], "stegverse.kv.personal-finance/v1")
+        self.assertFalse(snapshot["execution_authority"])
+        self.assertEqual(len(snapshot["snapshot_hash"]), 64)
+
+    def test_account_id_is_deterministic(self):
+        payload = {
+            "accounts": [{
+                "display_name": "Synthetic Checking",
+                "type": "depository",
+                "mask": "1234",
+                "balances": {
+                    "current": 1000.0,
+                    "available": 900.0,
+                    "limit": None,
+                    "currency": "USD",
+                    "as_of": "2026-08-28T12:00:00Z"
+                },
+                "source": {
+                    "kind": "provider_import",
+                    "provider_name": "Example Bank",
+                    "external_reference": "synthetic-account-ref",
+                    "connection_state": "CONNECTED_READ_ONLY"
+                }
+            }]
+        }
+        a = normalize_snapshot(payload)
+        b = normalize_snapshot(payload)
+        self.assertEqual(a["accounts"][0]["account_id"], b["accounts"][0]["account_id"])
+        self.assertTrue(a["accounts"][0]["account_id"].startswith("kvfin_acct_"))
+
+    def test_secret_fields_fail_closed(self):
+        with self.assertRaises(PersonalFinanceError):
+            normalize_snapshot({
+                "accounts": [],
+                "provider_access_token": "must-not-enter-kv"
+            })
+
+    def test_full_account_numbers_fail_closed(self):
+        with self.assertRaises(PersonalFinanceError):
+            normalize_snapshot({
+                "accounts": [{
+                    "display_name": "Synthetic",
+                    "type": "depository",
+                    "account_number": "1234567890"
+                }]
+            })
+
+    def test_execution_authority_cannot_be_granted(self):
+        with self.assertRaises(PersonalFinanceError):
+            normalize_snapshot({"execution_authority": True})
+
+    def test_reward_and_collateral_shapes_remain_read_only(self):
+        collateral_account = deterministic_id("acct", "Example Crypto", "usdc")
+        secured_account = deterministic_id("acct", "Example Card", "secured")
+        snapshot = normalize_snapshot({
+            "accounts": [],
+            "rewards": [{
+                "reward_id": deterministic_id("reward", "usdc-apy"),
+                "kind": "apy",
+                "source_account_id": collateral_account,
+                "asset": "USDC",
+                "rate_percent": 6.5,
+                "earning_balance": {"amount": 1000.0, "currency": "USD"},
+                "earned_value": None,
+                "as_of": "2026-08-28T12:00:00Z",
+                "notes": "synthetic fixture"
+            }],
+            "collateral_relationships": [{
+                "relationship_id": deterministic_id("collateral", "usdc", "secured-card"),
+                "collateral_account_id": collateral_account,
+                "secured_account_id": secured_account,
+                "asset": "USDC",
+                "locked_amount": {"amount": 1000.0, "currency": "USD"},
+                "purpose": "synthetic secured-card collateral",
+                "as_of": "2026-08-28T12:00:00Z"
+            }]
+        })
+        assert_read_only_finance_contract(snapshot)
+        self.assertFalse(snapshot["execution_authority"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_kv_personal_finance.py
+++ b/tools/check_kv_personal_finance.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Static checks for the Personal KV finance source lane."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HANDOFF = ROOT / "KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md"
+SCHEMA = ROOT / "schemas" / "kv-personal-finance-snapshot.schema.json"
+TEMPLATE = ROOT / "vault_template" / "KnowledgeVault" / "_Entities" / "Self" / "Personal_Finance.json"
+RUNTIME = ROOT / "runtime" / "personal_finance.py"
+TESTS = ROOT / "tests" / "test_personal_finance.py"
+
+REQUIRED = (HANDOFF, SCHEMA, TEMPLATE, RUNTIME, TESTS)
+
+
+def main() -> int:
+    missing = [str(path.relative_to(ROOT)) for path in REQUIRED if not path.exists()]
+    if missing:
+        raise SystemExit("missing personal-finance source files: " + ", ".join(missing))
+
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    template = json.loads(TEMPLATE.read_text(encoding="utf-8"))
+
+    if schema.get("$id") != "https://stegverse.org/schemas/kv-personal-finance-snapshot.schema.json":
+        raise SystemExit("unexpected personal-finance schema id")
+    if template.get("schema_version") != "stegverse.kv.personal-finance/v1":
+        raise SystemExit("unexpected template schema version")
+    if template.get("execution_authority") is not False:
+        raise SystemExit("template must not grant execution authority")
+
+    forbidden_literals = (
+        '"password"',
+        '"access_token"',
+        '"refresh_token"',
+        '"private_key"',
+        '"card_number"',
+        '"account_number"',
+        '"routing_number"',
+        '"cvv"',
+    )
+    template_text = TEMPLATE.read_text(encoding="utf-8").lower()
+    for token in forbidden_literals:
+        if token in template_text:
+            raise SystemExit(f"secret-bearing field present in KV template: {token}")
+
+    print("KV personal finance static checks: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vault_template/KnowledgeVault/03_Records/Assets/README.md
+++ b/vault_template/KnowledgeVault/03_Records/Assets/README.md
@@ -1,0 +1,20 @@
+# Assets
+
+This directory stores private continuity records about resources the owner possesses or controls.
+
+Examples include:
+
+- real estate;
+- vehicles;
+- investment accounts and holdings;
+- cash and cash-equivalents;
+- business interests;
+- receivables;
+- collectibles and valuables;
+- insurance cash value;
+- intellectual-property interests;
+- other material assets.
+
+Use masked provider/account identifiers only. Credentials, private keys, full account numbers, card numbers, recovery phrases, and equivalent reusable secrets are prohibited.
+
+Finance analysis may reference these records, but Assets remains a first-class continuity domain.

--- a/vault_template/KnowledgeVault/03_Records/Email/README.md
+++ b/vault_template/KnowledgeVault/03_Records/Email/README.md
@@ -1,0 +1,3 @@
+# Email
+
+Governed email continuity records may be projected here only after the canonical email-ingress admission path permits persistence. Provider credentials never belong in this directory.

--- a/vault_template/KnowledgeVault/03_Records/Finance/Accounts/README.md
+++ b/vault_template/KnowledgeVault/03_Records/Finance/Accounts/README.md
@@ -1,0 +1,3 @@
+# Finance — Accounts
+
+Private account continuity records belong here. Use masked identifiers only; credentials and full account/card numbers are prohibited.

--- a/vault_template/KnowledgeVault/03_Records/Finance/Finance_Overview.md
+++ b/vault_template/KnowledgeVault/03_Records/Finance/Finance_Overview.md
@@ -24,6 +24,42 @@ Suggested fields:
 - observation date;
 - notes about account role.
 
+## Assets
+
+Summarize major owned resources and the asset records that contribute to the owner's balance-sheet view.
+
+Suggested analysis:
+
+- liquid assets;
+- investment assets;
+- retirement assets;
+- real estate;
+- vehicles and other material property;
+- business interests and receivables;
+- valuables / collectibles where tracked;
+- estimated value and valuation date;
+- liquidity and concentration observations.
+
+Canonical detailed continuity records live under `03_Records/Assets/`.
+
+## Liabilities
+
+Summarize major obligations and the liability records that contribute to the owner's balance-sheet view.
+
+Suggested analysis:
+
+- credit-card balances;
+- auto loans;
+- mortgages;
+- student/personal loans;
+- taxes owed where applicable;
+- interest/APR;
+- minimum or scheduled payments;
+- maturity/payoff observations;
+- utilization and debt-service observations.
+
+Canonical detailed continuity records live under `03_Records/Liabilities/`.
+
 ## Spending habits and analysis
 
 Summarize observed spending patterns.

--- a/vault_template/KnowledgeVault/03_Records/Finance/Finance_Overview.md
+++ b/vault_template/KnowledgeVault/03_Records/Finance/Finance_Overview.md
@@ -1,0 +1,126 @@
+# Personal Finance Overview
+
+Status: USER_CONTROLLED_PRIVATE_KV_DOCUMENT  
+Scope: Personal KnowledgeVault finance continuity  
+Execution authority: NONE
+
+This is the top-level human-readable finance document for the owner's KnowledgeVault.
+
+It is intended to summarize private finance state persisted elsewhere in the Personal KV finance model and related finance directory files. It does not store provider credentials and does not grant payment, trading, transfer, borrowing, tax-filing, or account-management authority.
+
+## Accounts
+
+Summarize active financial accounts and their purpose.
+
+Suggested fields:
+
+- institution / provider display name;
+- masked account identifier;
+- account type;
+- current balance;
+- available balance;
+- credit limit where applicable;
+- liability balance where applicable;
+- observation date;
+- notes about account role.
+
+## Spending habits and analysis
+
+Summarize observed spending patterns.
+
+Suggested analysis:
+
+- monthly spending trend;
+- spending by category;
+- recurring bills and subscriptions;
+- large or unusual expenses;
+- discretionary vs required spending;
+- cash-flow observations;
+- credit-card utilization and payoff behavior.
+
+## Savings analysis
+
+Summarize liquid savings and reserve posture.
+
+Suggested analysis:
+
+- emergency reserve;
+- checking/savings cash levels;
+- savings rate;
+- short-term goals;
+- yield earned on cash/cash-equivalent positions;
+- locked or collateralized funds separately from available savings.
+
+## Retirement analysis
+
+Summarize retirement-oriented assets and progress.
+
+Suggested analysis:
+
+- retirement accounts;
+- contribution rate;
+- employer match where applicable;
+- current allocation;
+- concentration observations;
+- target-date or goal assumptions;
+- projected gap or surplus using explicitly recorded assumptions.
+
+## Income tax analysis
+
+### Federal
+
+Summarize federal income-tax observations and planning inputs.
+
+Suggested analysis:
+
+- year-to-date taxable income inputs;
+- withholding;
+- estimated payments;
+- realized gains/losses where available;
+- deductible or credit-relevant items tracked by the owner;
+- projected liability using explicitly recorded assumptions.
+
+### State
+
+Summarize state income-tax observations using the owner's applicable state jurisdiction and assumptions.
+
+Suggested analysis:
+
+- state taxable-income inputs;
+- withholding / estimated payments;
+- state-specific deductions or credits recorded by the owner;
+- projected state liability.
+
+Tax sections are analytical continuity records, not filing authority or a substitute for official tax forms or qualified advice.
+
+## Rewards, yield, and collateral
+
+Track rewards and yield without collapsing them into liquid cash.
+
+Examples:
+
+- cash/USDC yield rate and earned rewards;
+- card-spend BTC or other rewards;
+- locked collateral;
+- secured credit relationships;
+- observation timestamps because rates and program terms may change.
+
+## Analysis provenance
+
+Every generated or imported analysis should identify:
+
+- data sources;
+- observation / coverage period;
+- last refresh time;
+- assumptions;
+- incomplete or unavailable data;
+- whether the section is owner-entered, provider-imported, or derived.
+
+## Related canonical machine-readable state
+
+The normalized machine-readable finance snapshot is governed by:
+
+- `_Entities/Self/Personal_Finance.json`
+- `schemas/kv-personal-finance-snapshot.schema.json` in the source kit
+
+Private values belong in the connected KnowledgeVault, not the public source repository.

--- a/vault_template/KnowledgeVault/03_Records/Finance/Retirement/README.md
+++ b/vault_template/KnowledgeVault/03_Records/Finance/Retirement/README.md
@@ -1,0 +1,3 @@
+# Finance — Retirement
+
+Private retirement account, contribution, allocation, projection, and goal analysis belongs here.

--- a/vault_template/KnowledgeVault/03_Records/Finance/Savings/README.md
+++ b/vault_template/KnowledgeVault/03_Records/Finance/Savings/README.md
@@ -1,0 +1,3 @@
+# Finance — Savings
+
+Private savings, reserve, yield, and short-term goal analysis belongs here. Keep locked/collateralized funds distinct from available savings.

--- a/vault_template/KnowledgeVault/03_Records/Finance/Spending/README.md
+++ b/vault_template/KnowledgeVault/03_Records/Finance/Spending/README.md
@@ -1,0 +1,3 @@
+# Finance — Spending
+
+Private spending summaries, transaction exports, category analysis, recurring-expense analysis, and cash-flow observations belong here.

--- a/vault_template/KnowledgeVault/03_Records/Finance/Taxes/README.md
+++ b/vault_template/KnowledgeVault/03_Records/Finance/Taxes/README.md
@@ -1,0 +1,3 @@
+# Finance — Taxes
+
+Private federal and state income-tax continuity analysis belongs here. Preserve year, jurisdiction, source documents, assumptions, and refresh date. This directory grants no filing authority.

--- a/vault_template/KnowledgeVault/03_Records/Liabilities/README.md
+++ b/vault_template/KnowledgeVault/03_Records/Liabilities/README.md
@@ -1,0 +1,20 @@
+# Liabilities
+
+This directory stores private continuity records about amounts the owner owes or may owe.
+
+Examples include:
+
+- credit cards;
+- auto loans;
+- mortgages;
+- student loans;
+- personal loans;
+- tax liabilities;
+- installment obligations;
+- other debts.
+
+Records should preserve creditor/provider label, masked identifier, amount owed, applicable APR/rate, payment terms, due dates, and observation date where known.
+
+Credentials, full account/card numbers, CVVs, authentication tokens, and equivalent reusable secrets are prohibited.
+
+Finance analysis may reference these records, but Liabilities remains a first-class continuity domain.

--- a/vault_template/KnowledgeVault/04_Media/Music/README.md
+++ b/vault_template/KnowledgeVault/04_Media/Music/README.md
@@ -1,0 +1,3 @@
+# Music
+
+User-controlled music continuity records, listening history exports, playlists, song moments, and related metadata belong here according to the KnowledgeVault media policy.

--- a/vault_template/KnowledgeVault/04_Media/Pictures/README.md
+++ b/vault_template/KnowledgeVault/04_Media/Pictures/README.md
@@ -1,0 +1,3 @@
+# Pictures
+
+User-controlled picture continuity records and related metadata belong here. Binary media may be stored or referenced according to the KnowledgeVault media policy.

--- a/vault_template/KnowledgeVault/_Entities/Self/Personal_Finance.json
+++ b/vault_template/KnowledgeVault/_Entities/Self/Personal_Finance.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "stegverse.kv.personal-finance/v1",
+  "updated_at": null,
+  "accounts": [],
+  "liabilities": [],
+  "transactions": [],
+  "recurring_activity": [],
+  "rewards": [],
+  "collateral_relationships": [],
+  "provenance": [],
+  "snapshot_hash": null,
+  "execution_authority": false
+}


### PR DESCRIPTION
Implements the first bounded Personal KV finance-tracking contract for #106.

Included:
- finance-specific canonical mirror handoff;
- schema for accounts, balances, liabilities, transactions, recurring activity, rewards/yield, collateral, and provenance;
- empty Personal_Finance.json template with no real user values;
- deterministic runtime normalization/hash helpers;
- fail-closed rejection of secret-bearing fields and execution authority;
- synthetic-only unit tests and static checker;
- read-only GitHub validation workflow.

Privacy boundary: no real financial data or provider credentials are committed. Live owner financial values remain private-KV-only and are not yet written by this lane.

Activation authority: NONE.