### PR TITLE
Require direct-source SKAP-backed ingress for Personal KV data

### DIFF
--- a/.github/workflows/kv-direct-source-ingress.yml
+++ b/.github/workflows/kv-direct-source-ingress.yml
@@ -1,0 +1,29 @@
+name: Validate KV Direct-Source Ingress
+
+on:
+  pull_request:
+    paths:
+      - "KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md"
+      - "schemas/kv-direct-source-ingress-request.schema.json"
+      - "schemas/kv-direct-source-ingress-receipt.schema.json"
+      - "runtime/direct_source_ingress.py"
+      - "tests/test_direct_source_ingress.py"
+      - "tools/check_kv_direct_source_ingress.py"
+      - ".github/workflows/kv-direct-source-ingress.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Static direct-source ingress checks
+        run: python tools/check_kv_direct_source_ingress.py
+      - name: Direct-source ingress tests
+        run: python -m unittest tests.test_direct_source_ingress

--- a/KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md
@@ -1,0 +1,119 @@
+# KV Direct-Source SKAP Ingress Mirror Handoff
+
+Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS  
+Repository: `StegVerse-Labs/continuity-vault-kit`  
+Issue: `#108`  
+Branch: `feature/kv-direct-source-ingress-108`  
+Updated: 2026-08-28  
+Authority effect: NONE  
+Activation effect: false
+
+## Purpose
+
+Define the canonical ingress rule for Personal KnowledgeVault continuity data:
+
+```text
+owner chooses direct source
+ -> SKAP Vault resolves bounded credential/session reference
+ -> source-native provider login/session
+ -> minimum-necessary read
+ -> source-specific normalization
+ -> governance/admission
+ -> canonical KV directory/state projection
+ -> provenance + receipt
+```
+
+The direct provider/source remains the factual source of imported data. KnowledgeVault remains the durable user-controlled continuity store. SKAP Vault remains the reusable credential boundary.
+
+## Canonical rule
+
+Continuity data intended to populate Personal KV directories should be obtained from the direct authoritative source wherever such a source exists and the owner authorizes access.
+
+Examples:
+
+- finance / assets / liabilities: source financial institution, brokerage, card issuer, lender, exchange, payroll/tax source, or other direct account provider;
+- email: source mailbox provider;
+- pictures/media: source photo/media provider or owner-controlled storage;
+- music: source music provider or owner-controlled library;
+- future continuity domains: the original system of record or owner-controlled source.
+
+An intermediary aggregator may not silently become canonical source authority. If an intermediary is explicitly admitted as transport or convenience, provenance must still identify the underlying source and the intermediary role, and direct-source unavailability must not be hidden.
+
+## SKAP credential boundary
+
+1. Passwords, OAuth refresh tokens, API secrets, private keys, app passwords, recovery codes, and reusable authentication material remain behind SKAP Vault.
+2. Ordinary KV content stores only bounded `skap://` references, non-secret provider/session metadata, and receipts where required.
+3. A source adapter requests credential resolution from SKAP; it does not receive permission to persist the reusable secret into KV.
+4. Site/My KV never renders reusable credentials.
+5. Credential/session revocation must prevent subsequent source access.
+6. A SKAP reference does not itself grant data-write, payment, trading, sending, deletion, or provider-management authority.
+
+## Access authority
+
+Default ingress is:
+
+```text
+READ_ONLY
+MINIMUM_NECESSARY
+OWNER_AUTHORIZED
+DIRECT_SOURCE_REQUIRED
+```
+
+Any write/transaction/send/delete capability is a separate governed capability and is outside this ingress contract.
+
+## Fail-closed behavior
+
+Ingress fails closed when:
+
+- no supported direct-source adapter exists;
+- SKAP credential reference is absent or revoked;
+- provider login/session verification fails;
+- the provider cannot prove the requested owner/account binding;
+- returned data violates the adapter schema;
+- source identity/provenance is ambiguous;
+- governance/admission is unavailable or ambiguous;
+- canonical KV persistence cannot be confirmed.
+
+No synthetic or stale fallback data may be presented as fresh direct-source state.
+
+## Provenance
+
+Every admitted import must preserve:
+
+- provider/source identifier;
+- direct source URL/origin class or provider route identifier;
+- owner/account binding reference using a masked/non-secret identifier;
+- retrieval timestamp;
+- source coverage period where applicable;
+- adapter/version;
+- whether any intermediary transport was used;
+- normalization receipt/reference;
+- admission/persistence receipt/reference;
+- freshness state.
+
+## Initial source artifacts
+
+- `KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md`
+- `schemas/kv-direct-source-ingress-request.schema.json`
+- `schemas/kv-direct-source-ingress-receipt.schema.json`
+- `runtime/direct_source_ingress.py`
+- `tests/test_direct_source_ingress.py`
+- `tools/check_kv_direct_source_ingress.py`
+
+## Downstream dependencies
+
+This contract is intended to govern:
+
+- `KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md`;
+- `KV_EMAIL_INGRESS_MIRROR_HANDOFF.md`;
+- continuity directory population under `03_Records/**` and `04_Media/**`;
+- Site/My KV directory and connection UX.
+
+## Current boundary
+
+Source contract only.
+
+No real provider login has been performed by this lane.
+No user credential or private source data is committed to the repository.
+No provider session is activated.
+No payment, trading, transfer, email-send, delete, upload, or account-management authority is granted.

--- a/runtime/direct_source_ingress.py
+++ b/runtime/direct_source_ingress.py
@@ -1,0 +1,153 @@
+"""Direct-source SKAP-backed ingress contract helpers."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict
+
+REQUEST_SCHEMA = "stegverse.kv.direct-source-ingress-request/v1"
+RECEIPT_SCHEMA = "stegverse.kv.direct-source-ingress-receipt/v1"
+
+FORBIDDEN_SECRET_FRAGMENTS = (
+    "password",
+    "access_token",
+    "refresh_token",
+    "private_key",
+    "secret",
+    "api_key",
+    "cvv",
+    "card_number",
+    "account_number",
+    "routing_number",
+)
+
+
+class DirectSourceIngressError(ValueError):
+    pass
+
+
+def _reject_secret_fields(value: Any, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lowered = str(key).lower()
+            if any(fragment in lowered for fragment in FORBIDDEN_SECRET_FRAGMENTS):
+                raise DirectSourceIngressError(f"secret-bearing field prohibited at {path}.{key}")
+            _reject_secret_fields(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_secret_fields(child, f"{path}[{index}]")
+
+
+def build_request(
+    *,
+    source_id: str,
+    source_kind: str,
+    target_domain: str,
+    skap_credential_ref: str,
+    provider_route: str | None = None,
+    masked_owner_reference: str | None = None,
+) -> Dict[str, Any]:
+    if not isinstance(skap_credential_ref, str) or not skap_credential_ref.startswith("skap://"):
+        raise DirectSourceIngressError("SKAP credential reference required")
+    request = {
+        "schema_version": REQUEST_SCHEMA,
+        "source_id": str(source_id).strip(),
+        "source_kind": str(source_kind).strip(),
+        "target_domain": str(target_domain).strip(),
+        "provider_route": provider_route,
+        "masked_owner_reference": masked_owner_reference,
+        "skap_credential_ref": skap_credential_ref,
+        "requested_access": "READ_ONLY",
+        "direct_source_required": True,
+        "minimum_necessary": True,
+        "owner_authorized": True,
+        "intermediary_transport": None,
+        "authority_effect": "NONE",
+    }
+    assert_request(request)
+    return request
+
+
+def assert_request(request: Dict[str, Any]) -> None:
+    if not isinstance(request, dict):
+        raise DirectSourceIngressError("request must be an object")
+    _reject_secret_fields(request)
+    if request.get("schema_version") != REQUEST_SCHEMA:
+        raise DirectSourceIngressError("request schema mismatch")
+    if request.get("requested_access") != "READ_ONLY":
+        raise DirectSourceIngressError("direct-source ingress is read-only")
+    if request.get("direct_source_required") is not True:
+        raise DirectSourceIngressError("direct source must be required")
+    if request.get("minimum_necessary") is not True:
+        raise DirectSourceIngressError("minimum-necessary access required")
+    if request.get("owner_authorized") is not True:
+        raise DirectSourceIngressError("owner authorization required")
+    if request.get("authority_effect") != "NONE":
+        raise DirectSourceIngressError("ingress may not grant authority")
+    ref = request.get("skap_credential_ref")
+    if not isinstance(ref, str) or not ref.startswith("skap://"):
+        raise DirectSourceIngressError("valid SKAP reference required")
+
+
+def admit_receipt(
+    request: Dict[str, Any],
+    provider_result: Dict[str, Any],
+    *,
+    normalization_receipt_ref: str,
+    persistence_receipt_ref: str,
+) -> Dict[str, Any]:
+    assert_request(request)
+    _reject_secret_fields(provider_result, "provider_result")
+
+    if provider_result.get("direct_source_verified") is not True:
+        raise DirectSourceIngressError("FAIL_CLOSED: direct source verification required")
+    if provider_result.get("session_verified") is not True:
+        raise DirectSourceIngressError("FAIL_CLOSED: provider session verification required")
+    if not provider_result.get("retrieved_at"):
+        raise DirectSourceIngressError("FAIL_CLOSED: retrieval timestamp required")
+    if not normalization_receipt_ref or not persistence_receipt_ref:
+        raise DirectSourceIngressError("FAIL_CLOSED: normalization and persistence receipts required")
+
+    intermediary = provider_result.get("intermediary") or {}
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "source_id": request["source_id"],
+        "target_domain": request["target_domain"],
+        "state": "ADMITTED_PERSISTED",
+        "direct_source_verified": True,
+        "masked_owner_reference": request.get("masked_owner_reference"),
+        "retrieved_at": provider_result["retrieved_at"],
+        "coverage_start": provider_result.get("coverage_start"),
+        "coverage_end": provider_result.get("coverage_end"),
+        "adapter_version": provider_result.get("adapter_version"),
+        "intermediary_used": bool(intermediary.get("used", False)),
+        "intermediary_name": intermediary.get("name"),
+        "freshness_state": provider_result.get("freshness_state", "UNKNOWN"),
+        "normalization_receipt_ref": normalization_receipt_ref,
+        "persistence_receipt_ref": persistence_receipt_ref,
+        "failure_reason": None,
+        "authority_effect": "NONE",
+    }
+
+
+def fail_closed_receipt(request: Dict[str, Any], reason: str) -> Dict[str, Any]:
+    assert_request(request)
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "source_id": request["source_id"],
+        "target_domain": request["target_domain"],
+        "state": "FAIL_CLOSED",
+        "direct_source_verified": False,
+        "masked_owner_reference": request.get("masked_owner_reference"),
+        "retrieved_at": None,
+        "coverage_start": None,
+        "coverage_end": None,
+        "adapter_version": None,
+        "intermediary_used": False,
+        "intermediary_name": None,
+        "freshness_state": "UNAVAILABLE",
+        "normalization_receipt_ref": None,
+        "persistence_receipt_ref": None,
+        "failure_reason": str(reason)[:512],
+        "authority_effect": "NONE",
+    }

--- a/schemas/kv-direct-source-ingress-receipt.schema.json
+++ b/schemas/kv-direct-source-ingress-receipt.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-direct-source-ingress-receipt.schema.json",
+  "title": "KnowledgeVault Direct-Source Ingress Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_id",
+    "target_domain",
+    "state",
+    "direct_source_verified",
+    "retrieved_at",
+    "freshness_state",
+    "normalization_receipt_ref",
+    "persistence_receipt_ref",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema_version": { "const": "stegverse.kv.direct-source-ingress-receipt/v1" },
+    "source_id": { "type": "string", "minLength": 1, "maxLength": 160 },
+    "target_domain": { "type": "string", "minLength": 1, "maxLength": 80 },
+    "state": {
+      "enum": ["ADMITTED_PERSISTED", "FAIL_CLOSED", "REVOKED", "SESSION_UNAVAILABLE"]
+    },
+    "direct_source_verified": { "type": "boolean" },
+    "masked_owner_reference": { "type": ["string", "null"], "maxLength": 120 },
+    "retrieved_at": { "type": ["string", "null"], "format": "date-time" },
+    "coverage_start": { "type": ["string", "null"], "format": "date-time" },
+    "coverage_end": { "type": ["string", "null"], "format": "date-time" },
+    "adapter_version": { "type": ["string", "null"], "maxLength": 80 },
+    "intermediary_used": { "type": "boolean" },
+    "intermediary_name": { "type": ["string", "null"], "maxLength": 160 },
+    "freshness_state": { "enum": ["FRESH", "STALE", "UNKNOWN", "UNAVAILABLE"] },
+    "normalization_receipt_ref": { "type": ["string", "null"], "maxLength": 256 },
+    "persistence_receipt_ref": { "type": ["string", "null"], "maxLength": 256 },
+    "failure_reason": { "type": ["string", "null"], "maxLength": 512 },
+    "authority_effect": { "const": "NONE" }
+  }
+}

--- a/schemas/kv-direct-source-ingress-request.schema.json
+++ b/schemas/kv-direct-source-ingress-request.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-direct-source-ingress-request.schema.json",
+  "title": "KnowledgeVault Direct-Source Ingress Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_id",
+    "source_kind",
+    "target_domain",
+    "skap_credential_ref",
+    "requested_access",
+    "direct_source_required",
+    "minimum_necessary",
+    "owner_authorized",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema_version": { "const": "stegverse.kv.direct-source-ingress-request/v1" },
+    "source_id": { "type": "string", "minLength": 1, "maxLength": 160 },
+    "source_kind": {
+      "enum": ["financial_institution", "brokerage", "card_issuer", "lender", "crypto_exchange", "mailbox_provider", "photo_provider", "music_provider", "tax_provider", "owner_storage", "other_direct_source"]
+    },
+    "target_domain": {
+      "enum": ["finance", "assets", "liabilities", "email", "pictures", "music", "personal", "records", "projects", "research", "archive"]
+    },
+    "provider_route": { "type": ["string", "null"], "maxLength": 512 },
+    "masked_owner_reference": { "type": ["string", "null"], "maxLength": 120 },
+    "skap_credential_ref": {
+      "type": "string",
+      "pattern": "^skap://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+$"
+    },
+    "requested_access": { "const": "READ_ONLY" },
+    "direct_source_required": { "const": true },
+    "minimum_necessary": { "const": true },
+    "owner_authorized": { "const": true },
+    "intermediary_transport": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["used", "name"],
+      "properties": {
+        "used": { "type": "boolean" },
+        "name": { "type": ["string", "null"], "maxLength": 160 },
+        "role": { "type": ["string", "null"], "maxLength": 240 }
+      }
+    },
+    "authority_effect": { "const": "NONE" }
+  }
+}

--- a/tests/test_direct_source_ingress.py
+++ b/tests/test_direct_source_ingress.py
@@ -1,0 +1,110 @@
+import unittest
+
+from runtime.direct_source_ingress import (
+    DirectSourceIngressError,
+    admit_receipt,
+    build_request,
+    fail_closed_receipt,
+)
+
+
+class DirectSourceIngressTests(unittest.TestCase):
+    def test_build_request_requires_skap(self):
+        with self.assertRaises(DirectSourceIngressError):
+            build_request(
+                source_id="example-bank",
+                source_kind="financial_institution",
+                target_domain="finance",
+                skap_credential_ref="not-skap",
+            )
+
+    def test_build_request_is_read_only_direct_source(self):
+        req = build_request(
+            source_id="example-bank",
+            source_kind="financial_institution",
+            target_domain="finance",
+            skap_credential_ref="skap://finance/example-bank",
+            masked_owner_reference="acct-1234",
+        )
+        self.assertEqual(req["requested_access"], "READ_ONLY")
+        self.assertTrue(req["direct_source_required"])
+        self.assertTrue(req["minimum_necessary"])
+        self.assertEqual(req["authority_effect"], "NONE")
+
+    def test_secret_provider_result_is_rejected(self):
+        req = build_request(
+            source_id="example-bank",
+            source_kind="financial_institution",
+            target_domain="assets",
+            skap_credential_ref="skap://finance/example-bank",
+        )
+        with self.assertRaises(DirectSourceIngressError):
+            admit_receipt(
+                req,
+                {
+                    "direct_source_verified": True,
+                    "session_verified": True,
+                    "retrieved_at": "2026-08-28T15:00:00Z",
+                    "access_token": "should-not-propagate",
+                },
+                normalization_receipt_ref="norm:1",
+                persistence_receipt_ref="kv:1",
+            )
+
+    def test_verified_direct_source_can_admit(self):
+        req = build_request(
+            source_id="example-music",
+            source_kind="music_provider",
+            target_domain="music",
+            skap_credential_ref="skap://music/example",
+        )
+        receipt = admit_receipt(
+            req,
+            {
+                "direct_source_verified": True,
+                "session_verified": True,
+                "retrieved_at": "2026-08-28T15:00:00Z",
+                "freshness_state": "FRESH",
+                "adapter_version": "synthetic-v1",
+                "intermediary": {"used": False, "name": None},
+            },
+            normalization_receipt_ref="norm:music:1",
+            persistence_receipt_ref="kv:music:1",
+        )
+        self.assertEqual(receipt["state"], "ADMITTED_PERSISTED")
+        self.assertTrue(receipt["direct_source_verified"])
+        self.assertFalse(receipt["intermediary_used"])
+
+    def test_unverified_source_fails_closed(self):
+        req = build_request(
+            source_id="example-photo",
+            source_kind="photo_provider",
+            target_domain="pictures",
+            skap_credential_ref="skap://photos/example",
+        )
+        with self.assertRaises(DirectSourceIngressError):
+            admit_receipt(
+                req,
+                {
+                    "direct_source_verified": False,
+                    "session_verified": True,
+                    "retrieved_at": "2026-08-28T15:00:00Z",
+                },
+                normalization_receipt_ref="norm:1",
+                persistence_receipt_ref="kv:1",
+            )
+
+    def test_explicit_fail_closed_receipt(self):
+        req = build_request(
+            source_id="example-mail",
+            source_kind="mailbox_provider",
+            target_domain="email",
+            skap_credential_ref="skap://mail/example",
+        )
+        receipt = fail_closed_receipt(req, "provider session unavailable")
+        self.assertEqual(receipt["state"], "FAIL_CLOSED")
+        self.assertEqual(receipt["freshness_state"], "UNAVAILABLE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),39)
+        self.assertEqual(len(workflows),40)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tools/check_kv_direct_source_ingress.py
+++ b/tools/check_kv_direct_source_ingress.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+required = [
+    ROOT / "KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md",
+    ROOT / "schemas" / "kv-direct-source-ingress-request.schema.json",
+    ROOT / "schemas" / "kv-direct-source-ingress-receipt.schema.json",
+    ROOT / "runtime" / "direct_source_ingress.py",
+    ROOT / "tests" / "test_direct_source_ingress.py",
+]
+
+for path in required:
+    if not path.exists():
+        raise SystemExit(f"missing direct-source ingress artifact: {path.relative_to(ROOT)}")
+
+request_schema = json.loads(required[1].read_text(encoding="utf-8"))
+receipt_schema = json.loads(required[2].read_text(encoding="utf-8"))
+
+if request_schema["properties"]["requested_access"].get("const") != "READ_ONLY":
+    raise SystemExit("direct-source ingress must remain read-only")
+if request_schema["properties"]["direct_source_required"].get("const") is not True:
+    raise SystemExit("direct-source-required invariant missing")
+if request_schema["properties"]["authority_effect"].get("const") != "NONE":
+    raise SystemExit("request authority must remain NONE")
+if receipt_schema["properties"]["authority_effect"].get("const") != "NONE":
+    raise SystemExit("receipt authority must remain NONE")
+
+text = "\n".join(path.read_text(encoding="utf-8") for path in [required[0], required[3]])
+for phrase in ["SKAP", "direct source", "FAIL_CLOSED", "READ_ONLY"]:
+    if phrase not in text:
+        raise SystemExit(f"missing direct-source invariant: {phrase}")
+
+print("KV direct-source ingress static checks: PASS")


### PR DESCRIPTION
Replaces #109 after finance PR #107 advanced main.

Implements issue #108 on current main.

Adds the canonical direct-source ingress contract for Personal KnowledgeVault continuity data:
- direct authoritative provider/source required;
- reusable credentials resolved through SKAP Vault;
- READ_ONLY / minimum-necessary / owner-authorized default;
- direct-source/session verification before admission;
- explicit provenance for source, masked owner binding, coverage, freshness, adapter, intermediary role, normalization, and persistence;
- fail-closed behavior when source/session/provenance/admission/persistence is unavailable;
- no silent intermediary/aggregator substitution;
- no reusable credentials or private user data in repository state.

Authority effect: NONE. No provider login is activated by this source PR.