### PR TITLE
Make Personal KV a governed connection-assembly source

### DIFF
--- a/.github/workflows/kv-connection-assembly.yml
+++ b/.github/workflows/kv-connection-assembly.yml
@@ -1,0 +1,32 @@
+name: Validate KV Connection Assembly
+
+on:
+  pull_request:
+    paths:
+      - "KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md"
+      - "schemas/kv-connection-assembly*.json"
+      - "schemas/kv-source-change-observation.schema.json"
+      - "specs/kv-connection-assembly-registry.v1.json"
+      - "runtime/connection_assembly.py"
+      - "runtime/source_change_monitor.py"
+      - "tests/test_connection_assembly.py"
+      - "tests/test_source_change_monitor.py"
+      - "tools/check_kv_connection_assembly.py"
+      - ".github/workflows/kv-connection-assembly.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Static connection assembly checks
+        run: python tools/check_kv_connection_assembly.py
+      - name: Connection assembly tests
+        run: python -m unittest tests.test_connection_assembly tests.test_source_change_monitor

--- a/KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md
+++ b/KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md
@@ -1,0 +1,160 @@
+# KV Connection Assembly Source Mirror Handoff
+
+Status: SOURCE_LANE_OPEN / ARCHITECTURE_DEFINITION
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: TBD
+Branch: `feature/kv-connection-assembly-source`
+Updated: 2026-08-28
+Authority effect: NONE
+Activation effect: false
+
+## Purpose
+
+Evolve Personal KnowledgeVault from only a durable continuity destination into a governed connection-assembly source for its own ingress and egress Interlock/InTr paths.
+
+The KV should retain enough non-secret source/provider knowledge to deterministically assemble, validate, monitor, and repair the connection contract for each admitted data source without turning KV into credential authority or external-provider execution authority.
+
+Canonical model:
+
+```text
+provider/source facts
+ -> provider capability registry
+ -> source-specific connection assembly profile
+ -> SKAP/TVC credential/session references
+ -> Interlock/InTr ingress/egress route
+ -> live conformance observation
+ -> KV data/readback
+ -> source-change monitoring
+ -> compatibility impact assessment
+ -> route repair/revalidation when required
+```
+
+## Governing principles
+
+1. The external provider remains factual source authority.
+2. TV/TVC remains credential/secret/token authority.
+3. SKAP remains reusable credential custody/session boundary.
+4. KnowledgeVault may own durable non-secret connection metadata, route assembly intent, compatibility evidence, and source-change history.
+5. Site/My KV may display connection health and compatibility state but does not own provider execution.
+6. Provider capability facts remain canonical in `KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md`; this lane consumes that registry and must not create a duplicate provider-fact registry.
+7. Direct-source ingress remains governed by `KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md`.
+8. Any provider mutation/write/send/trade/payment/delete authority remains a separate governed capability.
+
+## Connection assembly record
+
+A provider connection assembly should be derivable from bounded, non-secret records describing:
+
+- provider/source identifier;
+- provider product/account class;
+- direct source route class;
+- required authentication mechanism class;
+- SKAP credential/session reference class, never reusable secret value;
+- device/platform/browser/runtime requirements where relevant;
+- ingress endpoint/surface;
+- egress endpoint/surface where separately authorized;
+- required Interlock/InTr hops;
+- normalization adapter/version;
+- canonical KV target path/domain;
+- source provenance requirements;
+- expected refresh/observation cadence;
+- provider capability version/date;
+- known limitations;
+- compatibility state;
+- last successful connection proof;
+- last successful data readback proof;
+- change-monitor state;
+- repair/revalidation state.
+
+## Source-change monitoring
+
+The connection assembly must support monitoring of authoritative source/provider changes that can affect KV/InTr compatibility, including:
+
+- API version changes;
+- authentication/OAuth changes;
+- MFA/session changes;
+- endpoint changes;
+- deprecation notices;
+- provider changelogs;
+- SDK/library compatibility notices where an adapter depends on them;
+- rate-limit changes;
+- permission/scope changes;
+- product/account model changes;
+- data-schema changes;
+- file/export format changes;
+- browser/platform support changes;
+- provider outage/service-health changes where relevant.
+
+Monitoring evidence must identify source, observation time, affected connection assembly IDs, compatibility impact, and whether revalidation is required.
+
+## Compatibility states
+
+Initial state model:
+
+```text
+UNASSEMBLED
+ASSEMBLED_UNVERIFIED
+VERIFIED
+DEGRADED
+REVALIDATION_REQUIRED
+BLOCKED_SOURCE_CHANGE
+BLOCKED_SESSION
+BLOCKED_RUNTIME
+RETIRED
+```
+
+A source change may never silently remain `VERIFIED` when its declared compatibility assumptions have changed.
+
+## Repair semantics
+
+Connection repair is a governed reconstruction process, not an ad hoc reconnect:
+
+```text
+source change observed
+ -> determine impacted assumptions
+ -> invalidate stale verification
+ -> rebuild bounded route/profile if source contract permits
+ -> re-run conformance proof
+ -> re-establish SKAP/TVC session binding if required
+ -> prove KV readback
+ -> emit new connection receipt
+```
+
+Credential values remain inaccessible to the assembly record.
+
+## Planned canonical artifacts
+
+- `KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md`
+- `schemas/kv-connection-assembly.schema.json`
+- `schemas/kv-source-change-observation.schema.json`
+- `schemas/kv-connection-health-receipt.schema.json`
+- `runtime/connection_assembly.py`
+- `runtime/source_change_monitor.py`
+- `tests/test_connection_assembly.py`
+- `tests/test_source_change_monitor.py`
+- `tools/check_kv_connection_assembly.py`
+- read-only validation workflow
+
+## Non-goals
+
+This lane does not:
+
+- store passwords/tokens/private keys;
+- replace TV/TVC or SKAP;
+- perform provider login by itself;
+- create a second provider capability registry;
+- make GitHub Actions production monitoring authority;
+- grant provider write/mutation authority;
+- claim live provider compatibility without observed conformance evidence.
+
+## Immediate implementation order
+
+1. Define the connection assembly schema referencing the existing provider capability registry.
+2. Define source-change observation and connection-health receipt schemas.
+3. Implement deterministic assembly validation and compatibility-state transitions.
+4. Add synthetic provider-change tests.
+5. Bind Coinbase as the first source-specific assembly consumer after the existing SKAP/TVC runtime is live-proven.
+6. Later project connection health into My KV Site.
+
+## Current boundary
+
+Architecture/source lane only. No source monitoring process is live, no provider change has been observed by this lane, no connection has been activated, and no credential or provider execution authority is granted.

--- a/KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md
+++ b/KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md
@@ -2,7 +2,7 @@
 
 Status: SOURCE_LANE_OPEN / ARCHITECTURE_DEFINITION
 Repository: `StegVerse-Labs/continuity-vault-kit`
-Issue: TBD
+Issue: #113
 Branch: `feature/kv-connection-assembly-source`
 Updated: 2026-08-28
 Authority effect: NONE

--- a/KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md
+++ b/KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Connection Assembly Source Mirror Handoff
 
-Status: SOURCE_LANE_OPEN / ARCHITECTURE_DEFINITION
+Status: SOURCE_IMPLEMENTED_ON_BRANCH / VALIDATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #113
 Branch: `feature/kv-connection-assembly-source`
@@ -125,6 +125,8 @@ Credential values remain inaccessible to the assembly record.
 
 - `KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md`
 - `schemas/kv-connection-assembly.schema.json`
+- `schemas/kv-connection-assembly-registry.schema.json`
+- `specs/kv-connection-assembly-registry.v1.json`
 - `schemas/kv-source-change-observation.schema.json`
 - `schemas/kv-connection-health-receipt.schema.json`
 - `runtime/connection_assembly.py`
@@ -157,4 +159,4 @@ This lane does not:
 
 ## Current boundary
 
-Architecture/source lane only. No source monitoring process is live, no provider change has been observed by this lane, no connection has been activated, and no credential or provider execution authority is granted.
+Machine-executable source contract is implemented on this branch. No source monitoring process is live, no provider change has been observed by this lane, no connection has been activated, and no credential or provider execution authority is granted.

--- a/runtime/connection_assembly.py
+++ b/runtime/connection_assembly.py
@@ -1,0 +1,129 @@
+"""Deterministic, non-secret KnowledgeVault connection assembly helpers."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from typing import Any, Dict
+
+ASSEMBLY_SCHEMA = "stegverse.kv.connection-assembly/v1"
+HEALTH_SCHEMA = "stegverse.kv.connection-health-receipt/v1"
+
+ALLOWED_STATES = {
+    "UNASSEMBLED","ASSEMBLED_UNVERIFIED","VERIFIED","DEGRADED",
+    "REVALIDATION_REQUIRED","BLOCKED_SOURCE_CHANGE","BLOCKED_SESSION",
+    "BLOCKED_RUNTIME","RETIRED",
+}
+FORBIDDEN_KEYS = {
+    "password","passcode","pin","cvv","cvc","card_number","account_number",
+    "routing_number","private_key","recovery_code","refresh_token","access_token",
+    "oauth_token","api_key","secret","client_secret","authorization",
+}
+
+class ConnectionAssemblyError(ValueError):
+    pass
+
+def _norm(key: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", key.lower()).strip("_")
+
+def reject_secret_fields(value: Any, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized = _norm(str(key))
+            padded = f"_{normalized}_"
+            if any(fragment == normalized or f"_{fragment}_" in padded for fragment in FORBIDDEN_KEYS):
+                raise ConnectionAssemblyError(f"forbidden credential-bearing field at {path}.{key}")
+            reject_secret_fields(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_secret_fields(child, f"{path}[{index}]")
+
+def deterministic_assembly_id(provider: str, target_domain: str, canonical_kv_path: str, adapter_name: str) -> str:
+    material = "|".join(part.strip().lower() for part in (provider,target_domain,canonical_kv_path,adapter_name))
+    return "kvcxn_" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:24]
+
+def canonical_hash(value: Dict[str, Any]) -> str:
+    return hashlib.sha256(json.dumps(value,sort_keys=True,separators=(",",":"),ensure_ascii=False).encode("utf-8")).hexdigest()
+
+def assemble_connection(spec: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(spec, dict):
+        raise ConnectionAssemblyError("connection specification must be an object")
+    reject_secret_fields(spec)
+    result = copy.deepcopy(spec)
+    if result.get("access") not in (None,"READ_ONLY"):
+        raise ConnectionAssemblyError("connection assembly access must be READ_ONLY")
+    if result.get("direct_source_required") not in (None,True):
+        raise ConnectionAssemblyError("direct_source_required must remain true")
+    if result.get("minimum_necessary") not in (None,True):
+        raise ConnectionAssemblyError("minimum_necessary must remain true")
+    if result.get("credential_authority") not in (None,"TV/TVC"):
+        raise ConnectionAssemblyError("credential authority must remain TV/TVC")
+    if result.get("authority_effect") not in (None,"NONE"):
+        raise ConnectionAssemblyError("authority effect must remain NONE")
+    for required in ("provider","source_kind","target_domain","canonical_kv_path","adapter","provider_capability_binding","intr_hops","monitoring"):
+        if not result.get(required):
+            raise ConnectionAssemblyError(f"missing connection assembly field: {required}")
+    if not isinstance(result["adapter"],dict) or not result["adapter"].get("name") or not result["adapter"].get("version"):
+        raise ConnectionAssemblyError("adapter name/version required")
+    if not isinstance(result["intr_hops"],list) or not result["intr_hops"]:
+        raise ConnectionAssemblyError("at least one InTr hop required")
+    result["schema"] = ASSEMBLY_SCHEMA
+    result["assembly_id"] = deterministic_assembly_id(
+        result["provider"], result["target_domain"], result["canonical_kv_path"], result["adapter"]["name"]
+    )
+    result["access"] = "READ_ONLY"
+    result["direct_source_required"] = True
+    result["minimum_necessary"] = True
+    result["credential_authority"] = "TV/TVC"
+    result.setdefault("credential_reference_class","SKAP_REFERENCE")
+    result.setdefault("authentication_mechanism_class",None)
+    result.setdefault("ingress_surface",None)
+    result.setdefault("egress_surface",None)
+    result.setdefault("last_connection_proof_ref",None)
+    result.setdefault("last_readback_proof_ref",None)
+    result.setdefault("compatibility_state","ASSEMBLED_UNVERIFIED")
+    if result["compatibility_state"] not in ALLOWED_STATES:
+        raise ConnectionAssemblyError("invalid compatibility state")
+    result["authority_effect"] = "NONE"
+    return result
+
+def verify_connection(assembly: Dict[str, Any], *, observed_at: str, connection_proof_ref: str, readback_proof_ref: str) -> tuple[Dict[str,Any],Dict[str,Any]]:
+    current = assemble_connection(assembly)
+    if current["compatibility_state"] == "RETIRED":
+        raise ConnectionAssemblyError("retired connection cannot be verified")
+    if not connection_proof_ref or not readback_proof_ref:
+        raise ConnectionAssemblyError("connection and KV readback proof are both required")
+    prior = current["compatibility_state"]
+    current["compatibility_state"] = "VERIFIED"
+    current["last_connection_proof_ref"] = connection_proof_ref
+    current["last_readback_proof_ref"] = readback_proof_ref
+    receipt = health_receipt(
+        current, observed_at=observed_at, prior_state=prior, current_state="VERIFIED",
+        reason="CONNECTION_AND_KV_READBACK_VERIFIED", revalidation_required=False,
+        connection_proof_ref=connection_proof_ref, readback_proof_ref=readback_proof_ref,
+    )
+    return current, receipt
+
+def health_receipt(assembly: Dict[str,Any], *, observed_at: str, prior_state: str, current_state: str, reason: str,
+                   revalidation_required: bool, change_observation_ref: str|None=None,
+                   connection_proof_ref: str|None=None, readback_proof_ref: str|None=None) -> Dict[str,Any]:
+    if prior_state not in ALLOWED_STATES or current_state not in ALLOWED_STATES:
+        raise ConnectionAssemblyError("invalid health state")
+    return {
+        "schema": HEALTH_SCHEMA,
+        "assembly_id": assembly["assembly_id"],
+        "provider": assembly["provider"],
+        "observed_at": observed_at,
+        "prior_state": prior_state,
+        "current_state": current_state,
+        "reason": reason,
+        "change_observation_ref": change_observation_ref,
+        "revalidation_required": revalidation_required,
+        "connection_proof_ref": connection_proof_ref,
+        "readback_proof_ref": readback_proof_ref,
+        "provider_operation_authorized": False,
+        "credential_material_present": False,
+        "authority_effect": "NONE",
+    }

--- a/runtime/source_change_monitor.py
+++ b/runtime/source_change_monitor.py
@@ -1,0 +1,73 @@
+"""Pure compatibility-state transition logic for provider/source change observations.
+
+This module does not perform network monitoring. Production observation belongs on an
+admitted resident machine surface; this code evaluates already-observed non-secret facts.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from typing import Any, Dict
+
+from runtime.connection_assembly import (
+    ConnectionAssemblyError, assemble_connection, health_receipt, reject_secret_fields,
+)
+
+CHANGE_SCHEMA = "stegverse.kv.source-change-observation/v1"
+BLOCKING_CLASSES = {"authentication","mfa_session","endpoint","deprecation","permission_scope","data_schema","product_model"}
+
+def deterministic_observation_id(provider: str, source_ref: str, observed_at: str, change_class: str) -> str:
+    material = "|".join((provider,source_ref,observed_at,change_class)).lower()
+    return "kvchg_" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:24]
+
+def normalize_change_observation(value: Dict[str,Any]) -> Dict[str,Any]:
+    if not isinstance(value,dict):
+        raise ConnectionAssemblyError("change observation must be an object")
+    reject_secret_fields(value)
+    for field in ("provider","observed_at","source_ref","source_type","change_class","severity","summary"):
+        if not value.get(field):
+            raise ConnectionAssemblyError(f"missing source change field: {field}")
+    result=copy.deepcopy(value)
+    result["schema"]=CHANGE_SCHEMA
+    result["observation_id"]=deterministic_observation_id(
+        result["provider"],result["source_ref"],result["observed_at"],result["change_class"]
+    )
+    result.setdefault("breaking",False)
+    result.setdefault("affected_assumptions",[])
+    result.setdefault("effective_at",None)
+    result["authority_effect"]="NONE"
+    return result
+
+def evaluate_source_change(assembly: Dict[str,Any], observation: Dict[str,Any]) -> tuple[Dict[str,Any],Dict[str,Any]]:
+    current=assemble_connection(assembly)
+    change=normalize_change_observation(observation)
+    if current["provider"].lower() != change["provider"].lower():
+        raise ConnectionAssemblyError("source change provider does not match assembly")
+    prior=current["compatibility_state"]
+    if prior == "RETIRED":
+        receipt=health_receipt(current,observed_at=change["observed_at"],prior_state=prior,current_state=prior,
+                               reason="RETIRED_CONNECTION_UNCHANGED",revalidation_required=False,
+                               change_observation_ref=change["observation_id"])
+        return current,receipt
+
+    monitored=set(current["monitoring"].get("change_classes") or [])
+    if change["change_class"] not in monitored:
+        receipt=health_receipt(current,observed_at=change["observed_at"],prior_state=prior,current_state=prior,
+                               reason="CHANGE_CLASS_NOT_MONITORED_FOR_ASSEMBLY",revalidation_required=False,
+                               change_observation_ref=change["observation_id"])
+        return current,receipt
+
+    blocking=bool(change.get("breaking")) and change["change_class"] in BLOCKING_CLASSES
+    new_state="BLOCKED_SOURCE_CHANGE" if blocking else "REVALIDATION_REQUIRED"
+    current["compatibility_state"]=new_state
+    current["monitoring"]["last_checked_at"]=change["observed_at"]
+    current["monitoring"]["last_change_ref"]=change["observation_id"]
+    receipt=health_receipt(
+        current,observed_at=change["observed_at"],prior_state=prior,current_state=new_state,
+        reason="BREAKING_SOURCE_CHANGE" if blocking else "SOURCE_CHANGE_REVALIDATION_REQUIRED",
+        revalidation_required=True,change_observation_ref=change["observation_id"],
+        connection_proof_ref=current.get("last_connection_proof_ref"),
+        readback_proof_ref=current.get("last_readback_proof_ref"),
+    )
+    return current,receipt

--- a/schemas/kv-connection-assembly-registry.schema.json
+++ b/schemas/kv-connection-assembly-registry.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/kv-connection-assembly-registry.schema.json",
+  "title":"KnowledgeVault connection assembly registry",
+  "type":"object",
+  "required":["schema","state","authority_effect","assemblies"],
+  "properties":{
+    "schema":{"const":"stegverse.kv.connection-assembly-registry/v1"},
+    "state":{"enum":["EMPTY","ASSEMBLED_UNVERIFIED","PARTIALLY_VERIFIED","VERIFIED","DEGRADED"]},
+    "authority_effect":{"const":"NONE"},
+    "assemblies":{"type":"array","items":{"$ref":"kv-connection-assembly.schema.json"}}
+  },
+  "additionalProperties":false
+}

--- a/schemas/kv-connection-assembly.schema.json
+++ b/schemas/kv-connection-assembly.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-connection-assembly.schema.json",
+  "title": "KnowledgeVault connection assembly",
+  "type": "object",
+  "required": ["schema","assembly_id","provider","source_kind","target_domain","canonical_kv_path","access","direct_source_required","minimum_necessary","credential_authority","credential_reference_class","intr_hops","adapter","provider_capability_binding","compatibility_state","monitoring","authority_effect"],
+  "properties": {
+    "schema": {"const":"stegverse.kv.connection-assembly/v1"},
+    "assembly_id": {"type":"string","pattern":"^kvcxn_[a-f0-9]{24}$"},
+    "provider": {"type":"string","minLength":1},
+    "source_kind": {"type":"string","minLength":1},
+    "target_domain": {"enum":["finance","assets","liabilities","email","pictures","music","personal","records","projects","research","archive"]},
+    "canonical_kv_path": {"type":"string","minLength":1},
+    "access": {"const":"READ_ONLY"},
+    "direct_source_required": {"const":true},
+    "minimum_necessary": {"const":true},
+    "credential_authority": {"const":"TV/TVC"},
+    "credential_reference_class": {"enum":["SKAP_REFERENCE","SESSION_REFERENCE","NONE"]},
+    "authentication_mechanism_class": {"type":["string","null"]},
+    "ingress_surface": {"type":["string","null"]},
+    "egress_surface": {"type":["string","null"]},
+    "intr_hops": {"type":"array","minItems":1,"items":{"type":"string","minLength":1}},
+    "adapter": {
+      "type":"object",
+      "required":["name","version"],
+      "properties":{"name":{"type":"string","minLength":1},"version":{"type":"string","minLength":1}},
+      "additionalProperties":false
+    },
+    "provider_capability_binding": {
+      "type":"object",
+      "required":["registry_schema","provider","observation_selector","evidence_version"],
+      "properties":{
+        "registry_schema":{"const":"stegverse.kv.provider-surface-capability-registry/v1"},
+        "provider":{"type":"string","minLength":1},
+        "observation_selector":{"type":"object"},
+        "evidence_version":{"type":["string","null"]}
+      },
+      "additionalProperties":false
+    },
+    "compatibility_state": {"enum":["UNASSEMBLED","ASSEMBLED_UNVERIFIED","VERIFIED","DEGRADED","REVALIDATION_REQUIRED","BLOCKED_SOURCE_CHANGE","BLOCKED_SESSION","BLOCKED_RUNTIME","RETIRED"]},
+    "last_connection_proof_ref": {"type":["string","null"]},
+    "last_readback_proof_ref": {"type":["string","null"]},
+    "monitoring": {
+      "type":"object",
+      "required":["enabled","authoritative_sources","change_classes","last_checked_at","last_change_ref"],
+      "properties":{
+        "enabled":{"type":"boolean"},
+        "authoritative_sources":{"type":"array","items":{"type":"string","minLength":1}},
+        "change_classes":{"type":"array","items":{"enum":["api_version","authentication","mfa_session","endpoint","deprecation","changelog","sdk_dependency","rate_limit","permission_scope","product_model","data_schema","export_format","browser_platform","service_health"]}},
+        "last_checked_at":{"type":["string","null"]},
+        "last_change_ref":{"type":["string","null"]}
+      },
+      "additionalProperties":false
+    },
+    "authority_effect": {"const":"NONE"}
+  },
+  "additionalProperties": false
+}

--- a/schemas/kv-connection-health-receipt.schema.json
+++ b/schemas/kv-connection-health-receipt.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/kv-connection-health-receipt.schema.json",
+  "title":"KnowledgeVault connection health receipt",
+  "type":"object",
+  "required":["schema","assembly_id","provider","observed_at","prior_state","current_state","reason","revalidation_required","provider_operation_authorized","credential_material_present","authority_effect"],
+  "properties":{
+    "schema":{"const":"stegverse.kv.connection-health-receipt/v1"},
+    "assembly_id":{"type":"string","pattern":"^kvcxn_[a-f0-9]{24}$"},
+    "provider":{"type":"string","minLength":1},
+    "observed_at":{"type":"string","minLength":1},
+    "prior_state":{"enum":["UNASSEMBLED","ASSEMBLED_UNVERIFIED","VERIFIED","DEGRADED","REVALIDATION_REQUIRED","BLOCKED_SOURCE_CHANGE","BLOCKED_SESSION","BLOCKED_RUNTIME","RETIRED"]},
+    "current_state":{"enum":["UNASSEMBLED","ASSEMBLED_UNVERIFIED","VERIFIED","DEGRADED","REVALIDATION_REQUIRED","BLOCKED_SOURCE_CHANGE","BLOCKED_SESSION","BLOCKED_RUNTIME","RETIRED"]},
+    "reason":{"type":"string","minLength":1},
+    "change_observation_ref":{"type":["string","null"]},
+    "revalidation_required":{"type":"boolean"},
+    "connection_proof_ref":{"type":["string","null"]},
+    "readback_proof_ref":{"type":["string","null"]},
+    "provider_operation_authorized":{"const":false},
+    "credential_material_present":{"const":false},
+    "authority_effect":{"const":"NONE"}
+  },
+  "additionalProperties":false
+}

--- a/schemas/kv-source-change-observation.schema.json
+++ b/schemas/kv-source-change-observation.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/kv-source-change-observation.schema.json",
+  "title":"KnowledgeVault source change observation",
+  "type":"object",
+  "required":["schema","observation_id","provider","observed_at","source_ref","source_type","change_class","severity","breaking","affected_assumptions","summary","authority_effect"],
+  "properties":{
+    "schema":{"const":"stegverse.kv.source-change-observation/v1"},
+    "observation_id":{"type":"string","pattern":"^kvchg_[a-f0-9]{24}$"},
+    "provider":{"type":"string","minLength":1},
+    "observed_at":{"type":"string","minLength":1},
+    "source_ref":{"type":"string","minLength":1},
+    "source_type":{"enum":["provider_documentation","provider_changelog","provider_status","stegverse_conformance_observation"]},
+    "change_class":{"enum":["api_version","authentication","mfa_session","endpoint","deprecation","changelog","sdk_dependency","rate_limit","permission_scope","product_model","data_schema","export_format","browser_platform","service_health"]},
+    "severity":{"enum":["INFO","LOW","MEDIUM","HIGH","CRITICAL"]},
+    "breaking":{"type":"boolean"},
+    "affected_assumptions":{"type":"array","items":{"type":"string","minLength":1}},
+    "summary":{"type":"string","minLength":1},
+    "effective_at":{"type":["string","null"]},
+    "authority_effect":{"const":"NONE"}
+  },
+  "additionalProperties":false
+}

--- a/specs/kv-connection-assembly-registry.v1.json
+++ b/specs/kv-connection-assembly-registry.v1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "stegverse.kv.connection-assembly-registry/v1",
+  "state": "EMPTY",
+  "authority_effect": "NONE",
+  "assemblies": []
+}

--- a/tests/test_connection_assembly.py
+++ b/tests/test_connection_assembly.py
@@ -1,0 +1,60 @@
+import unittest
+from runtime.connection_assembly import ConnectionAssemblyError, assemble_connection, verify_connection
+
+class ConnectionAssemblyTests(unittest.TestCase):
+    def spec(self):
+        return {
+            "provider":"coinbase",
+            "source_kind":"crypto_exchange",
+            "target_domain":"finance",
+            "canonical_kv_path":"03_Records/Finance",
+            "access":"READ_ONLY",
+            "direct_source_required":True,
+            "minimum_necessary":True,
+            "credential_authority":"TV/TVC",
+            "credential_reference_class":"SKAP_REFERENCE",
+            "authentication_mechanism_class":"provider_native_session",
+            "ingress_surface":"provider_api",
+            "egress_surface":None,
+            "intr_hops":["SKAP","TVC","Provider","KV"],
+            "adapter":{"name":"coinbase-finance-ingress","version":"v1"},
+            "provider_capability_binding":{
+                "registry_schema":"stegverse.kv.provider-surface-capability-registry/v1",
+                "provider":"coinbase",
+                "observation_selector":{"access_surface":"direct_api"},
+                "evidence_version":None
+            },
+            "monitoring":{
+                "enabled":True,
+                "authoritative_sources":["provider:coinbase:docs","provider:coinbase:changelog"],
+                "change_classes":["api_version","authentication","mfa_session","endpoint","deprecation","changelog","rate_limit","permission_scope","product_model","data_schema","service_health"],
+                "last_checked_at":None,
+                "last_change_ref":None
+            },
+            "authority_effect":"NONE"
+        }
+
+    def test_deterministic_assembly(self):
+        a=assemble_connection(self.spec()); b=assemble_connection(self.spec())
+        self.assertEqual(a["assembly_id"],b["assembly_id"])
+        self.assertEqual(a["compatibility_state"],"ASSEMBLED_UNVERIFIED")
+        self.assertEqual(a["credential_authority"],"TV/TVC")
+
+    def test_secret_rejected(self):
+        s=self.spec(); s["access_token"]="synthetic"
+        with self.assertRaises(ConnectionAssemblyError): assemble_connection(s)
+
+    def test_write_access_rejected(self):
+        s=self.spec(); s["access"]="READ_WRITE"
+        with self.assertRaises(ConnectionAssemblyError): assemble_connection(s)
+
+    def test_verified_requires_connection_and_readback(self):
+        a=assemble_connection(self.spec())
+        with self.assertRaises(ConnectionAssemblyError):
+            verify_connection(a,observed_at="2026-08-28T16:00:00Z",connection_proof_ref="proof:connection",readback_proof_ref="")
+        updated,receipt=verify_connection(a,observed_at="2026-08-28T16:00:00Z",connection_proof_ref="proof:connection",readback_proof_ref="proof:kv-readback")
+        self.assertEqual(updated["compatibility_state"],"VERIFIED")
+        self.assertFalse(receipt["provider_operation_authorized"])
+        self.assertFalse(receipt["credential_material_present"])
+
+if __name__=="__main__": unittest.main()

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),41)
+        self.assertEqual(len(workflows),42)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tests/test_source_change_monitor.py
+++ b/tests/test_source_change_monitor.py
@@ -1,0 +1,43 @@
+import unittest
+from runtime.connection_assembly import assemble_connection, verify_connection
+from runtime.source_change_monitor import evaluate_source_change
+
+class SourceChangeMonitorTests(unittest.TestCase):
+    def assembly(self):
+        spec={
+            "provider":"coinbase","source_kind":"crypto_exchange","target_domain":"finance",
+            "canonical_kv_path":"03_Records/Finance","access":"READ_ONLY",
+            "direct_source_required":True,"minimum_necessary":True,"credential_authority":"TV/TVC",
+            "credential_reference_class":"SKAP_REFERENCE","intr_hops":["SKAP","TVC","Provider","KV"],
+            "adapter":{"name":"coinbase-finance-ingress","version":"v1"},
+            "provider_capability_binding":{"registry_schema":"stegverse.kv.provider-surface-capability-registry/v1","provider":"coinbase","observation_selector":{},"evidence_version":None},
+            "monitoring":{"enabled":True,"authoritative_sources":["provider:coinbase:changelog"],"change_classes":["authentication","api_version","service_health"],"last_checked_at":None,"last_change_ref":None},
+            "authority_effect":"NONE"
+        }
+        a=assemble_connection(spec)
+        a,_=verify_connection(a,observed_at="2026-08-28T15:00:00Z",connection_proof_ref="proof:c",readback_proof_ref="proof:r")
+        return a
+
+    def change(self, change_class="api_version", breaking=False):
+        return {
+            "provider":"coinbase","observed_at":"2026-08-28T16:00:00Z","source_ref":"provider:coinbase:changelog:1",
+            "source_type":"provider_changelog","change_class":change_class,"severity":"MEDIUM","breaking":breaking,
+            "affected_assumptions":["adapter_api_version"],"summary":"Synthetic provider change"
+        }
+
+    def test_nonbreaking_monitored_change_requires_revalidation(self):
+        a,r=evaluate_source_change(self.assembly(),self.change())
+        self.assertEqual(a["compatibility_state"],"REVALIDATION_REQUIRED")
+        self.assertTrue(r["revalidation_required"])
+
+    def test_breaking_auth_change_blocks(self):
+        a,r=evaluate_source_change(self.assembly(),self.change("authentication",True))
+        self.assertEqual(a["compatibility_state"],"BLOCKED_SOURCE_CHANGE")
+        self.assertEqual(r["reason"],"BREAKING_SOURCE_CHANGE")
+
+    def test_unmonitored_change_does_not_invalidate(self):
+        a,r=evaluate_source_change(self.assembly(),self.change("export_format",True))
+        self.assertEqual(a["compatibility_state"],"VERIFIED")
+        self.assertFalse(r["revalidation_required"])
+
+if __name__=="__main__": unittest.main()

--- a/tools/check_kv_connection_assembly.py
+++ b/tools/check_kv_connection_assembly.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+ROOT=Path(__file__).resolve().parents[1]
+required=[
+    "KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md",
+    "schemas/kv-connection-assembly.schema.json",
+    "schemas/kv-source-change-observation.schema.json",
+    "schemas/kv-connection-health-receipt.schema.json",
+    "schemas/kv-connection-assembly-registry.schema.json",
+    "specs/kv-connection-assembly-registry.v1.json",
+    "runtime/connection_assembly.py",
+    "runtime/source_change_monitor.py",
+    "tests/test_connection_assembly.py",
+    "tests/test_source_change_monitor.py",
+]
+for rel in required:
+    if not (ROOT/rel).is_file(): raise SystemExit(f"missing connection assembly artifact: {rel}")
+for rel in [x for x in required if x.endswith(".json")]:
+    json.loads((ROOT/rel).read_text(encoding="utf-8"))
+assembly=(ROOT/"runtime/connection_assembly.py").read_text(encoding="utf-8")
+monitor=(ROOT/"runtime/source_change_monitor.py").read_text(encoding="utf-8")
+handoff=(ROOT/"KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md").read_text(encoding="utf-8")
+for marker in ["READ_ONLY","TV/TVC","SKAP_REFERENCE","credential_material_present","provider_operation_authorized"]:
+    if marker not in assembly: raise SystemExit(f"missing connection assembly invariant: {marker}")
+for marker in ["REVALIDATION_REQUIRED","BLOCKED_SOURCE_CHANGE","provider"]:
+    if marker not in monitor: raise SystemExit(f"missing source monitor invariant: {marker}")
+for forbidden in ["store passwords","provider login by itself"]:
+    if forbidden not in handoff: raise SystemExit(f"handoff missing boundary: {forbidden}")
+print("KV connection assembly static checks: PASS")


### PR DESCRIPTION
Implements #113.

Adds a machine-executable, non-secret connection-assembly layer for Personal KV:
- deterministic connection assembly records;
- binding to the existing provider-surface capability registry;
- explicit SKAP/TVC credential/session reference classes without credential material;
- canonical InTr hop and adapter metadata;
- connection health receipts;
- provider/source change observations;
- compatibility-state transitions that invalidate stale verification;
- synthetic-only tests and read-only hosted validation.

Production provider monitoring and provider execution remain outside GitHub Actions. Live monitoring must run on an admitted resident machine surface and feed non-secret observations into this contract.