### PR TITLE
docs(kv): reconcile connection owner handoffs after merge

### DIFF
--- a/KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md
+++ b/KV_CONNECTION_ASSEMBLY_SOURCE_MIRROR_HANDOFF.md
@@ -1,9 +1,9 @@
 # KV Connection Assembly Source Mirror Handoff
 
-Status: SOURCE_IMPLEMENTED_ON_BRANCH / VALIDATION_PENDING
+Status: SOURCE_MERGED_VALIDATED / LIVE_CONNECTION_OBSERVATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #113
-Branch: `feature/kv-connection-assembly-source`
+Branch: `main`
 Updated: 2026-08-28
 Authority effect: NONE
 Activation effect: false
@@ -160,3 +160,28 @@ This lane does not:
 ## Current boundary
 
 Machine-executable source contract is implemented on this branch. No source monitoring process is live, no provider change has been observed by this lane, no connection has been activated, and no credential or provider execution authority is granted.
+
+
+## Post-merge canonical reconciliation — 2026-08-28
+
+```text
+issue: #113
+pull_request: #114
+merge_commit: 660861d98f7ec57ee85baa6f53540d79584dcc10
+source_state: MERGED_VALIDATED
+authority_effect: NONE
+activation_effect: false
+```
+
+Validation evidence:
+
+```text
+Validate KV Connection Assembly run 33191143644: SUCCESS
+Security Baseline run 33191143335: SUCCESS
+Repository validation diagnostics run 33191143584: SUCCESS
+KV Guardrails run 33191143383: SUCCESS
+```
+
+Source contract, schemas, runtime assembly logic, synthetic tests, and validation are merged. No live provider connection, provider login, credential resolution, or production provider monitoring is claimed.
+
+GitHub Actions remain validation-only. TV/TVC remains credential authority. These source merges do not prove resident execution, provider compatibility, private-KV user state, provider login, or external provider operation.

--- a/KV_CONNECTION_REGISTRY_MATERIALIZATION_MIRROR_HANDOFF.md
+++ b/KV_CONNECTION_REGISTRY_MATERIALIZATION_MIRROR_HANDOFF.md
@@ -1,9 +1,9 @@
 # KV Connection Registry Materialization Mirror Handoff
 
-Status: SOURCE_IMPLEMENTED_ON_BRANCH / VALIDATION_PENDING
+Status: SOURCE_MERGED_VALIDATED / PRIVATE_KV_RUNTIME_MATERIALIZATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #115
-Branch: `feature/kv-connection-registry-materialization`
+Branch: `main`
 Updated: 2026-08-28
 Authority effect: NONE
 Activation effect: false
@@ -55,3 +55,28 @@ KnowledgeVault/
 ## Current boundary
 
 Machine-executable template/store source is implemented on this branch. No live provider connection, credential resolution, provider monitoring, or private user assembly state is committed to the repository.
+
+
+## Post-merge canonical reconciliation — 2026-08-28
+
+```text
+issue: #115
+pull_request: #116
+merge_commit: c7e895d3179800a395f19e5f376d6688b6e1f797
+source_state: MERGED_VALIDATED
+authority_effect: NONE
+activation_effect: false
+```
+
+Validation evidence:
+
+```text
+Validate KV Connection Registry Materialization run 33191624549: SUCCESS
+Security Baseline run 33191624719: SUCCESS
+Repository validation diagnostics run 33191624543: SUCCESS
+KV Guardrails run 33191624582: SUCCESS
+```
+
+Private-KV registry template/store source is merged and validated. No live user-specific assembly state, provider connection, credential resolution, or provider monitoring is claimed.
+
+GitHub Actions remain validation-only. TV/TVC remains credential authority. These source merges do not prove resident execution, provider compatibility, private-KV user state, provider login, or external provider operation.

--- a/KV_MONITOR_TARGETS_CANONICAL_STATE_MIRROR_HANDOFF.md
+++ b/KV_MONITOR_TARGETS_CANONICAL_STATE_MIRROR_HANDOFF.md
@@ -1,9 +1,9 @@
 # KV Monitor Targets Canonical State Mirror Handoff
 
-Status: SOURCE_IMPLEMENTED_ON_BRANCH / VALIDATION_PENDING
+Status: SOURCE_MERGED_VALIDATED / RESIDENT_MONITORING_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Issue: #117
-Branch: `feature/kv-monitor-targets-canonical`
+Branch: `main`
 Updated: 2026-08-28
 Authority effect: NONE
 Activation effect: false
@@ -70,3 +70,28 @@ Each target must bind:
 ## Current boundary
 
 Machine-executable source, empty private-KV template, compiler, tests, and validation are implemented on this branch. No live provider source monitoring is performed by this branch.
+
+
+## Post-merge canonical reconciliation — 2026-08-28
+
+```text
+issue: #117
+pull_request: #118
+merge_commit: 42bbb3dce721cedacff1d00e1f275a02b29f4712
+source_state: MERGED_VALIDATED
+authority_effect: NONE
+activation_effect: false
+```
+
+Validation evidence:
+
+```text
+Validate KV Monitor Targets run 33192150101: SUCCESS
+Validate KV Connection Registry Materialization run 33192149994: SUCCESS
+Security Baseline run 33192150199: SUCCESS
+Repository validation diagnostics run 33192150031: SUCCESS
+```
+
+Canonical non-secret provider monitor target source is merged and validated. The resident provider-change observer remains the execution consumer; no live provider monitoring is claimed.
+
+GitHub Actions remain validation-only. TV/TVC remains credential authority. These source merges do not prove resident execution, provider compatibility, private-KV user state, provider login, or external provider operation.


### PR DESCRIPTION
Corrects stale branch/validation-pending headers in the canonical KV connection source handoffs after PRs #114, #116, and #118 merged successfully. Records exact merge commits and green connection-assembly, registry-materialization, monitor-target, security, diagnostics, and KV guardrail validation evidence. Source state becomes MERGED_VALIDATED while live provider connection, private-KV user state, resident monitoring, credential resolution, provider login, and provider operation remain explicitly unclaimed. Authority effect remains NONE; TV/TVC remains credential authority.