### PR TITLE
Add adjustable organizational KV security posture

### DIFF
--- a/.github/workflows/validate-organization-security-posture.yml
+++ b/.github/workflows/validate-organization-security-posture.yml
@@ -1,0 +1,42 @@
+name: Validate organization KV security posture
+
+on:
+  pull_request:
+    paths:
+      - 'ORG_SECURITY_POSTURE_MIRROR_HANDOFF.md'
+      - 'schemas/kv-organization-security-posture.schema.json'
+      - 'schemas/kv-organization-posture-change-receipt.schema.json'
+      - 'policy/organization-security-postures.v1.json'
+      - 'runtime/organization_security_posture.py'
+      - 'tests/test_organization_security_posture.py'
+      - 'tools/check_organization_security_posture.py'
+      - '.github/workflows/validate-organization-security-posture.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'ORG_SECURITY_POSTURE_MIRROR_HANDOFF.md'
+      - 'schemas/kv-organization-security-posture.schema.json'
+      - 'schemas/kv-organization-posture-change-receipt.schema.json'
+      - 'policy/organization-security-postures.v1.json'
+      - 'runtime/organization_security_posture.py'
+      - 'tests/test_organization_security_posture.py'
+      - 'tools/check_organization_security_posture.py'
+      - '.github/workflows/validate-organization-security-posture.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Static posture checks
+        run: python tools/check_organization_security_posture.py
+      - name: Deterministic posture tests
+        run: python -m unittest tests.test_organization_security_posture -v

--- a/ORG_SECURITY_POSTURE_MIRROR_HANDOFF.md
+++ b/ORG_SECURITY_POSTURE_MIRROR_HANDOFF.md
@@ -1,0 +1,47 @@
+# Organizational KV Security Posture Mirror Handoff
+
+Updated: 2026-08-28
+Repository: StegVerse-Labs/continuity-vault-kit
+Issue: #121
+Branch: feature/org-security-posture-v1
+State: SOURCE_IMPLEMENTED_AWAITING_VALIDATION
+
+## Goal
+
+Make organization/KV privacy, administrative visibility, Replay, Reconstruction, retention and incident-response boundaries explicit before organizational products depend on implicit assumptions.
+
+## Invariants
+
+- Organization posture is a versioned governance contract, not a UI preference.
+- Presets are baselines; scoped overrides may narrow or expand only within declared authority.
+- Posture changes emit a deterministic receipt and do not silently reinterpret historical evidence.
+- Government/high-control posture may default official-use employee KVs to organization-visible without employee consent, while role, purpose, clearance, compartment, privilege and applicable-policy constraints still govern access.
+- "No privacy expectation" does not mean universal access by every organizational actor.
+- P1 enables user-facing Replay; P2 enables user-facing Reconstruction.
+- Evidence/receipt generation is not disabled for lower subscription tiers; tiers govern exposed capabilities.
+- Organization account sizing is employee-KV-count plus org capability level.
+- Replay answers ordered historical transitions; Reconstruction derives state from surviving admissible evidence.
+- Configuration grants no credential, provider, runtime, publication or sovereign execution authority.
+
+## Source surfaces
+
+- schemas/kv-organization-security-posture.schema.json
+- schemas/kv-organization-posture-change-receipt.schema.json
+- policy/organization-security-postures.v1.json
+- runtime/organization_security_posture.py
+- tests/test_organization_security_posture.py
+- tools/check_organization_security_posture.py
+
+## Preset families
+
+EMPLOYEE_PRIVATE
+BUSINESS_GOVERNED
+ADMINISTRATIVE_SUPERVISION
+GOVERNMENT_HIGH_CONTROL
+COMPARTMENTED_REGULATED
+
+## Completion
+
+SOURCE_IMPLEMENTED -> SOURCE_VALIDATED -> MERGED
+
+Runtime/org deployment activation, real employee-KV enrollment, org Replay execution and org Reconstruction execution remain separate evidence transitions.

--- a/policy/organization-security-postures.v1.json
+++ b/policy/organization-security-postures.v1.json
@@ -1,0 +1,75 @@
+{
+  "schema": "stegverse.kv.organization-security-posture-presets/v1",
+  "presets": {
+    "EMPLOYEE_PRIVATE": {
+      "admin_inspection": "BUSINESS_SCOPE",
+      "org_replay": false,
+      "org_reconstruction": false,
+      "cross_kv_search": "BUSINESS_SCOPE",
+      "employee_consent_required": true,
+      "break_glass": true,
+      "legal_hold": true,
+      "audit_receipt_required": true,
+      "compartment_enforcement": false
+    },
+    "BUSINESS_GOVERNED": {
+      "admin_inspection": "BUSINESS_SCOPE",
+      "org_replay": true,
+      "org_reconstruction": false,
+      "cross_kv_search": "BUSINESS_SCOPE",
+      "employee_consent_required": false,
+      "break_glass": true,
+      "legal_hold": true,
+      "audit_receipt_required": true,
+      "compartment_enforcement": false
+    },
+    "ADMINISTRATIVE_SUPERVISION": {
+      "admin_inspection": "BROAD_GOVERNED",
+      "org_replay": true,
+      "org_reconstruction": false,
+      "cross_kv_search": "BROAD_GOVERNED",
+      "employee_consent_required": false,
+      "break_glass": true,
+      "legal_hold": true,
+      "audit_receipt_required": true,
+      "compartment_enforcement": false
+    },
+    "GOVERNMENT_HIGH_CONTROL": {
+      "admin_inspection": "BROAD_GOVERNED",
+      "org_replay": true,
+      "org_reconstruction": true,
+      "cross_kv_search": "BROAD_GOVERNED",
+      "employee_consent_required": false,
+      "break_glass": true,
+      "legal_hold": true,
+      "audit_receipt_required": true,
+      "compartment_enforcement": true
+    },
+    "COMPARTMENTED_REGULATED": {
+      "admin_inspection": "ROLE_COMPARTMENT_BOUND",
+      "org_replay": true,
+      "org_reconstruction": true,
+      "cross_kv_search": "COMPARTMENT_BOUND",
+      "employee_consent_required": false,
+      "break_glass": true,
+      "legal_hold": true,
+      "audit_receipt_required": true,
+      "compartment_enforcement": true
+    }
+  },
+  "tier_rules": {
+    "CORE": {
+      "replay": false,
+      "reconstruction": false
+    },
+    "P1_REPLAY": {
+      "replay": true,
+      "reconstruction": false
+    },
+    "P2_RECONSTRUCTION": {
+      "replay": true,
+      "reconstruction": true
+    }
+  },
+  "authority_effect": "NONE_POLICY_ONLY"
+}

--- a/runtime/organization_security_posture.py
+++ b/runtime/organization_security_posture.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+import hashlib, json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+ROOT=Path(__file__).resolve().parents[1]
+PRESETS=json.loads((ROOT/"policy/organization-security-postures.v1.json").read_text(encoding="utf-8"))
+
+def canonical_hash(obj:dict[str,Any])->str:
+    return hashlib.sha256(json.dumps(obj,sort_keys=True,separators=(",",":"),ensure_ascii=False).encode()).hexdigest()
+
+def materialize_posture(*,organization_id:str,posture_id:str,version:int,preset:str,effective_at:str,employee_kv_count:int,capability_tier:str,official_use_default:bool=False,constraints:list[str]|None=None)->dict[str,Any]:
+    if preset not in PRESETS["presets"]: raise ValueError("UNKNOWN_PRESET")
+    if capability_tier not in PRESETS["tier_rules"]: raise ValueError("UNKNOWN_CAPABILITY_TIER")
+    surfaces=deepcopy(PRESETS["presets"][preset])
+    tier=PRESETS["tier_rules"][capability_tier]
+    # Commercial tier gates user-facing operations; posture may never elevate beyond entitlement.
+    surfaces["org_replay"]=bool(surfaces["org_replay"] and tier["replay"])
+    surfaces["org_reconstruction"]=bool(surfaces["org_reconstruction"] and tier["reconstruction"])
+    if surfaces["org_reconstruction"] and not surfaces["org_replay"]: raise ValueError("RECONSTRUCTION_REQUIRES_REPLAY")
+    return {
+      "schema":"stegverse.kv.organization-security-posture/v1",
+      "organization_id":organization_id,"posture_id":posture_id,"version":version,"preset":preset,"effective_at":effective_at,
+      "scope":{"employee_kv_count":employee_kv_count,"official_use_default":bool(official_use_default)},
+      "capability_tier":capability_tier,"surfaces":surfaces,
+      "history_policy":{"retrospective_scope_change":"EXPLICIT_ONLY","historical_access_requires_explicit_decision":True},
+      "constraints":list(constraints or []),"authority_effect":"NONE_POLICY_ONLY"
+    }
+
+def authorize_operation(posture:dict[str,Any],*,operation:str,actor_role:str,purpose_declared:bool,employee_consent:bool=False,clearance_ok:bool=True,compartment_ok:bool=True)->dict[str,Any]:
+    s=posture["surfaces"]
+    allowed=False; reason="OPERATION_NOT_ADMITTED"
+    if not purpose_declared: reason="PURPOSE_REQUIRED"
+    elif s.get("compartment_enforcement") and (not clearance_ok or not compartment_ok): reason="CLEARANCE_OR_COMPARTMENT_DENIED"
+    elif operation=="INSPECT":
+        allowed=s["admin_inspection"]!="NONE" and actor_role in {"ORG_ADMIN","SECURITY_ADMIN","AUDITOR","IT_ADMIN","INVESTIGATOR"}
+        reason="ADMITTED" if allowed else "ROLE_DENIED"
+    elif operation=="REPLAY":
+        allowed=bool(s["org_replay"]) and actor_role in {"ORG_ADMIN","SECURITY_ADMIN","AUDITOR","INVESTIGATOR"}
+        reason="ADMITTED" if allowed else "TIER_OR_ROLE_DENIED"
+    elif operation=="RECONSTRUCT":
+        allowed=bool(s["org_reconstruction"]) and actor_role in {"SECURITY_ADMIN","AUDITOR","INVESTIGATOR"}
+        reason="ADMITTED" if allowed else "TIER_OR_ROLE_DENIED"
+    elif operation=="SEARCH":
+        allowed=s["cross_kv_search"]!="NONE" and actor_role in {"ORG_ADMIN","SECURITY_ADMIN","AUDITOR","IT_ADMIN","INVESTIGATOR"}
+        reason="ADMITTED" if allowed else "ROLE_DENIED"
+    if allowed and s.get("employee_consent_required") and not employee_consent:
+        allowed=False; reason="EMPLOYEE_CONSENT_REQUIRED"
+    return {"schema":"stegverse.kv.organization-access-decision/v1","operation":operation,"allowed":allowed,"reason":reason,"audit_receipt_required":True,"authority_effect":"NONE_POLICY_EVALUATION_ONLY"}
+
+def posture_change_receipt(prior:dict[str,Any]|None,new:dict[str,Any],*,actor_ref:str,role:str,decision_ref:str,historical_scope_effect:str="NONE")->dict[str,Any]:
+    prior_hash=canonical_hash(prior) if prior else None
+    changed=[]
+    if prior:
+        keys=set(prior.get("surfaces",{}))|set(new.get("surfaces",{}))
+        changed=sorted(k for k in keys if prior.get("surfaces",{}).get(k)!=new.get("surfaces",{}).get(k))
+    else: changed=sorted(new.get("surfaces",{}))
+    if historical_scope_effect!="NONE" and new["history_policy"]["historical_access_requires_explicit_decision"] and historical_scope_effect!="EXPLICITLY_AUTHORIZED":
+        raise ValueError("HISTORICAL_SCOPE_REQUIRES_EXPLICIT_AUTHORIZATION")
+    return {
+      "schema":"stegverse.kv.organization-posture-change-receipt/v1","organization_id":new["organization_id"],
+      "prior_posture_hash":prior_hash,"new_posture_hash":canonical_hash(new),
+      "prior_version":None if prior is None else prior["version"],"new_version":new["version"],"effective_at":new["effective_at"],
+      "changed_surfaces":changed,"historical_scope_effect":historical_scope_effect,
+      "authorized_by":{"actor_ref":actor_ref,"role":role,"decision_ref":decision_ref},"authority_effect":"NONE_POLICY_ONLY"
+    }

--- a/schemas/kv-organization-posture-change-receipt.schema.json
+++ b/schemas/kv-organization-posture-change-receipt.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-organization-posture-change-receipt.schema.json",
+  "title": "StegVerse Organization Posture Change Receipt",
+  "type": "object",
+  "required": [
+    "schema",
+    "organization_id",
+    "prior_posture_hash",
+    "new_posture_hash",
+    "prior_version",
+    "new_version",
+    "effective_at",
+    "changed_surfaces",
+    "historical_scope_effect",
+    "authorized_by",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema": {
+      "const": "stegverse.kv.organization-posture-change-receipt/v1"
+    },
+    "organization_id": {
+      "type": "string"
+    },
+    "prior_posture_hash": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "new_posture_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "prior_version": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "new_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "effective_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "changed_surfaces": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "historical_scope_effect": {
+      "enum": [
+        "NONE",
+        "EXPLICITLY_AUTHORIZED",
+        "POLICY_DEFINED"
+      ]
+    },
+    "authorized_by": {
+      "type": "object",
+      "required": [
+        "actor_ref",
+        "role",
+        "decision_ref"
+      ],
+      "properties": {
+        "actor_ref": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        },
+        "decision_ref": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "authority_effect": {
+      "const": "NONE_POLICY_ONLY"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/kv-organization-security-posture.schema.json
+++ b/schemas/kv-organization-security-posture.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-organization-security-posture.schema.json",
+  "title": "StegVerse KV Organization Security Posture",
+  "type": "object",
+  "required": [
+    "schema",
+    "organization_id",
+    "posture_id",
+    "version",
+    "preset",
+    "effective_at",
+    "scope",
+    "capability_tier",
+    "surfaces",
+    "history_policy",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema": {
+      "const": "stegverse.kv.organization-security-posture/v1"
+    },
+    "organization_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "posture_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "preset": {
+      "enum": [
+        "EMPLOYEE_PRIVATE",
+        "BUSINESS_GOVERNED",
+        "ADMINISTRATIVE_SUPERVISION",
+        "GOVERNMENT_HIGH_CONTROL",
+        "COMPARTMENTED_REGULATED"
+      ]
+    },
+    "effective_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "scope": {
+      "type": "object",
+      "required": [
+        "employee_kv_count",
+        "official_use_default"
+      ],
+      "properties": {
+        "employee_kv_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "official_use_default": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "capability_tier": {
+      "enum": [
+        "CORE",
+        "P1_REPLAY",
+        "P2_RECONSTRUCTION"
+      ]
+    },
+    "surfaces": {
+      "type": "object",
+      "required": [
+        "admin_inspection",
+        "org_replay",
+        "org_reconstruction",
+        "cross_kv_search",
+        "employee_consent_required",
+        "break_glass",
+        "legal_hold",
+        "audit_receipt_required",
+        "compartment_enforcement"
+      ],
+      "properties": {
+        "admin_inspection": {
+          "enum": [
+            "NONE",
+            "BUSINESS_SCOPE",
+            "BROAD_GOVERNED",
+            "ROLE_COMPARTMENT_BOUND"
+          ]
+        },
+        "org_replay": {
+          "type": "boolean"
+        },
+        "org_reconstruction": {
+          "type": "boolean"
+        },
+        "cross_kv_search": {
+          "enum": [
+            "NONE",
+            "BUSINESS_SCOPE",
+            "BROAD_GOVERNED",
+            "COMPARTMENT_BOUND"
+          ]
+        },
+        "employee_consent_required": {
+          "type": "boolean"
+        },
+        "break_glass": {
+          "type": "boolean"
+        },
+        "legal_hold": {
+          "type": "boolean"
+        },
+        "audit_receipt_required": {
+          "const": true
+        },
+        "compartment_enforcement": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "history_policy": {
+      "type": "object",
+      "required": [
+        "retrospective_scope_change",
+        "historical_access_requires_explicit_decision"
+      ],
+      "properties": {
+        "retrospective_scope_change": {
+          "enum": [
+            "PROHIBITED",
+            "EXPLICIT_ONLY",
+            "POLICY_DEFINED"
+          ]
+        },
+        "historical_access_requires_explicit_decision": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "constraints": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "authority_effect": {
+      "const": "NONE_POLICY_ONLY"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),45)
+        self.assertEqual(len(workflows),46)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tests/test_organization_security_posture.py
+++ b/tests/test_organization_security_posture.py
@@ -1,0 +1,41 @@
+import unittest
+from runtime.organization_security_posture import materialize_posture, authorize_operation, posture_change_receipt
+
+class OrgPostureTests(unittest.TestCase):
+    def mk(self,preset="GOVERNMENT_HIGH_CONTROL",tier="P2_RECONSTRUCTION",version=1):
+        return materialize_posture(organization_id="org:test",posture_id="posture:test",version=version,preset=preset,effective_at="2026-08-28T23:00:00Z",employee_kv_count=100,capability_tier=tier,official_use_default=True)
+
+    def test_p1_replay_but_not_reconstruction(self):
+        p=self.mk(tier="P1_REPLAY")
+        self.assertTrue(p["surfaces"]["org_replay"])
+        self.assertFalse(p["surfaces"]["org_reconstruction"])
+
+    def test_p2_reconstruction_requires_authorized_role(self):
+        p=self.mk()
+        self.assertTrue(authorize_operation(p,operation="RECONSTRUCT",actor_role="AUDITOR",purpose_declared=True)["allowed"])
+        self.assertFalse(authorize_operation(p,operation="RECONSTRUCT",actor_role="IT_ADMIN",purpose_declared=True)["allowed"])
+
+    def test_government_posture_no_employee_consent_requirement(self):
+        p=self.mk()
+        d=authorize_operation(p,operation="INSPECT",actor_role="IT_ADMIN",purpose_declared=True,employee_consent=False)
+        self.assertTrue(d["allowed"])
+
+    def test_compartment_denies_even_broad_org_authority(self):
+        p=self.mk()
+        d=authorize_operation(p,operation="INSPECT",actor_role="IT_ADMIN",purpose_declared=True,clearance_ok=False)
+        self.assertFalse(d["allowed"]); self.assertEqual(d["reason"],"CLEARANCE_OR_COMPARTMENT_DENIED")
+
+    def test_employee_private_requires_consent(self):
+        p=self.mk(preset="EMPLOYEE_PRIVATE",tier="P1_REPLAY")
+        d=authorize_operation(p,operation="INSPECT",actor_role="ORG_ADMIN",purpose_declared=True,employee_consent=False)
+        self.assertFalse(d["allowed"]); self.assertEqual(d["reason"],"EMPLOYEE_CONSENT_REQUIRED")
+
+    def test_posture_change_is_hash_bound_and_history_not_silent(self):
+        a=self.mk(version=1)
+        b=self.mk(preset="COMPARTMENTED_REGULATED",version=2)
+        r=posture_change_receipt(a,b,actor_ref="actor:1",role="SECURITY_ADMIN",decision_ref="decision:2")
+        self.assertEqual(r["prior_version"],1); self.assertEqual(r["new_version"],2)
+        self.assertEqual(r["historical_scope_effect"],"NONE")
+        self.assertEqual(len(r["new_posture_hash"]),64)
+
+if __name__=="__main__": unittest.main()

--- a/tools/check_organization_security_posture.py
+++ b/tools/check_organization_security_posture.py
@@ -14,7 +14,11 @@ for rel in required:
     if not (ROOT/rel).is_file(): raise SystemExit("missing "+rel)
 for rel in [x for x in required if x.endswith(".json")]:
     json.loads((ROOT/rel).read_text(encoding="utf-8"))
-src=(ROOT/"runtime/organization_security_posture.py").read_text(encoding="utf-8")
+src="\n".join((ROOT/rel).read_text(encoding="utf-8") for rel in [
+ "runtime/organization_security_posture.py",
+ "policy/organization-security-postures.v1.json",
+ "schemas/kv-organization-security-posture.schema.json"
+])
 for marker in ["GOVERNMENT_HIGH_CONTROL","P1_REPLAY","P2_RECONSTRUCTION","HISTORICAL_SCOPE_REQUIRES_EXPLICIT_AUTHORIZATION","NONE_POLICY_ONLY","CLEARANCE_OR_COMPARTMENT_DENIED"]:
     if marker not in src: raise SystemExit("missing invariant "+marker)
 print("organization security posture static checks: PASS")

--- a/tools/check_organization_security_posture.py
+++ b/tools/check_organization_security_posture.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+required=[
+ "ORG_SECURITY_POSTURE_MIRROR_HANDOFF.md",
+ "schemas/kv-organization-security-posture.schema.json",
+ "schemas/kv-organization-posture-change-receipt.schema.json",
+ "policy/organization-security-postures.v1.json",
+ "runtime/organization_security_posture.py",
+ "tests/test_organization_security_posture.py"
+]
+for rel in required:
+    if not (ROOT/rel).is_file(): raise SystemExit("missing "+rel)
+for rel in [x for x in required if x.endswith(".json")]:
+    json.loads((ROOT/rel).read_text(encoding="utf-8"))
+src=(ROOT/"runtime/organization_security_posture.py").read_text(encoding="utf-8")
+for marker in ["GOVERNMENT_HIGH_CONTROL","P1_REPLAY","P2_RECONSTRUCTION","HISTORICAL_SCOPE_REQUIRES_EXPLICIT_AUTHORIZATION","NONE_POLICY_ONLY","CLEARANCE_OR_COMPARTMENT_DENIED"]:
+    if marker not in src: raise SystemExit("missing invariant "+marker)
+print("organization security posture static checks: PASS")


### PR DESCRIPTION
Implements #121.

Adds a versioned organization/KV security-posture contract before Org Replay/Reconstruction and pricing harden implicit privacy assumptions.

Included:
- posture schema + posture-change receipt schema;
- five baseline posture families, including GOVERNMENT_HIGH_CONTROL and COMPARTMENTED_REGULATED;
- CORE / P1_REPLAY / P2_RECONSTRUCTION capability gates;
- deterministic access evaluator enforcing role/purpose/clearance/compartment/consent boundaries;
- explicit history policy preventing silent retrospective scope reinterpretation;
- hash-bound posture-change receipts;
- deterministic tests;
- validation-only GitHub workflow with contents:read and persisted checkout credentials disabled;
- canonical scoped mirror handoff.

No credential, runtime, provider, publication, or sovereign execution authority is created by this policy layer.