### PR TITLE
Materialize connection assembly registry inside Personal KV

### DIFF
--- a/.github/workflows/kv-connection-registry-materialization.yml
+++ b/.github/workflows/kv-connection-registry-materialization.yml
@@ -1,0 +1,28 @@
+name: Validate KV Connection Registry Materialization
+
+on:
+  pull_request:
+    paths:
+      - "KV_CONNECTION_REGISTRY_MATERIALIZATION_MIRROR_HANDOFF.md"
+      - "vault_template/KnowledgeVault/_System/Connections/**"
+      - "runtime/connection_registry_store.py"
+      - "tests/test_connection_registry_store.py"
+      - "tools/check_kv_connection_registry_materialization.py"
+      - ".github/workflows/kv-connection-registry-materialization.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Static materialization checks
+        run: python tools/check_kv_connection_registry_materialization.py
+      - name: Connection registry store tests
+        run: python -m unittest tests.test_connection_registry_store

--- a/KV_CONNECTION_REGISTRY_MATERIALIZATION_MIRROR_HANDOFF.md
+++ b/KV_CONNECTION_REGISTRY_MATERIALIZATION_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Connection Registry Materialization Mirror Handoff
 
-Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS
+Status: SOURCE_IMPLEMENTED_ON_BRANCH / VALIDATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #115
 Branch: `feature/kv-connection-registry-materialization`
@@ -54,4 +54,4 @@ KnowledgeVault/
 
 ## Current boundary
 
-Source implementation only. No live provider connection, credential resolution, provider monitoring, or private user assembly state is committed to the repository.
+Machine-executable template/store source is implemented on this branch. No live provider connection, credential resolution, provider monitoring, or private user assembly state is committed to the repository.

--- a/KV_CONNECTION_REGISTRY_MATERIALIZATION_MIRROR_HANDOFF.md
+++ b/KV_CONNECTION_REGISTRY_MATERIALIZATION_MIRROR_HANDOFF.md
@@ -1,0 +1,57 @@
+# KV Connection Registry Materialization Mirror Handoff
+
+Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #115
+Branch: `feature/kv-connection-registry-materialization`
+Updated: 2026-08-28
+Authority effect: NONE
+Activation effect: false
+
+## Purpose
+
+Materialize the canonical non-secret connection assembly registry inside each Personal KnowledgeVault so the vault itself is the durable reconstruction source for its own ingress/egress Interlock/InTr paths.
+
+## Canonical private KV paths
+
+```text
+KnowledgeVault/
+  _System/
+    Connections/
+      Connection_Assemblies.json
+      Source_Changes/
+      Health/
+```
+
+## Boundary
+
+- Public source carries only empty/synthetic initialization.
+- User-specific assembly state persists only in the connected private KV.
+- Reusable credentials, tokens, passwords, private keys, cookies, recovery material, and provider secrets are prohibited.
+- TV/TVC remains credential authority.
+- SKAP remains reusable credential/session custody.
+- Provider operation authority remains NONE.
+- Source-change observations and health receipts are non-secret evidence only.
+- No connection is VERIFIED without connection proof and KV readback proof.
+
+## Upstream contracts
+
+- `KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md`
+- `schemas/kv-connection-assembly-registry.schema.json`
+- `schemas/kv-source-change-observation.schema.json`
+- `schemas/kv-connection-health-receipt.schema.json`
+
+## Planned source
+
+- `KV_CONNECTION_REGISTRY_MATERIALIZATION_MIRROR_HANDOFF.md`
+- `vault_template/KnowledgeVault/_System/Connections/Connection_Assemblies.json`
+- `vault_template/KnowledgeVault/_System/Connections/Source_Changes/README.md`
+- `vault_template/KnowledgeVault/_System/Connections/Health/README.md`
+- `runtime/connection_registry_store.py`
+- `tests/test_connection_registry_store.py`
+- `tools/check_kv_connection_registry_materialization.py`
+- read-only validation workflow
+
+## Current boundary
+
+Source implementation only. No live provider connection, credential resolution, provider monitoring, or private user assembly state is committed to the repository.

--- a/runtime/connection_registry_store.py
+++ b/runtime/connection_registry_store.py
@@ -1,0 +1,100 @@
+"""Private-KV connection registry persistence helpers.
+
+These helpers operate on local/private filesystem paths supplied by an admitted runtime.
+They do not perform provider login, credential resolution, network access, or provider mutation.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from runtime.connection_assembly import ConnectionAssemblyError, assemble_connection, reject_secret_fields
+
+REGISTRY_SCHEMA="stegverse.kv.connection-assembly-registry/v1"
+SOURCE_CHANGE_SCHEMA="stegverse.kv.source-change-observation/v1"
+HEALTH_SCHEMA="stegverse.kv.connection-health-receipt/v1"
+
+class ConnectionRegistryStoreError(ConnectionAssemblyError):
+    pass
+
+def canonical_paths(kv_root: Path) -> dict[str,Path]:
+    root=kv_root.expanduser().resolve()
+    base=root/"_System"/"Connections"
+    return {
+        "root":base,
+        "registry":base/"Connection_Assemblies.json",
+        "source_changes":base/"Source_Changes",
+        "health":base/"Health",
+    }
+
+def initialize_store(kv_root: Path) -> dict[str,Path]:
+    paths=canonical_paths(kv_root)
+    paths["root"].mkdir(parents=True,exist_ok=True)
+    paths["source_changes"].mkdir(parents=True,exist_ok=True)
+    paths["health"].mkdir(parents=True,exist_ok=True)
+    if not paths["registry"].exists():
+        paths["registry"].write_text(json.dumps({
+            "schema":REGISTRY_SCHEMA,"state":"EMPTY","authority_effect":"NONE","assemblies":[]
+        },sort_keys=True,indent=2)+"\n",encoding="utf-8")
+    return paths
+
+def load_registry(kv_root: Path) -> Dict[str,Any]:
+    paths=initialize_store(kv_root)
+    try:
+        value=json.loads(paths["registry"].read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ConnectionRegistryStoreError("connection registry is unreadable") from exc
+    reject_secret_fields(value,"$.connection_registry")
+    if value.get("schema")!=REGISTRY_SCHEMA: raise ConnectionRegistryStoreError("unexpected registry schema")
+    if value.get("authority_effect")!="NONE": raise ConnectionRegistryStoreError("registry authority effect must remain NONE")
+    assemblies=value.get("assemblies")
+    if not isinstance(assemblies,list): raise ConnectionRegistryStoreError("assemblies must be a list")
+    return value
+
+def _registry_state(assemblies:list[dict[str,Any]])->str:
+    if not assemblies: return "EMPTY"
+    states={a.get("compatibility_state") for a in assemblies}
+    if states=={"VERIFIED"}: return "VERIFIED"
+    if "DEGRADED" in states or "BLOCKED_SOURCE_CHANGE" in states or "BLOCKED_SESSION" in states or "BLOCKED_RUNTIME" in states:
+        return "DEGRADED"
+    if "VERIFIED" in states: return "PARTIALLY_VERIFIED"
+    return "ASSEMBLED_UNVERIFIED"
+
+def upsert_assembly(kv_root:Path,assembly:Dict[str,Any])->Dict[str,Any]:
+    normalized=assemble_connection(assembly)
+    registry=load_registry(kv_root)
+    rows=[row for row in registry["assemblies"] if row.get("assembly_id")!=normalized["assembly_id"]]
+    rows.append(normalized)
+    rows=sorted(rows,key=lambda row:row["assembly_id"])
+    registry["assemblies"]=rows
+    registry["state"]=_registry_state(rows)
+    registry["authority_effect"]="NONE"
+    reject_secret_fields(registry,"$.connection_registry")
+    canonical_paths(kv_root)["registry"].write_text(json.dumps(registry,sort_keys=True,indent=2)+"\n",encoding="utf-8")
+    return copy.deepcopy(registry)
+
+def persist_source_change(kv_root:Path,observation:Dict[str,Any])->Path:
+    reject_secret_fields(observation,"$.source_change")
+    if observation.get("schema")!=SOURCE_CHANGE_SCHEMA: raise ConnectionRegistryStoreError("unexpected source change schema")
+    if observation.get("authority_effect")!="NONE": raise ConnectionRegistryStoreError("source change authority effect must remain NONE")
+    observation_id=str(observation.get("observation_id") or "")
+    if not observation_id.startswith("kvchg_"): raise ConnectionRegistryStoreError("source change observation_id invalid")
+    path=initialize_store(kv_root)["source_changes"]/f"{observation_id}.json"
+    path.write_text(json.dumps(observation,sort_keys=True,indent=2)+"\n",encoding="utf-8")
+    return path
+
+def persist_health_receipt(kv_root:Path,receipt:Dict[str,Any])->Path:
+    reject_secret_fields(receipt,"$.connection_health")
+    if receipt.get("schema")!=HEALTH_SCHEMA: raise ConnectionRegistryStoreError("unexpected health receipt schema")
+    if receipt.get("authority_effect")!="NONE": raise ConnectionRegistryStoreError("health authority effect must remain NONE")
+    if receipt.get("provider_operation_authorized") is not False: raise ConnectionRegistryStoreError("provider operation authority prohibited")
+    if receipt.get("credential_material_present") is not False: raise ConnectionRegistryStoreError("credential material prohibited")
+    assembly_id=str(receipt.get("assembly_id") or "")
+    observed_at=str(receipt.get("observed_at") or "").replace(":","-")
+    if not assembly_id.startswith("kvcxn_") or not observed_at: raise ConnectionRegistryStoreError("health receipt identity invalid")
+    path=initialize_store(kv_root)["health"]/f"{assembly_id}__{observed_at}.json"
+    path.write_text(json.dumps(receipt,sort_keys=True,indent=2)+"\n",encoding="utf-8")
+    return path

--- a/runtime/connection_registry_store.py
+++ b/runtime/connection_registry_store.py
@@ -47,7 +47,10 @@ def load_registry(kv_root: Path) -> Dict[str,Any]:
         value=json.loads(paths["registry"].read_text(encoding="utf-8"))
     except Exception as exc:
         raise ConnectionRegistryStoreError("connection registry is unreadable") from exc
-    reject_secret_fields(value,"$.connection_registry")
+    try:
+        reject_secret_fields(value,"$.connection_registry")
+    except ConnectionAssemblyError as exc:
+        raise ConnectionRegistryStoreError(str(exc)) from exc
     if value.get("schema")!=REGISTRY_SCHEMA: raise ConnectionRegistryStoreError("unexpected registry schema")
     if value.get("authority_effect")!="NONE": raise ConnectionRegistryStoreError("registry authority effect must remain NONE")
     assemblies=value.get("assemblies")

--- a/tests/test_connection_registry_store.py
+++ b/tests/test_connection_registry_store.py
@@ -1,0 +1,60 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from runtime.connection_assembly import assemble_connection, verify_connection
+from runtime.connection_registry_store import (
+    ConnectionRegistryStoreError, canonical_paths, initialize_store, load_registry,
+    persist_health_receipt, persist_source_change, upsert_assembly,
+)
+
+class ConnectionRegistryStoreTests(unittest.TestCase):
+    def spec(self):
+        return {
+            "provider":"coinbase","source_kind":"crypto_exchange","target_domain":"finance",
+            "canonical_kv_path":"03_Records/Finance","access":"READ_ONLY",
+            "direct_source_required":True,"minimum_necessary":True,"credential_authority":"TV/TVC",
+            "credential_reference_class":"SKAP_REFERENCE","intr_hops":["SKAP","TVC","Provider","KV"],
+            "adapter":{"name":"coinbase-finance-ingress","version":"v1"},
+            "provider_capability_binding":{"registry_schema":"stegverse.kv.provider-surface-capability-registry/v1","provider":"coinbase","observation_selector":{},"evidence_version":None},
+            "monitoring":{"enabled":True,"authoritative_sources":["provider:coinbase:changelog"],"change_classes":["api_version"],"last_checked_at":None,"last_change_ref":None},
+            "authority_effect":"NONE"
+        }
+
+    def test_initialize_empty_registry(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td); initialize_store(root); value=load_registry(root)
+            self.assertEqual(value["state"],"EMPTY")
+            self.assertTrue(canonical_paths(root)["source_changes"].is_dir())
+
+    def test_upsert_assembly(self):
+        with tempfile.TemporaryDirectory() as td:
+            value=upsert_assembly(Path(td),self.spec())
+            self.assertEqual(value["state"],"ASSEMBLED_UNVERIFIED")
+            self.assertEqual(len(value["assemblies"]),1)
+
+    def test_verified_assembly_sets_verified_registry(self):
+        with tempfile.TemporaryDirectory() as td:
+            a=assemble_connection(self.spec())
+            a,_=verify_connection(a,observed_at="2026-08-28T16:00:00Z",connection_proof_ref="proof:c",readback_proof_ref="proof:r")
+            value=upsert_assembly(Path(td),a)
+            self.assertEqual(value["state"],"VERIFIED")
+
+    def test_secret_registry_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td); initialize_store(root)
+            p=canonical_paths(root)["registry"]
+            value=json.loads(p.read_text()); value["access_token"]="synthetic"; p.write_text(json.dumps(value))
+            with self.assertRaises(ConnectionRegistryStoreError): load_registry(root)
+
+    def test_persist_source_change_and_health(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)
+            obs={"schema":"stegverse.kv.source-change-observation/v1","observation_id":"kvchg_1234567890abcdef12345678","provider":"coinbase","observed_at":"2026-08-28T16:00:00Z","source_ref":"provider:coinbase:changelog","source_type":"provider_changelog","change_class":"api_version","severity":"MEDIUM","breaking":False,"affected_assumptions":["api_version"],"summary":"Synthetic","effective_at":None,"authority_effect":"NONE"}
+            sp=persist_source_change(root,obs); self.assertTrue(sp.is_file())
+            a=assemble_connection(self.spec())
+            _,r=verify_connection(a,observed_at="2026-08-28T16:00:00Z",connection_proof_ref="proof:c",readback_proof_ref="proof:r")
+            hp=persist_health_receipt(root,r); self.assertTrue(hp.is_file())
+
+if __name__=="__main__": unittest.main()

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),42)
+        self.assertEqual(len(workflows),43)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tools/check_kv_connection_registry_materialization.py
+++ b/tools/check_kv_connection_registry_materialization.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+required=[
+  "KV_CONNECTION_REGISTRY_MATERIALIZATION_MIRROR_HANDOFF.md",
+  "vault_template/KnowledgeVault/_System/Connections/Connection_Assemblies.json",
+  "vault_template/KnowledgeVault/_System/Connections/Source_Changes/README.md",
+  "vault_template/KnowledgeVault/_System/Connections/Health/README.md",
+  "runtime/connection_registry_store.py",
+  "tests/test_connection_registry_store.py",
+]
+for rel in required:
+  if not (ROOT/rel).is_file(): raise SystemExit(f"missing connection registry materialization artifact: {rel}")
+template=json.loads((ROOT/required[1]).read_text(encoding="utf-8"))
+if template!={"schema":"stegverse.kv.connection-assembly-registry/v1","state":"EMPTY","authority_effect":"NONE","assemblies":[]}:
+  raise SystemExit("connection registry template must remain empty and non-authorizing")
+runtime=(ROOT/"runtime/connection_registry_store.py").read_text(encoding="utf-8")
+for marker in ["_System","Connections","Source_Changes","Health","provider operation authority prohibited","credential material prohibited"]:
+  if marker not in runtime: raise SystemExit(f"missing materialization invariant: {marker}")
+print("KV connection registry materialization static checks: PASS")

--- a/vault_template/KnowledgeVault/_System/Connections/Connection_Assemblies.json
+++ b/vault_template/KnowledgeVault/_System/Connections/Connection_Assemblies.json
@@ -1,0 +1,6 @@
+{
+  "schema": "stegverse.kv.connection-assembly-registry/v1",
+  "state": "EMPTY",
+  "authority_effect": "NONE",
+  "assemblies": []
+}

--- a/vault_template/KnowledgeVault/_System/Connections/Health/README.md
+++ b/vault_template/KnowledgeVault/_System/Connections/Health/README.md
@@ -1,0 +1,7 @@
+# Connection Health
+
+This private KnowledgeVault directory stores non-secret connection-health receipts that conform to `stegverse.kv.connection-health-receipt/v1`.
+
+A VERIFIED state requires both connection proof and KnowledgeVault readback proof. Provider operation authority remains NONE.
+
+Credentials and reusable authentication material are prohibited from this directory.

--- a/vault_template/KnowledgeVault/_System/Connections/Source_Changes/README.md
+++ b/vault_template/KnowledgeVault/_System/Connections/Source_Changes/README.md
@@ -1,0 +1,7 @@
+# Source Changes
+
+This private KnowledgeVault directory stores admitted non-secret provider/source change observations that conform to `stegverse.kv.source-change-observation/v1`.
+
+It must not contain reusable credentials, passwords, tokens, private keys, cookies, recovery material, or provider secrets.
+
+Source-change evidence does not itself grant provider operation authority or alter a connection. The canonical connection-health evaluator determines whether revalidation or repair is required.


### PR DESCRIPTION
Implements #115.

Adds the canonical private-KV materialization surface for connection assembly state:
- `_System/Connections/Connection_Assemblies.json` empty template;
- `Source_Changes/` and `Health/` evidence directories;
- deterministic local/private registry store helpers;
- secret-field rejection and non-authorizing persistence checks;
- registry state derived from contained connection compatibility states;
- synthetic-only tests and read-only validation.

No real user connection metadata or credentials are committed.