### PR TITLE
Make provider monitor targets canonical Personal KV state

### DIFF
--- a/.github/workflows/kv-monitor-targets.yml
+++ b/.github/workflows/kv-monitor-targets.yml
@@ -1,0 +1,29 @@
+name: Validate KV Monitor Targets
+
+on:
+  pull_request:
+    paths:
+      - "KV_MONITOR_TARGETS_CANONICAL_STATE_MIRROR_HANDOFF.md"
+      - "schemas/kv-provider-monitor-targets.schema.json"
+      - "vault_template/KnowledgeVault/_System/Connections/Monitor_Targets.json"
+      - "runtime/connection_monitor_targets.py"
+      - "tests/test_connection_monitor_targets.py"
+      - "tools/check_kv_monitor_targets.py"
+      - ".github/workflows/kv-monitor-targets.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Static monitor-target checks
+        run: python tools/check_kv_monitor_targets.py
+      - name: Monitor-target tests
+        run: python -m unittest tests.test_connection_monitor_targets

--- a/KV_MONITOR_TARGETS_CANONICAL_STATE_MIRROR_HANDOFF.md
+++ b/KV_MONITOR_TARGETS_CANONICAL_STATE_MIRROR_HANDOFF.md
@@ -1,0 +1,72 @@
+# KV Monitor Targets Canonical State Mirror Handoff
+
+Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #117
+Branch: `feature/kv-monitor-targets-canonical`
+Updated: 2026-08-28
+Authority effect: NONE
+Activation effect: false
+
+## Purpose
+
+Make provider/source monitoring targets canonical, non-secret Personal KV state so the resident provider-change observer can derive its work from the vault itself rather than from an ad hoc external runtime file.
+
+## Canonical private KV path
+
+```text
+KnowledgeVault/
+  _System/
+    Connections/
+      Monitor_Targets.json
+```
+
+## Contract
+
+`Monitor_Targets.json` uses:
+
+`stegverse.kv.provider-monitor-targets/v1`
+
+Each target must bind:
+
+- target ID;
+- provider;
+- explicit HTTPS source URL;
+- exact allowed host;
+- source type: provider documentation, changelog, or status;
+- source-change class;
+- severity;
+- whether any content change is treated as breaking;
+- affected connection assumptions;
+- bounded summary text.
+
+## Boundaries
+
+1. Monitoring targets are public provider/source observation instructions only.
+2. Embedded URL credentials are prohibited.
+3. HTTP/non-TLS sources are prohibited.
+4. Provider login, owner-account access, cookies, Authorization headers, API keys, tokens, passwords, and private keys are prohibited.
+5. TV/TVC credential authority remains unchanged.
+6. SKAP is not resolved by this monitoring contract.
+7. Provider operation authority remains NONE.
+8. GitHub Actions may validate source only; resident execution is owned by the WorkerCoordinator provider-change observer.
+9. The target set may be generated from connection assembly monitoring configuration, but provider capability facts must not be duplicated.
+10. User-specific target state belongs in the private KV; public source contains only an empty template and synthetic tests.
+
+## Machine surfaces
+
+- `KV_MONITOR_TARGETS_CANONICAL_STATE_MIRROR_HANDOFF.md`
+- `schemas/kv-provider-monitor-targets.schema.json`
+- `vault_template/KnowledgeVault/_System/Connections/Monitor_Targets.json`
+- `runtime/connection_monitor_targets.py`
+- `tests/test_connection_monitor_targets.py`
+- `tools/check_kv_monitor_targets.py`
+- read-only validation workflow
+
+## Downstream consumer
+
+`StegVerse-Labs/.github#362` resident provider-change observer.
+
+## Current boundary
+
+Source lane only. No live provider source monitoring is performed by this branch.

--- a/KV_MONITOR_TARGETS_CANONICAL_STATE_MIRROR_HANDOFF.md
+++ b/KV_MONITOR_TARGETS_CANONICAL_STATE_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Monitor Targets Canonical State Mirror Handoff
 
-Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS
+Status: SOURCE_IMPLEMENTED_ON_BRANCH / VALIDATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #117
 Branch: `feature/kv-monitor-targets-canonical`
@@ -69,4 +69,4 @@ Each target must bind:
 
 ## Current boundary
 
-Source lane only. No live provider source monitoring is performed by this branch.
+Machine-executable source, empty private-KV template, compiler, tests, and validation are implemented on this branch. No live provider source monitoring is performed by this branch.

--- a/runtime/connection_monitor_targets.py
+++ b/runtime/connection_monitor_targets.py
@@ -40,7 +40,10 @@ def validate_target(target:Dict[str,Any])->Dict[str,Any]:
 def compile_monitor_targets(assemblies:list[Dict[str,Any]],source_catalog:Dict[str,Dict[str,Any]])->Dict[str,Any]:
     if not isinstance(assemblies,list) or not isinstance(source_catalog,dict):
         raise ConnectionMonitorTargetError("assemblies list and source catalog object required")
-    reject_secret_fields(source_catalog,"$.source_catalog")
+    try:
+        reject_secret_fields(source_catalog,"$.source_catalog")
+    except ConnectionAssemblyError as exc:
+        raise ConnectionMonitorTargetError(str(exc)) from exc
     targets=[]
     for assembly in assemblies:
         reject_secret_fields(assembly,"$.assembly")

--- a/runtime/connection_monitor_targets.py
+++ b/runtime/connection_monitor_targets.py
@@ -1,0 +1,79 @@
+"""Compile and validate non-secret provider monitoring targets from connection assemblies."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+from runtime.connection_assembly import ConnectionAssemblyError, reject_secret_fields
+
+SCHEMA="stegverse.kv.provider-monitor-targets/v1"
+ALLOWED_SOURCE_TYPES={"provider_documentation","provider_changelog","provider_status"}
+ALLOWED_CHANGE_CLASSES={"api_version","authentication","mfa_session","endpoint","deprecation","changelog","sdk_dependency","rate_limit","permission_scope","product_model","data_schema","export_format","browser_platform","service_health"}
+ALLOWED_SEVERITY={"INFO","LOW","MEDIUM","HIGH","CRITICAL"}
+
+class ConnectionMonitorTargetError(ConnectionAssemblyError):
+    pass
+
+def deterministic_target_id(provider:str,source_ref:str)->str:
+    material=f"{provider}|{source_ref}".strip().lower()
+    return "kvmon_"+hashlib.sha256(material.encode("utf-8")).hexdigest()[:24]
+
+def validate_target(target:Dict[str,Any])->Dict[str,Any]:
+    if not isinstance(target,dict): raise ConnectionMonitorTargetError("monitor target must be object")
+    reject_secret_fields(target,"$.monitor_target")
+    required=("provider","url","allowed_host","source_type","change_class","severity","breaking_on_change","affected_assumptions","source_binding_ref")
+    for key in required:
+        if key not in target: raise ConnectionMonitorTargetError(f"monitor target missing field: {key}")
+    parsed=urlparse(str(target["url"]))
+    if parsed.scheme!="https": raise ConnectionMonitorTargetError("monitor target requires HTTPS")
+    if parsed.username or parsed.password: raise ConnectionMonitorTargetError("embedded URL credentials prohibited")
+    if parsed.hostname!=target["allowed_host"]: raise ConnectionMonitorTargetError("monitor target allowed_host mismatch")
+    if target["source_type"] not in ALLOWED_SOURCE_TYPES: raise ConnectionMonitorTargetError("unsupported source_type")
+    if target["change_class"] not in ALLOWED_CHANGE_CLASSES: raise ConnectionMonitorTargetError("unsupported change_class")
+    if target["severity"] not in ALLOWED_SEVERITY: raise ConnectionMonitorTargetError("unsupported severity")
+    result=dict(target)
+    result["target_id"]=deterministic_target_id(str(result["provider"]),str(result["source_binding_ref"]))
+    return result
+
+def compile_monitor_targets(assemblies:list[Dict[str,Any]],source_catalog:Dict[str,Dict[str,Any]])->Dict[str,Any]:
+    if not isinstance(assemblies,list) or not isinstance(source_catalog,dict):
+        raise ConnectionMonitorTargetError("assemblies list and source catalog object required")
+    targets=[]
+    for assembly in assemblies:
+        reject_secret_fields(assembly,"$.assembly")
+        provider=str(assembly.get("provider") or "")
+        monitoring=assembly.get("monitoring") or {}
+        refs=list(monitoring.get("authoritative_sources") or [])
+        for source_ref in refs:
+            descriptor=source_catalog.get(str(source_ref))
+            if not isinstance(descriptor,dict):
+                raise ConnectionMonitorTargetError(f"monitor source descriptor missing: {source_ref}")
+            raw={
+                "provider":provider,
+                "url":descriptor.get("url"),
+                "allowed_host":descriptor.get("allowed_host"),
+                "source_type":descriptor.get("source_type"),
+                "change_class":descriptor.get("change_class","changelog"),
+                "severity":descriptor.get("severity","MEDIUM"),
+                "breaking_on_change":bool(descriptor.get("breaking_on_change",False)),
+                "affected_assumptions":list(descriptor.get("affected_assumptions") or []),
+                "summary_on_change":str(descriptor.get("summary_on_change") or "Authoritative provider source changed."),
+                "source_binding_ref":str(source_ref),
+            }
+            targets.append(validate_target(raw))
+    dedup={target["target_id"]:target for target in targets}
+    return {"schema":SCHEMA,"authority_effect":"NONE","targets":[dedup[k] for k in sorted(dedup)]}
+
+def validate_target_document(value:Dict[str,Any])->None:
+    if not isinstance(value,dict) or value.get("schema")!=SCHEMA: raise ConnectionMonitorTargetError("monitor target document schema invalid")
+    if value.get("authority_effect")!="NONE": raise ConnectionMonitorTargetError("monitor target authority effect must remain NONE")
+    targets=value.get("targets")
+    if not isinstance(targets,list): raise ConnectionMonitorTargetError("targets must be a list")
+    ids=set()
+    for target in targets:
+        validated=validate_target(target)
+        if validated["target_id"]!=target.get("target_id"): raise ConnectionMonitorTargetError("monitor target deterministic ID mismatch")
+        if target["target_id"] in ids: raise ConnectionMonitorTargetError("duplicate monitor target ID")
+        ids.add(target["target_id"])

--- a/runtime/connection_monitor_targets.py
+++ b/runtime/connection_monitor_targets.py
@@ -40,6 +40,7 @@ def validate_target(target:Dict[str,Any])->Dict[str,Any]:
 def compile_monitor_targets(assemblies:list[Dict[str,Any]],source_catalog:Dict[str,Dict[str,Any]])->Dict[str,Any]:
     if not isinstance(assemblies,list) or not isinstance(source_catalog,dict):
         raise ConnectionMonitorTargetError("assemblies list and source catalog object required")
+    reject_secret_fields(source_catalog,"$.source_catalog")
     targets=[]
     for assembly in assemblies:
         reject_secret_fields(assembly,"$.assembly")

--- a/schemas/kv-provider-monitor-targets.schema.json
+++ b/schemas/kv-provider-monitor-targets.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/kv-provider-monitor-targets.schema.json",
+  "title":"KnowledgeVault provider monitor targets",
+  "type":"object",
+  "required":["schema","authority_effect","targets"],
+  "properties":{
+    "schema":{"const":"stegverse.kv.provider-monitor-targets/v1"},
+    "authority_effect":{"const":"NONE"},
+    "targets":{"type":"array","items":{
+      "type":"object",
+      "required":["target_id","provider","url","allowed_host","source_type","change_class","severity","breaking_on_change","affected_assumptions"],
+      "properties":{
+        "target_id":{"type":"string","pattern":"^kvmon_[a-f0-9]{24}$"},
+        "provider":{"type":"string","minLength":1},
+        "url":{"type":"string","pattern":"^https://"},
+        "allowed_host":{"type":"string","minLength":1},
+        "source_type":{"enum":["provider_documentation","provider_changelog","provider_status"]},
+        "change_class":{"enum":["api_version","authentication","mfa_session","endpoint","deprecation","changelog","sdk_dependency","rate_limit","permission_scope","product_model","data_schema","export_format","browser_platform","service_health"]},
+        "severity":{"enum":["INFO","LOW","MEDIUM","HIGH","CRITICAL"]},
+        "breaking_on_change":{"type":"boolean"},
+        "affected_assumptions":{"type":"array","items":{"type":"string","minLength":1}},
+        "summary_on_change":{"type":"string"},
+        "source_binding_ref":{"type":"string","minLength":1}
+      },
+      "additionalProperties":false
+    }}
+  },
+  "additionalProperties":false
+}

--- a/tests/test_connection_monitor_targets.py
+++ b/tests/test_connection_monitor_targets.py
@@ -1,0 +1,54 @@
+import unittest
+
+from runtime.connection_monitor_targets import ConnectionMonitorTargetError, compile_monitor_targets, validate_target_document
+
+class ConnectionMonitorTargetTests(unittest.TestCase):
+    def assembly(self):
+        return {
+            "provider":"coinbase",
+            "monitoring":{
+                "authoritative_sources":["coinbase:changelog"],
+                "change_classes":["api_version"],
+            }
+        }
+    def catalog(self):
+        return {
+            "coinbase:changelog":{
+                "url":"https://docs.coinbase.example/changelog",
+                "allowed_host":"docs.coinbase.example",
+                "source_type":"provider_changelog",
+                "change_class":"api_version",
+                "severity":"MEDIUM",
+                "breaking_on_change":False,
+                "affected_assumptions":["adapter_api_version"],
+                "summary_on_change":"Coinbase changelog changed"
+            }
+        }
+
+    def test_compile_deterministic_target(self):
+        a=compile_monitor_targets([self.assembly()],self.catalog())
+        b=compile_monitor_targets([self.assembly()],self.catalog())
+        self.assertEqual(a,b)
+        self.assertTrue(a["targets"][0]["target_id"].startswith("kvmon_"))
+        validate_target_document(a)
+
+    def test_non_https_rejected(self):
+        catalog=self.catalog(); catalog["coinbase:changelog"]["url"]="http://docs.coinbase.example/changelog"
+        with self.assertRaises(ConnectionMonitorTargetError): compile_monitor_targets([self.assembly()],catalog)
+
+    def test_host_mismatch_rejected(self):
+        catalog=self.catalog(); catalog["coinbase:changelog"]["allowed_host"]="evil.example"
+        with self.assertRaises(ConnectionMonitorTargetError): compile_monitor_targets([self.assembly()],catalog)
+
+    def test_embedded_credentials_rejected(self):
+        catalog=self.catalog(); catalog["coinbase:changelog"]["url"]="https://user:pass@docs.coinbase.example/changelog"
+        with self.assertRaises(ConnectionMonitorTargetError): compile_monitor_targets([self.assembly()],catalog)
+
+    def test_secret_descriptor_rejected(self):
+        catalog=self.catalog(); catalog["coinbase:changelog"]["access_token"]="synthetic"
+        # descriptor field is not copied, so rejection is enforced by validating source catalog first at integration boundary
+        with self.assertRaises(Exception):
+            from runtime.connection_assembly import reject_secret_fields
+            reject_secret_fields(catalog)
+
+if __name__=="__main__": unittest.main()

--- a/tests/test_connection_monitor_targets.py
+++ b/tests/test_connection_monitor_targets.py
@@ -46,9 +46,7 @@ class ConnectionMonitorTargetTests(unittest.TestCase):
 
     def test_secret_descriptor_rejected(self):
         catalog=self.catalog(); catalog["coinbase:changelog"]["access_token"]="synthetic"
-        # descriptor field is not copied, so rejection is enforced by validating source catalog first at integration boundary
-        with self.assertRaises(Exception):
-            from runtime.connection_assembly import reject_secret_fields
-            reject_secret_fields(catalog)
+        with self.assertRaises(ConnectionMonitorTargetError):
+            compile_monitor_targets([self.assembly()],catalog)
 
 if __name__=="__main__": unittest.main()

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),43)
+        self.assertEqual(len(workflows),44)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tools/check_kv_monitor_targets.py
+++ b/tools/check_kv_monitor_targets.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+required=[
+ "KV_MONITOR_TARGETS_CANONICAL_STATE_MIRROR_HANDOFF.md",
+ "schemas/kv-provider-monitor-targets.schema.json",
+ "vault_template/KnowledgeVault/_System/Connections/Monitor_Targets.json",
+ "runtime/connection_monitor_targets.py",
+ "tests/test_connection_monitor_targets.py"
+]
+for rel in required:
+    if not (ROOT/rel).is_file(): raise SystemExit(f"missing KV monitor target artifact: {rel}")
+json.loads((ROOT/"schemas/kv-provider-monitor-targets.schema.json").read_text())
+template=json.loads((ROOT/"vault_template/KnowledgeVault/_System/Connections/Monitor_Targets.json").read_text())
+if template!={"schema":"stegverse.kv.provider-monitor-targets/v1","authority_effect":"NONE","targets":[]}:
+    raise SystemExit("monitor target template must remain empty and non-authorizing")
+runtime=(ROOT/"runtime/connection_monitor_targets.py").read_text()
+for marker in ["https","embedded URL credentials prohibited","allowed_host mismatch","authority effect must remain NONE"]:
+    if marker not in runtime: raise SystemExit(f"missing monitor target invariant: {marker}")
+print("KV monitor target static checks: PASS")

--- a/vault_template/KnowledgeVault/_System/Connections/Monitor_Targets.json
+++ b/vault_template/KnowledgeVault/_System/Connections/Monitor_Targets.json
@@ -1,0 +1,5 @@
+{
+  "schema": "stegverse.kv.provider-monitor-targets/v1",
+  "authority_effect": "NONE",
+  "targets": []
+}


### PR DESCRIPTION
Implements #117.

Adds the canonical source-of-truth contract for resident provider-change monitoring targets:
- `stegverse.kv.provider-monitor-targets/v1` schema;
- empty private-KV `_System/Connections/Monitor_Targets.json` template;
- deterministic compiler from connection assembly source refs + bounded source descriptors;
- HTTPS/host-binding enforcement;
- embedded credential and secret-bearing descriptor rejection;
- synthetic-only tests and read-only hosted validation.

The resident execution consumer remains StegVerse-Labs/.github#362. This source PR performs no provider monitoring.