### PR TITLE
Add governed Personal KV connection revalidation proofs

### DIFF
--- a/.github/workflows/kv-connection-revalidation.yml
+++ b/.github/workflows/kv-connection-revalidation.yml
@@ -1,0 +1,29 @@
+name: Validate KV Connection Revalidation
+
+on:
+  pull_request:
+    paths:
+      - "KV_CONNECTION_REVALIDATION_PROOF_MIRROR_HANDOFF.md"
+      - "schemas/kv-connection-conformance-proof.schema.json"
+      - "schemas/kv-connection-readback-proof.schema.json"
+      - "runtime/connection_revalidation.py"
+      - "tests/test_connection_revalidation.py"
+      - "tools/check_kv_connection_revalidation.py"
+      - ".github/workflows/kv-connection-revalidation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Static revalidation checks
+        run: python tools/check_kv_connection_revalidation.py
+      - name: Revalidation tests
+        run: python -m unittest tests.test_connection_revalidation

--- a/KV_CONNECTION_REVALIDATION_PROOF_MIRROR_HANDOFF.md
+++ b/KV_CONNECTION_REVALIDATION_PROOF_MIRROR_HANDOFF.md
@@ -1,0 +1,101 @@
+# KV Connection Revalidation Proof Mirror Handoff
+
+Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: #119
+Branch: `feature/kv-connection-revalidation-proof`
+Updated: 2026-08-28
+Authority effect: NONE
+Activation effect: false
+
+## Purpose
+
+Define the exact non-secret proof contract required to restore a Personal KV connection assembly to `VERIFIED` after initial assembly, source-change invalidation, session repair, or runtime recovery.
+
+Canonical verification flow:
+
+```text
+exact connection assembly
+ + provider/source conformance proof
+ + private KV readback proof
+ -> proof admission
+ -> existing verify_connection transition
+ -> VERIFIED connection assembly
+ -> connection-health receipt
+```
+
+## Required proof classes
+
+### Provider/source conformance proof
+
+Must bind:
+
+- exact assembly ID;
+- provider;
+- direct source verified;
+- provider session verified;
+- exact adapter name/version;
+- current source compatibility assumptions reference/hash;
+- observation timestamp;
+- provider operation authorized: false;
+- credential material present: false;
+- authority effect: NONE.
+
+This proof may be emitted only by the separately governed provider/session lane. It contains no reusable credential or secret material.
+
+### Private KV readback proof
+
+Must bind:
+
+- exact assembly ID;
+- canonical KV path;
+- readback verified: true;
+- exact persisted state/receipt reference;
+- observation timestamp;
+- provider operation authorized: false;
+- credential material present: false;
+- authority effect: NONE.
+
+## Verification rule
+
+A connection may transition to `VERIFIED` only when:
+
+1. both proof objects are present;
+2. both match the same exact assembly;
+3. provider and adapter bindings match the assembly;
+4. canonical KV path matches the assembly;
+5. direct-source/session verification is true;
+6. readback verification is true;
+7. credential material is absent;
+8. provider operation authority is false;
+9. neither proof predates the source-change/revalidation event that invalidated the prior verification;
+10. the existing canonical `verify_connection` transition succeeds.
+
+## Hard boundaries
+
+- No provider credential, password, token, API key, private key, cookie, recovery material, or SKAP plaintext.
+- No new credential architecture.
+- No new generic provider-auth mechanism.
+- Provider authentication remains owned by existing TVC/SKAP provider lanes.
+- This lane admits proof only; it does not log in to a provider.
+- GitHub Actions is validation-only and cannot produce live provider/readback proof.
+- A source merge or test PASS cannot satisfy live conformance/readback proof.
+- Provider mutation authority remains NONE.
+
+## Planned source
+
+- `KV_CONNECTION_REVALIDATION_PROOF_MIRROR_HANDOFF.md`
+- `schemas/kv-connection-conformance-proof.schema.json`
+- `schemas/kv-connection-readback-proof.schema.json`
+- `runtime/connection_revalidation.py`
+- `tests/test_connection_revalidation.py`
+- `tools/check_kv_connection_revalidation.py`
+- read-only validation workflow
+
+## Downstream machine consumer
+
+A resident WorkerCoordinator task may consume these proof objects and persist the verified assembly/health receipt after live provider and private-KV proof generation is separately observed.
+
+## Current boundary
+
+Source proof contract only. No live provider session, private-KV readback proof, or connection verification is claimed by this branch.

--- a/KV_CONNECTION_REVALIDATION_PROOF_MIRROR_HANDOFF.md
+++ b/KV_CONNECTION_REVALIDATION_PROOF_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Connection Revalidation Proof Mirror Handoff
 
-Status: SOURCE_LANE_OPEN / IMPLEMENTATION_IN_PROGRESS
+Status: SOURCE_IMPLEMENTED_ON_BRANCH / VALIDATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #119
 Branch: `feature/kv-connection-revalidation-proof`
@@ -98,4 +98,4 @@ A resident WorkerCoordinator task may consume these proof objects and persist th
 
 ## Current boundary
 
-Source proof contract only. No live provider session, private-KV readback proof, or connection verification is claimed by this branch.
+Machine-executable proof schemas, admission runtime, tests, and validation are implemented on this branch. No live provider session, private-KV readback proof, or connection verification is claimed by this branch.

--- a/runtime/connection_revalidation.py
+++ b/runtime/connection_revalidation.py
@@ -1,0 +1,110 @@
+"""Non-secret proof admission for Personal KV connection revalidation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from runtime.connection_assembly import (
+    ConnectionAssemblyError,
+    assemble_connection,
+    reject_secret_fields,
+    verify_connection,
+)
+
+CONFORMANCE_SCHEMA="stegverse.kv.connection-conformance-proof/v1"
+READBACK_SCHEMA="stegverse.kv.connection-readback-proof/v1"
+
+class ConnectionRevalidationError(ConnectionAssemblyError):
+    pass
+
+def _parse_time(value: Any, label: str) -> datetime:
+    text=str(value or "").strip()
+    if not text:
+        raise ConnectionRevalidationError(f"{label} timestamp required")
+    try:
+        if text.endswith("Z"):
+            parsed=datetime.fromisoformat(text[:-1]+"+00:00")
+        else:
+            parsed=datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ConnectionRevalidationError(f"{label} timestamp invalid") from exc
+    if parsed.tzinfo is None:
+        raise ConnectionRevalidationError(f"{label} timestamp must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+def _assert_common_proof_boundary(proof: Dict[str,Any], label: str) -> None:
+    if not isinstance(proof,dict):
+        raise ConnectionRevalidationError(f"{label} proof must be an object")
+    try:
+        reject_secret_fields(proof,f"$.{label}")
+    except ConnectionAssemblyError as exc:
+        raise ConnectionRevalidationError(str(exc)) from exc
+    if proof.get("provider_operation_authorized") is not False:
+        raise ConnectionRevalidationError(f"{label} provider operation authority prohibited")
+    if proof.get("credential_material_present") is not False:
+        raise ConnectionRevalidationError(f"{label} credential material prohibited")
+    if proof.get("authority_effect")!="NONE":
+        raise ConnectionRevalidationError(f"{label} authority effect must remain NONE")
+    _parse_time(proof.get("observed_at"),label)
+
+def validate_conformance_proof(assembly: Dict[str,Any], proof: Dict[str,Any]) -> None:
+    current=assemble_connection(assembly)
+    _assert_common_proof_boundary(proof,"conformance")
+    if proof.get("schema")!=CONFORMANCE_SCHEMA:
+        raise ConnectionRevalidationError("unexpected conformance proof schema")
+    if proof.get("assembly_id")!=current["assembly_id"]:
+        raise ConnectionRevalidationError("conformance proof assembly mismatch")
+    if str(proof.get("provider") or "").lower()!=str(current["provider"]).lower():
+        raise ConnectionRevalidationError("conformance proof provider mismatch")
+    if proof.get("direct_source_verified") is not True:
+        raise ConnectionRevalidationError("direct source verification required")
+    if proof.get("session_verified") is not True:
+        raise ConnectionRevalidationError("provider session verification required")
+    adapter=proof.get("adapter")
+    if not isinstance(adapter,dict) or adapter.get("name")!=current["adapter"]["name"] or adapter.get("version")!=current["adapter"]["version"]:
+        raise ConnectionRevalidationError("conformance proof adapter mismatch")
+    if not proof.get("compatibility_assumptions_ref"):
+        raise ConnectionRevalidationError("compatibility assumptions reference required")
+    if not proof.get("connection_proof_ref"):
+        raise ConnectionRevalidationError("connection proof reference required")
+
+def validate_readback_proof(assembly: Dict[str,Any], proof: Dict[str,Any]) -> None:
+    current=assemble_connection(assembly)
+    _assert_common_proof_boundary(proof,"readback")
+    if proof.get("schema")!=READBACK_SCHEMA:
+        raise ConnectionRevalidationError("unexpected readback proof schema")
+    if proof.get("assembly_id")!=current["assembly_id"]:
+        raise ConnectionRevalidationError("readback proof assembly mismatch")
+    if proof.get("canonical_kv_path")!=current["canonical_kv_path"]:
+        raise ConnectionRevalidationError("readback proof canonical path mismatch")
+    if proof.get("readback_verified") is not True:
+        raise ConnectionRevalidationError("private KV readback verification required")
+    if not proof.get("persistence_receipt_ref") or not proof.get("readback_proof_ref"):
+        raise ConnectionRevalidationError("persistence and readback proof references required")
+
+def admit_revalidation(
+    assembly: Dict[str,Any],
+    conformance_proof: Dict[str,Any],
+    readback_proof: Dict[str,Any],
+    *,
+    required_after: str|None=None,
+) -> tuple[Dict[str,Any],Dict[str,Any]]:
+    current=assemble_connection(assembly)
+    if current["compatibility_state"]=="RETIRED":
+        raise ConnectionRevalidationError("retired connection cannot be revalidated")
+    validate_conformance_proof(current,conformance_proof)
+    validate_readback_proof(current,readback_proof)
+    conformance_time=_parse_time(conformance_proof["observed_at"],"conformance")
+    readback_time=_parse_time(readback_proof["observed_at"],"readback")
+    if required_after is not None:
+        floor=_parse_time(required_after,"required_after")
+        if conformance_time < floor or readback_time < floor:
+            raise ConnectionRevalidationError("revalidation proof predates required invalidation/recovery event")
+    observed_at=max(conformance_time,readback_time).isoformat().replace("+00:00","Z")
+    return verify_connection(
+        current,
+        observed_at=observed_at,
+        connection_proof_ref=str(conformance_proof["connection_proof_ref"]),
+        readback_proof_ref=str(readback_proof["readback_proof_ref"]),
+    )

--- a/schemas/kv-connection-conformance-proof.schema.json
+++ b/schemas/kv-connection-conformance-proof.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/kv-connection-conformance-proof.schema.json",
+  "title":"KnowledgeVault connection provider conformance proof",
+  "type":"object",
+  "required":["schema","assembly_id","provider","observed_at","direct_source_verified","session_verified","adapter","compatibility_assumptions_ref","connection_proof_ref","provider_operation_authorized","credential_material_present","authority_effect"],
+  "properties":{
+    "schema":{"const":"stegverse.kv.connection-conformance-proof/v1"},
+    "assembly_id":{"type":"string","pattern":"^kvcxn_[a-f0-9]{24}$"},
+    "provider":{"type":"string","minLength":1},
+    "observed_at":{"type":"string","minLength":1},
+    "direct_source_verified":{"const":true},
+    "session_verified":{"const":true},
+    "adapter":{
+      "type":"object",
+      "required":["name","version"],
+      "properties":{"name":{"type":"string","minLength":1},"version":{"type":"string","minLength":1}},
+      "additionalProperties":false
+    },
+    "compatibility_assumptions_ref":{"type":"string","minLength":1},
+    "connection_proof_ref":{"type":"string","minLength":1},
+    "provider_operation_authorized":{"const":false},
+    "credential_material_present":{"const":false},
+    "authority_effect":{"const":"NONE"}
+  },
+  "additionalProperties":false
+}

--- a/schemas/kv-connection-readback-proof.schema.json
+++ b/schemas/kv-connection-readback-proof.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/kv-connection-readback-proof.schema.json",
+  "title":"KnowledgeVault connection readback proof",
+  "type":"object",
+  "required":["schema","assembly_id","canonical_kv_path","observed_at","readback_verified","persistence_receipt_ref","readback_proof_ref","provider_operation_authorized","credential_material_present","authority_effect"],
+  "properties":{
+    "schema":{"const":"stegverse.kv.connection-readback-proof/v1"},
+    "assembly_id":{"type":"string","pattern":"^kvcxn_[a-f0-9]{24}$"},
+    "canonical_kv_path":{"type":"string","minLength":1},
+    "observed_at":{"type":"string","minLength":1},
+    "readback_verified":{"const":true},
+    "persistence_receipt_ref":{"type":"string","minLength":1},
+    "readback_proof_ref":{"type":"string","minLength":1},
+    "provider_operation_authorized":{"const":false},
+    "credential_material_present":{"const":false},
+    "authority_effect":{"const":"NONE"}
+  },
+  "additionalProperties":false
+}

--- a/tests/test_connection_revalidation.py
+++ b/tests/test_connection_revalidation.py
@@ -1,0 +1,63 @@
+import unittest
+
+from runtime.connection_assembly import assemble_connection
+from runtime.connection_revalidation import ConnectionRevalidationError, admit_revalidation
+
+class ConnectionRevalidationTests(unittest.TestCase):
+    def assembly(self):
+        return assemble_connection({
+            "provider":"coinbase","source_kind":"crypto_exchange","target_domain":"finance",
+            "canonical_kv_path":"03_Records/Finance","access":"READ_ONLY",
+            "direct_source_required":True,"minimum_necessary":True,"credential_authority":"TV/TVC",
+            "credential_reference_class":"SKAP_REFERENCE","intr_hops":["SKAP","TVC","Provider","KV"],
+            "adapter":{"name":"coinbase-finance-ingress","version":"v1"},
+            "provider_capability_binding":{"registry_schema":"stegverse.kv.provider-surface-capability-registry/v1","provider":"coinbase","observation_selector":{},"evidence_version":None},
+            "monitoring":{"enabled":True,"authoritative_sources":["provider:coinbase:changelog"],"change_classes":["api_version"],"last_checked_at":"2026-08-28T16:00:00Z","last_change_ref":"kvchg_synthetic"},
+            "compatibility_state":"REVALIDATION_REQUIRED","authority_effect":"NONE"
+        })
+    def conformance(self,a):
+        return {
+            "schema":"stegverse.kv.connection-conformance-proof/v1","assembly_id":a["assembly_id"],
+            "provider":"coinbase","observed_at":"2026-08-28T17:00:00Z",
+            "direct_source_verified":True,"session_verified":True,
+            "adapter":{"name":"coinbase-finance-ingress","version":"v1"},
+            "compatibility_assumptions_ref":"sha256:synthetic-current-assumptions",
+            "connection_proof_ref":"proof:provider-conformance",
+            "provider_operation_authorized":False,"credential_material_present":False,"authority_effect":"NONE"
+        }
+    def readback(self,a):
+        return {
+            "schema":"stegverse.kv.connection-readback-proof/v1","assembly_id":a["assembly_id"],
+            "canonical_kv_path":"03_Records/Finance","observed_at":"2026-08-28T17:01:00Z",
+            "readback_verified":True,"persistence_receipt_ref":"receipt:private-kv-persist",
+            "readback_proof_ref":"proof:private-kv-readback",
+            "provider_operation_authorized":False,"credential_material_present":False,"authority_effect":"NONE"
+        }
+    def test_both_proofs_restore_verified(self):
+        a=self.assembly()
+        updated,receipt=admit_revalidation(a,self.conformance(a),self.readback(a),required_after="2026-08-28T16:00:00Z")
+        self.assertEqual(updated["compatibility_state"],"VERIFIED")
+        self.assertEqual(receipt["current_state"],"VERIFIED")
+        self.assertFalse(receipt["provider_operation_authorized"])
+        self.assertFalse(receipt["credential_material_present"])
+    def test_stale_proof_rejected(self):
+        a=self.assembly(); c=self.conformance(a); c["observed_at"]="2026-08-28T15:59:59Z"
+        with self.assertRaises(ConnectionRevalidationError):
+            admit_revalidation(a,c,self.readback(a),required_after="2026-08-28T16:00:00Z")
+    def test_adapter_mismatch_rejected(self):
+        a=self.assembly(); c=self.conformance(a); c["adapter"]["version"]="v2"
+        with self.assertRaises(ConnectionRevalidationError):
+            admit_revalidation(a,c,self.readback(a))
+    def test_path_mismatch_rejected(self):
+        a=self.assembly(); r=self.readback(a); r["canonical_kv_path"]="03_Records/Assets"
+        with self.assertRaises(ConnectionRevalidationError):
+            admit_revalidation(a,self.conformance(a),r)
+    def test_secret_field_rejected(self):
+        a=self.assembly(); c=self.conformance(a); c["access_token"]="synthetic"
+        with self.assertRaises(ConnectionRevalidationError):
+            admit_revalidation(a,c,self.readback(a))
+    def test_provider_authority_rejected(self):
+        a=self.assembly(); c=self.conformance(a); c["provider_operation_authorized"]=True
+        with self.assertRaises(ConnectionRevalidationError):
+            admit_revalidation(a,c,self.readback(a))
+if __name__=="__main__": unittest.main()

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),44)
+        self.assertEqual(len(workflows),45)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tools/check_kv_connection_revalidation.py
+++ b/tools/check_kv_connection_revalidation.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+required=[
+ "KV_CONNECTION_REVALIDATION_PROOF_MIRROR_HANDOFF.md",
+ "schemas/kv-connection-conformance-proof.schema.json",
+ "schemas/kv-connection-readback-proof.schema.json",
+ "runtime/connection_revalidation.py",
+ "tests/test_connection_revalidation.py"
+]
+for rel in required:
+    if not (ROOT/rel).is_file(): raise SystemExit(f"missing connection revalidation artifact: {rel}")
+for rel in [x for x in required if x.endswith(".json")]:
+    json.loads((ROOT/rel).read_text(encoding="utf-8"))
+runtime=(ROOT/"runtime/connection_revalidation.py").read_text(encoding="utf-8")
+for marker in ["direct source verification required","provider session verification required","private KV readback verification required","revalidation proof predates","provider operation authority prohibited","credential material prohibited","verify_connection"]:
+    if marker not in runtime: raise SystemExit(f"missing revalidation invariant: {marker}")
+print("KV connection revalidation static checks: PASS")


### PR DESCRIPTION
Implements #119.

Adds the exact non-secret proof contract required to restore a connection assembly to VERIFIED:
- provider/source conformance proof;
- private-KV readback proof;
- exact assembly/provider/adapter/path binding;
- direct-source and session verification requirements;
- stale-proof rejection against a required invalidation/recovery time;
- no credential material or provider operation authority;
- reuses the existing canonical `verify_connection` transition only after both proofs pass.

Live provider sessions and readback proof generation remain separate resident runtime gates.