### PR TITLE
Add Coinbase read-only finance normalization behind SKAP/TVC

### DIFF
--- a/.github/workflows/kv-coinbase-finance-ingress.yml
+++ b/.github/workflows/kv-coinbase-finance-ingress.yml
@@ -1,0 +1,30 @@
+name: Validate KV Coinbase Finance Ingress
+
+on:
+  pull_request:
+    paths:
+      - "KV_COINBASE_FINANCE_INGRESS_MIRROR_HANDOFF.md"
+      - "runtime/coinbase_finance_ingress.py"
+      - "runtime/personal_finance.py"
+      - "tests/test_coinbase_finance_ingress.py"
+      - "tools/check_kv_coinbase_finance_ingress.py"
+      - ".github/workflows/kv-coinbase-finance-ingress.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Static Coinbase finance ingress checks
+        run: python tools/check_kv_coinbase_finance_ingress.py
+      - name: Coinbase finance ingress tests
+        run: python -m unittest tests.test_coinbase_finance_ingress
+      - name: Existing Personal Finance tests
+        run: python -m unittest tests.test_personal_finance

--- a/KV_COINBASE_FINANCE_INGRESS_MIRROR_HANDOFF.md
+++ b/KV_COINBASE_FINANCE_INGRESS_MIRROR_HANDOFF.md
@@ -1,0 +1,82 @@
+# KV Coinbase Finance Ingress Mirror Handoff
+
+Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS  
+Repository: `StegVerse-Labs/continuity-vault-kit`  
+Issue: `#111`  
+Branch: `feature/kv-coinbase-finance-ingress-111`  
+Updated: 2026-08-28  
+Authority effect: NONE  
+Activation effect: false
+
+## Purpose
+
+Implement the first finance-specific direct-source normalization adapter using Coinbase as the source, while reusing the existing TVC + SKAP/InTr Coinbase session path rather than creating a new credential architecture.
+
+Canonical flow:
+
+```text
+existing TVC/SKAP Coinbase session
+ -> non-secret authenticated Coinbase read result
+ -> Coinbase finance adapter
+ -> canonical Personal Finance snapshot
+ -> private KV persistence
+ -> readback
+```
+
+## Credential and authority boundary
+
+1. This adapter does not log in to Coinbase.
+2. This adapter does not accept passwords, API keys, OAuth tokens, private keys, recovery material, or provider secrets.
+3. Provider authentication/session establishment remains owned by the existing TVC Coinbase SKAP/InTr lane.
+4. The adapter requires explicit non-secret proof that the direct source and provider session were verified.
+5. Access is read-only and minimum-necessary.
+6. No trading, payment, transfer, borrowing, card-spending, staking-action, withdrawal, or account-management authority is created.
+7. Real values belong only in the connected private KV or an admitted private runtime.
+8. Repository fixtures remain synthetic.
+
+## Normalized source coverage
+
+The first adapter may represent provider-returned:
+
+- crypto/cash-equivalent balances;
+- available vs locked balances;
+- secured-card collateral relationships;
+- reward/yield observations with as-of timestamps;
+- read-only transaction history;
+- masked account/product references;
+- source/session/provenance evidence.
+
+The adapter must preserve provider-native distinctions rather than flattening locked collateral, available cash, reward value, and liabilities into one balance.
+
+## Existing upstream dependencies
+
+- `KV_PERSONAL_FINANCE_MIRROR_HANDOFF.md`
+- `KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md`
+- `runtime/personal_finance.py`
+- `runtime/direct_source_ingress.py`
+- TVC canonical Coinbase SKAP/InTr handoff and provider-session evidence.
+
+## Planned source
+
+- `KV_COINBASE_FINANCE_INGRESS_MIRROR_HANDOFF.md`
+- `runtime/coinbase_finance_ingress.py`
+- `tests/test_coinbase_finance_ingress.py`
+- `tools/check_kv_coinbase_finance_ingress.py`
+- `.github/workflows/kv-coinbase-finance-ingress.yml`
+
+## Completion gates
+
+- finance secret-field guard false-positive repair validated;
+- synthetic Coinbase provider result normalizes deterministically;
+- direct-source/session verification required;
+- secret-bearing source payload rejected;
+- locked collateral remains separate from liquid balance;
+- execution authority remains false;
+- exact-head hosted validation passes;
+- PR merged;
+- live SKAP provider session: SEPARATE RUNTIME GATE;
+- real private-KV write/readback: SEPARATE RUNTIME GATE.
+
+## Current boundary
+
+Source implementation only. No live Coinbase login, credential resolution, provider operation, or real finance observation is performed by this repository lane.

--- a/runtime/coinbase_finance_ingress.py
+++ b/runtime/coinbase_finance_ingress.py
@@ -1,0 +1,178 @@
+"""Coinbase direct-source finance normalization.
+
+This adapter consumes a non-secret, already-authenticated Coinbase read result from
+an existing TVC/SKAP provider-session boundary. It does not perform login, token
+exchange, provider mutation, trading, transfer, withdrawal, or account management.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from runtime.personal_finance import (
+    PersonalFinanceError,
+    deterministic_id,
+    normalize_snapshot,
+    reject_secret_fields,
+)
+
+PROVIDER_NAME = "Coinbase"
+
+
+class CoinbaseFinanceIngressError(PersonalFinanceError):
+    pass
+
+
+def _require_verified(result: Dict[str, Any]) -> None:
+    if not isinstance(result, dict):
+        raise CoinbaseFinanceIngressError("Coinbase provider result must be an object")
+    reject_secret_fields(result, "$.coinbase_result")
+    if result.get("provider") != "coinbase":
+        raise CoinbaseFinanceIngressError("FAIL_CLOSED: Coinbase direct source required")
+    if result.get("direct_source_verified") is not True:
+        raise CoinbaseFinanceIngressError("FAIL_CLOSED: direct source verification required")
+    if result.get("session_verified") is not True:
+        raise CoinbaseFinanceIngressError("FAIL_CLOSED: provider session verification required")
+    if not result.get("retrieved_at"):
+        raise CoinbaseFinanceIngressError("FAIL_CLOSED: retrieval timestamp required")
+    if result.get("access") not in (None, "READ_ONLY"):
+        raise CoinbaseFinanceIngressError("FAIL_CLOSED: Coinbase finance ingress is read-only")
+    if result.get("provider_operation_authorized") not in (None, False):
+        raise CoinbaseFinanceIngressError("FAIL_CLOSED: provider operation authority prohibited")
+
+
+def _map_accounts(rows: Iterable[Dict[str, Any]], retrieved_at: str) -> list[Dict[str, Any]]:
+    mapped = []
+    for row in rows or []:
+        reject_secret_fields(row, "$.coinbase_result.accounts[]")
+        source_ref = str(row.get("source_ref") or "").strip()
+        if not source_ref:
+            raise CoinbaseFinanceIngressError("Coinbase account source_ref required")
+        display_name = str(row.get("display_name") or row.get("asset") or "Coinbase account").strip()
+        account_type = row.get("account_type") or "crypto"
+        mapped.append({
+            "account_id": deterministic_id("acct", PROVIDER_NAME, source_ref, display_name, row.get("mask")),
+            "display_name": display_name,
+            "account_type": account_type,
+            "subtype": row.get("subtype"),
+            "mask": row.get("mask"),
+            "currency": row.get("currency") or row.get("asset"),
+            "current_balance": row.get("current_balance"),
+            "available_balance": row.get("available_balance"),
+            "credit_limit": row.get("credit_limit"),
+            "as_of": row.get("as_of") or retrieved_at,
+            "source": {
+                "provider_name": PROVIDER_NAME,
+                "external_reference": source_ref,
+                "source_type": "DIRECT_PROVIDER",
+            },
+            "notes": row.get("notes"),
+        })
+    return mapped
+
+
+def _map_transactions(rows: Iterable[Dict[str, Any]]) -> list[Dict[str, Any]]:
+    mapped = []
+    for row in rows or []:
+        reject_secret_fields(row, "$.coinbase_result.transactions[]")
+        source_ref = str(row.get("source_ref") or "").strip()
+        if not source_ref:
+            raise CoinbaseFinanceIngressError("Coinbase transaction source_ref required")
+        mapped.append({
+            "transaction_id": deterministic_id("txn", PROVIDER_NAME, source_ref),
+            "account_id": row.get("account_id"),
+            "posted_at": row.get("posted_at"),
+            "description": row.get("description"),
+            "amount": row.get("amount"),
+            "currency": row.get("currency"),
+            "category": row.get("category"),
+            "pending": bool(row.get("pending", False)),
+            "source": {
+                "provider_name": PROVIDER_NAME,
+                "external_reference": source_ref,
+                "source_type": "DIRECT_PROVIDER",
+            },
+        })
+    return mapped
+
+
+def _map_rewards(rows: Iterable[Dict[str, Any]], retrieved_at: str) -> list[Dict[str, Any]]:
+    mapped = []
+    for row in rows or []:
+        reject_secret_fields(row, "$.coinbase_result.rewards[]")
+        reward_ref = str(row.get("source_ref") or "").strip()
+        if not reward_ref:
+            raise CoinbaseFinanceIngressError("Coinbase reward source_ref required")
+        mapped.append({
+            "reward_id": deterministic_id("reward", PROVIDER_NAME, reward_ref),
+            "account_id": row.get("account_id"),
+            "reward_type": row.get("reward_type") or "other",
+            "asset": row.get("asset"),
+            "rate": row.get("rate"),
+            "rate_unit": row.get("rate_unit"),
+            "earned_amount": row.get("earned_amount"),
+            "earned_asset": row.get("earned_asset"),
+            "as_of": row.get("as_of") or retrieved_at,
+            "source": {
+                "provider_name": PROVIDER_NAME,
+                "external_reference": reward_ref,
+                "source_type": "DIRECT_PROVIDER",
+            },
+            "notes": row.get("notes"),
+        })
+    return mapped
+
+
+def _map_collateral(rows: Iterable[Dict[str, Any]], retrieved_at: str) -> list[Dict[str, Any]]:
+    mapped = []
+    for row in rows or []:
+        reject_secret_fields(row, "$.coinbase_result.collateral[]")
+        source_ref = str(row.get("source_ref") or "").strip()
+        if not source_ref:
+            raise CoinbaseFinanceIngressError("Coinbase collateral source_ref required")
+        mapped.append({
+            "relationship_id": deterministic_id("collateral", PROVIDER_NAME, source_ref),
+            "collateral_account_id": row.get("collateral_account_id"),
+            "secured_account_id": row.get("secured_account_id"),
+            "asset": row.get("asset"),
+            "locked_amount": row.get("locked_amount"),
+            "purpose": row.get("purpose"),
+            "as_of": row.get("as_of") or retrieved_at,
+            "source": {
+                "provider_name": PROVIDER_NAME,
+                "external_reference": source_ref,
+                "source_type": "DIRECT_PROVIDER",
+            },
+        })
+    return mapped
+
+
+def normalize_coinbase_finance_result(provider_result: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize verified, non-secret Coinbase read data into Personal Finance."""
+
+    _require_verified(provider_result)
+    retrieved_at = provider_result["retrieved_at"]
+
+    snapshot = {
+        "schema_version": "stegverse.kv.personal-finance/v1",
+        "updated_at": retrieved_at,
+        "accounts": _map_accounts(provider_result.get("accounts", []), retrieved_at),
+        "liabilities": [],
+        "transactions": _map_transactions(provider_result.get("transactions", [])),
+        "recurring_activity": [],
+        "rewards": _map_rewards(provider_result.get("rewards", []), retrieved_at),
+        "collateral_relationships": _map_collateral(provider_result.get("collateral", []), retrieved_at),
+        "provenance": [{
+            "provider_name": PROVIDER_NAME,
+            "source_type": "DIRECT_PROVIDER",
+            "retrieved_at": retrieved_at,
+            "coverage_start": provider_result.get("coverage_start"),
+            "coverage_end": provider_result.get("coverage_end"),
+            "adapter_version": provider_result.get("adapter_version") or "coinbase-finance-ingress/v1",
+            "session_evidence_ref": provider_result.get("session_evidence_ref"),
+            "direct_source_verified": True,
+            "intermediary_used": bool(provider_result.get("intermediary_used", False)),
+        }],
+        "execution_authority": False,
+    }
+    return normalize_snapshot(snapshot)

--- a/runtime/personal_finance.py
+++ b/runtime/personal_finance.py
@@ -59,7 +59,8 @@ def reject_secret_fields(value: Any, path: str = "$") -> None:
     if isinstance(value, dict):
         for key, child in value.items():
             normalized = _normalized_key(str(key))
-            if any(fragment == normalized or fragment in normalized for fragment in FORBIDDEN_KEY_FRAGMENTS):
+            padded = f"_{normalized}_"
+            if any(fragment == normalized or f"_{fragment}_" in padded for fragment in FORBIDDEN_KEY_FRAGMENTS):
                 raise PersonalFinanceError(f"forbidden secret-bearing field at {path}.{key}")
             reject_secret_fields(child, f"{path}.{key}")
     elif isinstance(value, list):

--- a/tests/test_coinbase_finance_ingress.py
+++ b/tests/test_coinbase_finance_ingress.py
@@ -1,0 +1,126 @@
+import unittest
+
+from runtime.coinbase_finance_ingress import (
+    CoinbaseFinanceIngressError,
+    normalize_coinbase_finance_result,
+)
+from runtime.personal_finance import reject_secret_fields
+
+
+class CoinbaseFinanceIngressTests(unittest.TestCase):
+    def synthetic_result(self):
+        return {
+            "provider": "coinbase",
+            "direct_source_verified": True,
+            "session_verified": True,
+            "access": "READ_ONLY",
+            "provider_operation_authorized": False,
+            "retrieved_at": "2026-08-28T16:00:00Z",
+            "coverage_start": "2026-08-01T00:00:00Z",
+            "coverage_end": "2026-08-28T16:00:00Z",
+            "adapter_version": "synthetic-v1",
+            "session_evidence_ref": "receipt:synthetic-session",
+            "accounts": [
+                {
+                    "source_ref": "coinbase-usdc-wallet",
+                    "display_name": "USDC",
+                    "account_type": "crypto",
+                    "asset": "USDC",
+                    "currency": "USD",
+                    "current_balance": 1000.0,
+                    "available_balance": 0.0,
+                    "as_of": "2026-08-28T16:00:00Z",
+                },
+                {
+                    "source_ref": "coinbase-secured-card",
+                    "display_name": "Coinbase Secured Card",
+                    "account_type": "credit",
+                    "subtype": "secured_card",
+                    "mask": "1234",
+                    "current_balance": 75.0,
+                    "credit_limit": 1000.0,
+                    "currency": "USD",
+                },
+            ],
+            "transactions": [
+                {
+                    "source_ref": "txn-1",
+                    "posted_at": "2026-08-27T12:00:00Z",
+                    "description": "Synthetic purchase",
+                    "amount": -25.0,
+                    "currency": "USD",
+                    "category": "purchase",
+                    "pending": False,
+                }
+            ],
+            "rewards": [
+                {
+                    "source_ref": "usdc-reward-program",
+                    "reward_type": "apy",
+                    "asset": "USDC",
+                    "rate": 6.5,
+                    "rate_unit": "PERCENT_APY",
+                    "earned_amount": 10.0,
+                    "earned_asset": "USDC",
+                },
+                {
+                    "source_ref": "btc-card-reward",
+                    "reward_type": "crypto_back",
+                    "asset": "BTC",
+                    "rate": 1.0,
+                    "rate_unit": "PERCENT",
+                },
+            ],
+            "collateral": [
+                {
+                    "source_ref": "secured-card-usdc-collateral",
+                    "asset": "USDC",
+                    "locked_amount": 1000.0,
+                    "purpose": "SECURED_CARD_COLLATERAL",
+                }
+            ],
+        }
+
+    def test_synthetic_result_normalizes(self):
+        snapshot = normalize_coinbase_finance_result(self.synthetic_result())
+        self.assertEqual(snapshot["schema_version"], "stegverse.kv.personal-finance/v1")
+        self.assertFalse(snapshot["execution_authority"])
+        self.assertEqual(len(snapshot["accounts"]), 2)
+        self.assertEqual(len(snapshot["rewards"]), 2)
+        self.assertEqual(snapshot["collateral_relationships"][0]["locked_amount"], 1000.0)
+        self.assertTrue(snapshot["snapshot_hash"])
+
+    def test_direct_source_required(self):
+        result = self.synthetic_result()
+        result["direct_source_verified"] = False
+        with self.assertRaises(CoinbaseFinanceIngressError):
+            normalize_coinbase_finance_result(result)
+
+    def test_session_required(self):
+        result = self.synthetic_result()
+        result["session_verified"] = False
+        with self.assertRaises(CoinbaseFinanceIngressError):
+            normalize_coinbase_finance_result(result)
+
+    def test_provider_operation_authority_rejected(self):
+        result = self.synthetic_result()
+        result["provider_operation_authorized"] = True
+        with self.assertRaises(CoinbaseFinanceIngressError):
+            normalize_coinbase_finance_result(result)
+
+    def test_secret_field_rejected(self):
+        result = self.synthetic_result()
+        result["access_token"] = "synthetic-secret"
+        with self.assertRaises(Exception):
+            normalize_coinbase_finance_result(result)
+
+    def test_spending_field_name_does_not_trip_pin_fragment(self):
+        reject_secret_fields({"spending_category": "food"})
+
+    def test_actual_pin_field_remains_rejected(self):
+        with self.assertRaises(Exception):
+            reject_secret_fields({"pin": "0000"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),40)
+        self.assertEqual(len(workflows),41)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tools/check_kv_coinbase_finance_ingress.py
+++ b/tools/check_kv_coinbase_finance_ingress.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+required = [
+    ROOT / "KV_COINBASE_FINANCE_INGRESS_MIRROR_HANDOFF.md",
+    ROOT / "runtime" / "coinbase_finance_ingress.py",
+    ROOT / "tests" / "test_coinbase_finance_ingress.py",
+]
+
+for path in required:
+    if not path.exists():
+        raise SystemExit(f"missing Coinbase finance ingress artifact: {path.relative_to(ROOT)}")
+
+runtime = required[1].read_text(encoding="utf-8")
+handoff = required[0].read_text(encoding="utf-8")
+
+for marker in [
+    "direct_source_verified",
+    "session_verified",
+    "READ_ONLY",
+    "provider_operation_authorized",
+    "execution_authority",
+]:
+    if marker not in runtime:
+        raise SystemExit(f"missing Coinbase finance ingress invariant: {marker}")
+
+for forbidden in ["COINBASE_API_KEY", "COINBASE_API_SECRET", "password =", "access_token ="]:
+    if forbidden in runtime:
+        raise SystemExit(f"credential-bearing implementation prohibited: {forbidden}")
+
+if "does not log in to Coinbase" not in handoff:
+    raise SystemExit("handoff must preserve existing TVC/SKAP authentication ownership")
+
+print("KV Coinbase finance ingress static checks: PASS")


### PR DESCRIPTION
Implements #111.

This is the first provider-specific finance normalization adapter behind the existing TVC/SKAP provider-session boundary.

It does not authenticate to Coinbase and accepts no reusable credentials. It requires non-secret direct-source/session verification, READ_ONLY semantics, and no provider-operation authority before mapping Coinbase-native balances, transactions, rewards/yield, and locked collateral into the canonical Personal Finance snapshot.

Also repairs the Personal Finance secret-field guard so benign keys such as `spending_category` are not rejected merely because they contain the substring `pin`, while exact/token-boundary secret fields remain prohibited.

Repository fixtures are synthetic only. Live SKAP login and private-KV write/readback remain separate runtime gates.