### PR TITLE
Add KV-backed typed transport capability governance

### DIFF
--- a/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
+++ b/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
@@ -1,0 +1,94 @@
+# KV Typed Transport Capability Governance Mirror Handoff
+
+Status: ACTIVE_IMPLEMENTATION
+Repository: StegVerse-Labs/continuity-vault-kit
+Issue: #124
+Branch: build/kv-typed-transport-capability-124
+Created: 2026-08-30
+
+## Goal
+
+Make typed transport capability a first-class KnowledgeVault / Device-Node governance object.
+
+This lane formalizes the first governance layer for transport-capable StegVerse interactions:
+
+```text
+Device/StegOS Node continuity
+  -> KnowledgeVault continuity binding
+  -> typed transport capability
+  -> Interlock admission
+  -> adjacent InTr transport
+  -> HANDOFF_RECEIPT / reconstruction evidence
+```
+
+The transport capability is not generic network reachability and is not equivalent to its carrier protocol.
+
+## Governing invariants
+
+- A governed transport lane may not become ACTIVE without an admissible Node continuity root and a KV continuity binding or equivalent reconstruction evidence.
+- KnowledgeVault is the durable continuity/reconstruction host.
+- Device/StegOS is the ephemeral activity edge.
+- A transport capability is typed by governed semantics; carrier protocol is recorded separately.
+- HTTPS does not imply one generic StegVerse transport capability.
+- Capability evidence does not grant execution, identity, credential, governance, provider, or endpoint authority.
+- Credential authority remains TV/TVC.
+- Each independently governed Interlock/InTr boundary must still admit its own transition and issue its own receipt.
+- Valid capability evidence may be reused by later lanes only while its continuity binding and lifecycle state remain valid.
+- Revoked, expired, or superseded capability evidence must fail closed.
+- Installation/source presence never implies runtime activation or OBSERVED transport.
+
+## Initial capability types
+
+```text
+KV_DISTRIBUTION_DOWNLOAD
+DEVICE_KV_INTR
+PUBLIC_HTTPS_INGRESS
+ADJACENT_EXTERNAL_API_EGRESS
+NODE_TO_NODE_SYNC
+KV_SKAP_INTR
+TVC_RELAY
+```
+
+These names describe StegVerse transport semantics, not merely carrier technology.
+
+## Reference observations
+
+- Hugging Face / SV-DN-1 is the first successful observed Node-rooted external transport pattern and corresponds to an adjacent external API egress capability.
+- HIL is the next governed instantiation and requires a public HTTPS ingress capability.
+- KnowledgeVault distribution is itself a transport establishment event in the canonical onboarding path: Node establishment precedes governed distribution/download and later KV binding.
+
+## Automation requirement
+
+For a new evaluator, third party, or user, capability establishment should be protocol-driven where possible:
+
+```text
+transport requested
+-> establish/recover Device Node
+-> bind/reconstruct KV continuity
+-> determine required transport type
+-> reuse valid capability OR execute capability-establishment protocol
+-> emit capability receipt
+-> admit requested Interlock/InTr lane
+-> execute
+-> persist receipts/reconstruction evidence to KV
+```
+
+A registration page is one possible UI, not an architectural requirement. Human interaction is required only when a policy/authority/consent predicate actually requires it.
+
+## Source deliverables
+
+- `schemas/kv-transport-capability-registry.schema.json`
+- `specs/kv-transport-capability-registry.v1.json`
+- `scripts/validate_kv_transport_capability_registry.py`
+- `tests/test_kv_transport_capability_registry.py`
+
+## Runtime/non-claims
+
+This lane does not itself activate any Node, transport, Interlock, InTr, provider, credential, endpoint, or external side effect.
+
+The Hugging Face observation remains OBSERVED independently of this source abstraction.
+The HIL runtime observation remains a separate live gate.
+
+## Next executable action
+
+Implement and validate the typed transport capability registry, then reconcile it into KnowledgeVault readiness and downstream StegOS consumption without promoting source state to runtime activation.

--- a/schemas/kv-transport-capability-registry.schema.json
+++ b/schemas/kv-transport-capability-registry.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-transport-capability-registry.schema.json",
+  "title": "KnowledgeVault typed transport capability registry",
+  "type": "object",
+  "required": [
+    "schema",
+    "state",
+    "device_role",
+    "kv_role",
+    "credential_authority",
+    "authority_effect",
+    "runtime_activation_claimed",
+    "capabilities"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.kv.transport-capability-registry/v1"},
+    "state": {"const": "DEFINED_INACTIVE"},
+    "device_role": {"const": "EPHEMERAL_ACTIVITY_EDGE"},
+    "kv_role": {"const": "DURABLE_STATE_CONTINUITY_AND_RECONSTRUCTION"},
+    "credential_authority": {"const": "TV/TVC"},
+    "authority_effect": {"const": "NONE"},
+    "runtime_activation_claimed": {"const": false},
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "capability_type",
+          "capability_state",
+          "direction",
+          "carrier_profiles",
+          "binding_requirements",
+          "required_boundaries",
+          "receipt_requirements",
+          "reuse_policy",
+          "authority_effect",
+          "runtime_observed"
+        ],
+        "properties": {
+          "capability_type": {"type": "string", "minLength": 1},
+          "capability_state": {"const": "DEFINED_UNOBSERVED"},
+          "direction": {"enum": ["INGRESS", "EGRESS", "BIDIRECTIONAL"]},
+          "carrier_profiles": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "binding_requirements": {
+            "type": "object",
+            "required": [
+              "device_node_continuity_required",
+              "kv_continuity_binding_required"
+            ],
+            "properties": {
+              "device_node_continuity_required": {"const": true},
+              "kv_continuity_binding_required": {"const": true}
+            },
+            "additionalProperties": true
+          },
+          "required_boundaries": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "receipt_requirements": {
+            "type": "object",
+            "required": [
+              "capability_establishment_receipt_required",
+              "adjacent_boundary_receipts_required",
+              "reconstruction_evidence_required"
+            ],
+            "properties": {
+              "capability_establishment_receipt_required": {"const": true},
+              "adjacent_boundary_receipts_required": {"const": true},
+              "reconstruction_evidence_required": {"const": true}
+            },
+            "additionalProperties": true
+          },
+          "reuse_policy": {
+            "type": "object",
+            "required": [
+              "reuse_allowed_when_valid",
+              "revoked_fails_closed",
+              "expired_fails_closed",
+              "superseded_fails_closed"
+            ],
+            "properties": {
+              "reuse_allowed_when_valid": {"const": true},
+              "revoked_fails_closed": {"const": true},
+              "expired_fails_closed": {"const": true},
+              "superseded_fails_closed": {"const": true}
+            },
+            "additionalProperties": true
+          },
+          "authority_effect": {"const": "NONE"},
+          "runtime_observed": {"const": false}
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/validate_kv_transport_capability_registry.py
+++ b/scripts/validate_kv_transport_capability_registry.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Validate the KnowledgeVault typed transport capability registry."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "specs" / "kv-transport-capability-registry.v1.json"
+
+REQUIRED_TYPES = {
+    "KV_DISTRIBUTION_DOWNLOAD",
+    "DEVICE_KV_INTR",
+    "PUBLIC_HTTPS_INGRESS",
+    "ADJACENT_EXTERNAL_API_EGRESS",
+    "NODE_TO_NODE_SYNC",
+    "KV_SKAP_INTR",
+    "TVC_RELAY",
+}
+ALLOWED_DIRECTIONS = {"INGRESS", "EGRESS", "BIDIRECTIONAL"}
+
+
+def validate(payload: dict) -> list[str]:
+    failures: list[str] = []
+    if payload.get("schema") != "stegverse.kv.transport-capability-registry/v1":
+        failures.append("unexpected registry schema")
+    if payload.get("state") != "DEFINED_INACTIVE":
+        failures.append("registry must remain DEFINED_INACTIVE")
+    if payload.get("device_role") != "EPHEMERAL_ACTIVITY_EDGE":
+        failures.append("device role drift")
+    if payload.get("kv_role") != "DURABLE_STATE_CONTINUITY_AND_RECONSTRUCTION":
+        failures.append("KV role drift")
+    if payload.get("credential_authority") != "TV/TVC":
+        failures.append("credential authority must remain TV/TVC")
+    if payload.get("authority_effect") != "NONE":
+        failures.append("registry authority_effect must be NONE")
+    if payload.get("runtime_activation_claimed") is not False:
+        failures.append("source registry may not claim runtime activation")
+
+    capabilities = payload.get("capabilities")
+    if not isinstance(capabilities, list) or not capabilities:
+        failures.append("capabilities must be a non-empty list")
+        return failures
+
+    seen: set[str] = set()
+    for cap in capabilities:
+        ctype = cap.get("capability_type")
+        if not isinstance(ctype, str) or not ctype:
+            failures.append("capability_type missing")
+            continue
+        if ctype in seen:
+            failures.append(f"duplicate capability_type: {ctype}")
+        seen.add(ctype)
+
+        if cap.get("capability_state") != "DEFINED_UNOBSERVED":
+            failures.append(f"{ctype}: capability_state must remain DEFINED_UNOBSERVED")
+        if cap.get("direction") not in ALLOWED_DIRECTIONS:
+            failures.append(f"{ctype}: invalid direction")
+        carriers = cap.get("carrier_profiles")
+        if not isinstance(carriers, list) or not carriers:
+            failures.append(f"{ctype}: carrier_profiles required")
+
+        binding = cap.get("binding_requirements")
+        if not isinstance(binding, dict):
+            failures.append(f"{ctype}: binding_requirements required")
+        else:
+            if binding.get("device_node_continuity_required") is not True:
+                failures.append(f"{ctype}: device node continuity must be required")
+            if binding.get("kv_continuity_binding_required") is not True:
+                failures.append(f"{ctype}: KV continuity binding must be required")
+
+        boundaries = cap.get("required_boundaries")
+        if not isinstance(boundaries, list) or not boundaries:
+            failures.append(f"{ctype}: required_boundaries required")
+
+        receipts = cap.get("receipt_requirements")
+        if not isinstance(receipts, dict):
+            failures.append(f"{ctype}: receipt_requirements required")
+        else:
+            for key in (
+                "capability_establishment_receipt_required",
+                "adjacent_boundary_receipts_required",
+                "reconstruction_evidence_required",
+            ):
+                if receipts.get(key) is not True:
+                    failures.append(f"{ctype}: {key} must be true")
+
+        reuse = cap.get("reuse_policy")
+        if not isinstance(reuse, dict):
+            failures.append(f"{ctype}: reuse_policy required")
+        else:
+            for key in (
+                "reuse_allowed_when_valid",
+                "revoked_fails_closed",
+                "expired_fails_closed",
+                "superseded_fails_closed",
+            ):
+                if reuse.get(key) is not True:
+                    failures.append(f"{ctype}: {key} must be true")
+
+        if cap.get("authority_effect") != "NONE":
+            failures.append(f"{ctype}: authority_effect must be NONE")
+        if cap.get("runtime_observed") is not False:
+            failures.append(f"{ctype}: source registry may not claim runtime observation")
+
+    missing = REQUIRED_TYPES - seen
+    extra = seen - REQUIRED_TYPES
+    if missing:
+        failures.append("missing capability types: " + ",".join(sorted(missing)))
+    if extra:
+        failures.append("unexpected capability types: " + ",".join(sorted(extra)))
+
+    by_type = {cap["capability_type"]: cap for cap in capabilities if isinstance(cap, dict) and cap.get("capability_type")}
+    hil = by_type.get("PUBLIC_HTTPS_INGRESS")
+    if hil and "HTTPS" not in hil.get("carrier_profiles", []):
+        failures.append("PUBLIC_HTTPS_INGRESS must include HTTPS carrier profile")
+    hf = by_type.get("ADJACENT_EXTERNAL_API_EGRESS")
+    if hf and hf.get("direction") != "EGRESS":
+        failures.append("ADJACENT_EXTERNAL_API_EGRESS must be EGRESS")
+
+    return failures
+
+
+def main() -> int:
+    payload = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    failures = validate(payload)
+    if failures:
+        print("KV_TRANSPORT_CAPABILITY_REGISTRY_FAIL")
+        for failure in failures:
+            print(failure)
+        return 1
+    print("KV_TRANSPORT_CAPABILITY_REGISTRY_PASS")
+    print(f"CAPABILITY_COUNT={len(payload['capabilities'])}")
+    print("STATE=DEFINED_INACTIVE")
+    print("AUTHORITY_EFFECT=NONE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/kv-transport-capability-registry.v1.json
+++ b/specs/kv-transport-capability-registry.v1.json
@@ -1,0 +1,195 @@
+{
+  "schema": "stegverse.kv.transport-capability-registry/v1",
+  "state": "DEFINED_INACTIVE",
+  "device_role": "EPHEMERAL_ACTIVITY_EDGE",
+  "kv_role": "DURABLE_STATE_CONTINUITY_AND_RECONSTRUCTION",
+  "credential_authority": "TV/TVC",
+  "authority_effect": "NONE",
+  "runtime_activation_claimed": false,
+  "capabilities": [
+    {
+      "capability_type": "KV_DISTRIBUTION_DOWNLOAD",
+      "capability_state": "DEFINED_UNOBSERVED",
+      "direction": "INGRESS",
+      "carrier_profiles": ["HTTP(S)_DOWNLOAD_OR_EQUIVALENT"],
+      "binding_requirements": {
+        "device_node_continuity_required": true,
+        "kv_continuity_binding_required": true,
+        "preinstallation_binding_may_reference_pending_kv_identity": true
+      },
+      "required_boundaries": [
+        "DISTRIBUTION_SOURCE->DEVICE_STEGOS_NODE",
+        "DEVICE_STEGOS_NODE->KNOWLEDGEVAULT_INSTALLATION"
+      ],
+      "receipt_requirements": {
+        "capability_establishment_receipt_required": true,
+        "adjacent_boundary_receipts_required": true,
+        "reconstruction_evidence_required": true
+      },
+      "reuse_policy": {
+        "reuse_allowed_when_valid": true,
+        "revoked_fails_closed": true,
+        "expired_fails_closed": true,
+        "superseded_fails_closed": true
+      },
+      "reference_observation": null,
+      "authority_effect": "NONE",
+      "runtime_observed": false
+    },
+    {
+      "capability_type": "DEVICE_KV_INTR",
+      "capability_state": "DEFINED_UNOBSERVED",
+      "direction": "BIDIRECTIONAL",
+      "carrier_profiles": ["InTr"],
+      "binding_requirements": {
+        "device_node_continuity_required": true,
+        "kv_continuity_binding_required": true
+      },
+      "required_boundaries": ["DEVICE_STEGOS_NODE<->KNOWLEDGEVAULT"],
+      "receipt_requirements": {
+        "capability_establishment_receipt_required": true,
+        "adjacent_boundary_receipts_required": true,
+        "reconstruction_evidence_required": true
+      },
+      "reuse_policy": {
+        "reuse_allowed_when_valid": true,
+        "revoked_fails_closed": true,
+        "expired_fails_closed": true,
+        "superseded_fails_closed": true
+      },
+      "reference_observation": null,
+      "authority_effect": "NONE",
+      "runtime_observed": false
+    },
+    {
+      "capability_type": "PUBLIC_HTTPS_INGRESS",
+      "capability_state": "DEFINED_UNOBSERVED",
+      "direction": "INGRESS",
+      "carrier_profiles": ["HTTPS"],
+      "binding_requirements": {
+        "device_node_continuity_required": true,
+        "kv_continuity_binding_required": true,
+        "public_rendezvous_identity_required": true
+      },
+      "required_boundaries": ["EXTERNAL_REQUESTER->DEVICE_STEGOS_NODE", "DEVICE_STEGOS_NODE->TARGET_INGRESS"],
+      "receipt_requirements": {
+        "capability_establishment_receipt_required": true,
+        "adjacent_boundary_receipts_required": true,
+        "reconstruction_evidence_required": true
+      },
+      "reuse_policy": {
+        "reuse_allowed_when_valid": true,
+        "revoked_fails_closed": true,
+        "expired_fails_closed": true,
+        "superseded_fails_closed": true
+      },
+      "reference_observation": "HIL_REQUIRES_THIS_TYPE_BUT_AUTHENTIC_RUNTIME_OBSERVATION_REMAINS_OPEN",
+      "authority_effect": "NONE",
+      "runtime_observed": false
+    },
+    {
+      "capability_type": "ADJACENT_EXTERNAL_API_EGRESS",
+      "capability_state": "DEFINED_UNOBSERVED",
+      "direction": "EGRESS",
+      "carrier_profiles": ["HTTPS", "PROVIDER_API"],
+      "binding_requirements": {
+        "device_node_continuity_required": true,
+        "kv_continuity_binding_required": true,
+        "destination_validation_required": true
+      },
+      "required_boundaries": ["DEVICE_STEGOS_NODE->EXTERNAL_NETWORK", "EXTERNAL_NETWORK->ENDPOINT"],
+      "receipt_requirements": {
+        "capability_establishment_receipt_required": true,
+        "adjacent_boundary_receipts_required": true,
+        "reconstruction_evidence_required": true
+      },
+      "reuse_policy": {
+        "reuse_allowed_when_valid": true,
+        "revoked_fails_closed": true,
+        "expired_fails_closed": true,
+        "superseded_fails_closed": true
+      },
+      "reference_observation": "SV-DN-1_HUGGING_FACE_OBSERVED_PATTERN",
+      "authority_effect": "NONE",
+      "runtime_observed": false
+    },
+    {
+      "capability_type": "NODE_TO_NODE_SYNC",
+      "capability_state": "DEFINED_UNOBSERVED",
+      "direction": "BIDIRECTIONAL",
+      "carrier_profiles": ["InTr", "NETWORK_TRANSPORT"],
+      "binding_requirements": {
+        "device_node_continuity_required": true,
+        "kv_continuity_binding_required": true,
+        "peer_node_continuity_required": true
+      },
+      "required_boundaries": ["DEVICE_STEGOS_NODE->EXTERNAL_NETWORK", "EXTERNAL_NETWORK->PEER_STEGOS_NODE"],
+      "receipt_requirements": {
+        "capability_establishment_receipt_required": true,
+        "adjacent_boundary_receipts_required": true,
+        "reconstruction_evidence_required": true
+      },
+      "reuse_policy": {
+        "reuse_allowed_when_valid": true,
+        "revoked_fails_closed": true,
+        "expired_fails_closed": true,
+        "superseded_fails_closed": true
+      },
+      "reference_observation": null,
+      "authority_effect": "NONE",
+      "runtime_observed": false
+    },
+    {
+      "capability_type": "KV_SKAP_INTR",
+      "capability_state": "DEFINED_UNOBSERVED",
+      "direction": "BIDIRECTIONAL",
+      "carrier_profiles": ["InTr"],
+      "binding_requirements": {
+        "device_node_continuity_required": true,
+        "kv_continuity_binding_required": true,
+        "skap_boundary_binding_required": true
+      },
+      "required_boundaries": ["KNOWLEDGEVAULT<->SKAP_VAULT"],
+      "receipt_requirements": {
+        "capability_establishment_receipt_required": true,
+        "adjacent_boundary_receipts_required": true,
+        "reconstruction_evidence_required": true
+      },
+      "reuse_policy": {
+        "reuse_allowed_when_valid": true,
+        "revoked_fails_closed": true,
+        "expired_fails_closed": true,
+        "superseded_fails_closed": true
+      },
+      "reference_observation": null,
+      "authority_effect": "NONE",
+      "runtime_observed": false
+    },
+    {
+      "capability_type": "TVC_RELAY",
+      "capability_state": "DEFINED_UNOBSERVED",
+      "direction": "BIDIRECTIONAL",
+      "carrier_profiles": ["InTr", "TVC_ADMITTED_RELAY"],
+      "binding_requirements": {
+        "device_node_continuity_required": true,
+        "kv_continuity_binding_required": true,
+        "tvc_admission_required": true
+      },
+      "required_boundaries": ["DEVICE_OR_RUNTIME->TVC", "TVC->ADMITTED_DESTINATION"],
+      "receipt_requirements": {
+        "capability_establishment_receipt_required": true,
+        "adjacent_boundary_receipts_required": true,
+        "reconstruction_evidence_required": true
+      },
+      "reuse_policy": {
+        "reuse_allowed_when_valid": true,
+        "revoked_fails_closed": true,
+        "expired_fails_closed": true,
+        "superseded_fails_closed": true
+      },
+      "reference_observation": null,
+      "authority_effect": "NONE",
+      "runtime_observed": false
+    }
+  ]
+}

--- a/tests/test_kv_transport_capability_registry.py
+++ b/tests/test_kv_transport_capability_registry.py
@@ -1,0 +1,84 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "validate_kv_transport_capability_registry",
+    ROOT / "scripts" / "validate_kv_transport_capability_registry.py",
+)
+module = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(module)
+
+REGISTRY = json.loads(
+    (ROOT / "specs" / "kv-transport-capability-registry.v1.json").read_text(encoding="utf-8")
+)
+
+
+def test_current_registry_is_fail_closed_and_non_authorizing():
+    assert module.validate(REGISTRY) == []
+    assert REGISTRY["state"] == "DEFINED_INACTIVE"
+    assert REGISTRY["credential_authority"] == "TV/TVC"
+    assert REGISTRY["authority_effect"] == "NONE"
+    assert REGISTRY["runtime_activation_claimed"] is False
+    assert all(cap["capability_state"] == "DEFINED_UNOBSERVED" for cap in REGISTRY["capabilities"])
+    assert all(cap["runtime_observed"] is False for cap in REGISTRY["capabilities"])
+    assert all(cap["authority_effect"] == "NONE" for cap in REGISTRY["capabilities"])
+
+
+def test_every_transport_type_requires_node_and_kv_continuity():
+    for cap in REGISTRY["capabilities"]:
+        binding = cap["binding_requirements"]
+        assert binding["device_node_continuity_required"] is True
+        assert binding["kv_continuity_binding_required"] is True
+
+
+def test_carrier_protocol_does_not_collapse_distinct_transport_types():
+    by_type = {cap["capability_type"]: cap for cap in REGISTRY["capabilities"]}
+    hil = by_type["PUBLIC_HTTPS_INGRESS"]
+    hf = by_type["ADJACENT_EXTERNAL_API_EGRESS"]
+    assert "HTTPS" in hil["carrier_profiles"]
+    assert "HTTPS" in hf["carrier_profiles"]
+    assert hil["capability_type"] != hf["capability_type"]
+    assert hil["direction"] == "INGRESS"
+    assert hf["direction"] == "EGRESS"
+
+
+def test_transport_capability_requires_receipts_and_reconstruction():
+    for cap in REGISTRY["capabilities"]:
+        receipts = cap["receipt_requirements"]
+        assert receipts["capability_establishment_receipt_required"] is True
+        assert receipts["adjacent_boundary_receipts_required"] is True
+        assert receipts["reconstruction_evidence_required"] is True
+
+
+def test_revoked_expired_or_superseded_capability_fails_closed():
+    for cap in REGISTRY["capabilities"]:
+        policy = cap["reuse_policy"]
+        assert policy["reuse_allowed_when_valid"] is True
+        assert policy["revoked_fails_closed"] is True
+        assert policy["expired_fails_closed"] is True
+        assert policy["superseded_fails_closed"] is True
+
+
+def test_validator_rejects_runtime_observation_in_source_registry():
+    payload = copy.deepcopy(REGISTRY)
+    payload["capabilities"][0]["runtime_observed"] = True
+    failures = module.validate(payload)
+    assert any("may not claim runtime observation" in failure for failure in failures)
+
+
+def test_validator_rejects_missing_kv_binding_requirement():
+    payload = copy.deepcopy(REGISTRY)
+    payload["capabilities"][0]["binding_requirements"]["kv_continuity_binding_required"] = False
+    failures = module.validate(payload)
+    assert any("KV continuity binding must be required" in failure for failure in failures)
+
+
+def test_validator_rejects_duplicate_transport_type():
+    payload = copy.deepcopy(REGISTRY)
+    payload["capabilities"].append(copy.deepcopy(payload["capabilities"][0]))
+    failures = module.validate(payload)
+    assert any("duplicate capability_type" in failure for failure in failures)


### PR DESCRIPTION
Closes #124.

Implements the first-level transport governance abstraction for KnowledgeVault / Device-Node continuity. Adds a typed transport-capability registry, schema, validator, tests, and canonical handoff. Carrier protocols remain distinct from governed StegVerse transport types. All source states remain non-authorizing and runtime-unobserved.