### PR TITLE
Add governed KV document export boundary

### DIFF
--- a/.github/workflows/kv-document-export.yml
+++ b/.github/workflows/kv-document-export.yml
@@ -1,0 +1,52 @@
+name: Validate governed KV document export
+
+on:
+  pull_request:
+    paths:
+      - "runtime/document_export.py"
+      - "schemas/kv-document-export-request.schema.json"
+      - "fixtures/document-export/**"
+      - "tests/test_document_export.py"
+      - "tools/prepare_document_export.py"
+      - "vault_template/KnowledgeVault/_System/Exports/**"
+      - "KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md"
+      - ".github/workflows/kv-document-export.yml"
+  push:
+    branches: [main]
+    paths:
+      - "runtime/document_export.py"
+      - "schemas/kv-document-export-request.schema.json"
+      - "fixtures/document-export/**"
+      - "tests/test_document_export.py"
+      - "tools/prepare_document_export.py"
+      - "vault_template/KnowledgeVault/_System/Exports/**"
+      - "KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md"
+      - ".github/workflows/kv-document-export.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Compile document export boundary
+        run: python -m py_compile runtime/document_export.py tools/prepare_document_export.py tests/test_document_export.py
+      - name: Validate schema JSON
+        run: python -m json.tool schemas/kv-document-export-request.schema.json >/dev/null
+      - name: Run document export tests
+        run: python -m unittest tests.test_document_export -v
+      - name: Demonstrate bounded preparation
+        run: |
+          python tools/prepare_document_export.py \
+            fixtures/document-export/admitted.json \
+            --bundle-out /tmp/publisher-bundle.json \
+            --receipt-out /tmp/kv-export-receipt.json
+          test -s /tmp/publisher-bundle.json
+          test -s /tmp/kv-export-receipt.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- governed KV-to-Publisher document export preparation with owner-scoped formats, provenance/fidelity classes, owner-approved redaction, deterministic receipts, revocation evidence, and fail-closed tests
 - governed KnowledgeVault email-continuity ingress contract with pre-admission staging, fail-closed admission decisions, SKAP Vault credential-reference binding, deterministic mailbox mapping, and source-ready runtime validation
 - provider-neutral email account mapping runtime that prohibits raw mailbox secrets in KV state and requires `skap://` binding before provider-session verification
 - documented-unverified Gmail, Microsoft Graph/Outlook, and iCloud Mail provider adapter metadata with minimum read access, explicit user authorization, SKAP Vault credential destination, and fail-closed unknown-domain handling
@@ -29,6 +30,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 - preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
 
 ### Notes
+- the new document-export source is locally validated but remains unmerged, uninstalled in the connected KnowledgeVault, and inactive until private-KV transport/readback evidence exists
 - production KV endpoint deployment, live InTr boundary identity/sealing, canonical Site readback, SKAP owner ingress, provider execution, and TVC release publication remain separate runtime evidence gates
 
 ---

--- a/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -803,3 +803,29 @@ Connected Drive evidence:
 - machine-readable repository evidence: `evidence/kv/2026-08-28-personal-contact-profile-connected-installation.json`
 
 The previous installation receipt was retired only after the refreshed current-tree receipt was verified. This parity closure has `authority_effect=NONE` and `activation_effect=false`; no provider credential, SKAP capability, Interlock transport, or email-monitoring activation occurred.
+
+
+## Governed KV-to-Publisher document export — 2026-08-29
+
+The feature branch `feature/kv-governed-document-export` adds a fail-closed
+preparation boundary for owner-selected KnowledgeVault evidence and a
+source-template destination under `_System/Exports/`.
+
+```text
+schema: stegverse.kv.document-export-request/v1
+destination: GCAT-BCAT-Engine/Publisher
+formats: Markdown, HTML, PDF, DOCX, JSON
+content classes: RAW_SOURCE_EXCERPT, OWNER_AUTHORED, AI_DERIVED
+local unit validation: 9/9 PASS
+hosted workflow authority: VALIDATION_TRANSPORT_ONLY
+authority_effect: NONE
+state: IMPLEMENTED_LOCAL_VALIDATED
+```
+
+The source-template delta is exactly four files beneath
+`vault_template/KnowledgeVault/_System/Exports/` (root guidance plus Requests,
+Receipts, and Artifacts guidance). Those files are developed source, not
+placeholders, but they are not yet installed in the connected KnowledgeVault.
+No private request, InTr transmission, Publisher artifact readback, publication,
+release, deployment, or runtime activation is claimed. The scoped continuation
+record is `KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md`.

--- a/KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md
+++ b/KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md
@@ -1,0 +1,89 @@
+# KnowledgeVault Governed Document Export Mirror Handoff
+
+Status: IMPLEMENTED_LOCAL_VALIDATED
+Repository: StegVerse-Labs/continuity-vault-kit
+Destination: GCAT-BCAT-Engine/Publisher
+Updated: 2026-08-29
+
+## Goal
+
+Give a KnowledgeVault owner a governed path to create portable documents from
+selected KV evidence without turning Publisher, a renderer, a model, transport,
+or a stored credential into source or publication authority.
+
+## Implemented source
+
+```text
+schemas/kv-document-export-request.schema.json
+runtime/document_export.py
+tools/prepare_document_export.py
+fixtures/document-export/admitted.json
+tests/test_document_export.py
+.github/workflows/kv-document-export.yml
+vault_template/KnowledgeVault/_System/Exports/**
+```
+
+The source distinguishes raw excerpts, owner-authored text, and AI-derived text;
+binds every non-owner-authored section to admitted evidence; preserves fidelity,
+retention, supersession, and content hashes; rejects restricted/policy/SKAP paths;
+requires owner-approved redaction; prevents format expansion; and produces a
+hash-bound Publisher bundle plus a deterministic preparation receipt.
+
+## Lifecycle boundary
+
+```text
+KV request != prepared export
+prepared export != transmitted bundle
+transmitted bundle != Publisher admission
+Publisher admission != rendered artifact
+rendered artifact != publication
+publication != release
+revocation != deletion or public retraction authority
+```
+
+Current state:
+
+```text
+PLANNED: complete
+IMPLEMENTED: source complete on feature branch
+VALIDATED: dependency-light local unit, CLI, schema, compile, and hosted-authority checks pass
+MERGED: no
+DEPLOYED: no
+ACTIVATED: no
+OBSERVED: no connected-KV request/artifact readback
+RECONSTRUCTED: synthetic fixture replay is deterministic; no retained private-KV replay evidence
+RELEASED: no
+COMPLETE: no
+```
+
+## Remaining gates
+
+1. Validate the exact branch head through repository workflows.
+2. Merge only the validated head.
+3. Install the four-file `_System/Exports/` source-template delta into the connected KV.
+4. Obtain one owner-authorized private-KV export request and Interlock receipts.
+5. Admit and render the exact bundle in Publisher.
+6. Read back the artifact manifest and receipt into the private KV.
+7. Prove deterministic reconstruction from the retained private bundle.
+
+## Local validation
+
+```text
+python -m unittest tests.test_document_export -v: 9/9 PASS
+python tools/prepare_document_export.py ...: PASS
+python -m unittest tests.test_global_hosted_workflow_authority -v: PASS
+python -m compileall -q runtime tools tests: PASS
+schema JSON parsing: PASS
+repository-wide unittest discovery: 375 runnable tests PASS; 4 stale
+provider-workflow assertions were reconciled to validation-only authority; 2
+pytest-only modules are not runnable under the dependency-light unittest environment
+```
+
+## Authority
+
+KV remains source-selection, authorization, redaction, fidelity, provenance, and
+revocation authority. Publisher owns bounded composition and rendering only.
+TV/TVC and SKAP credential authority are unchanged. GitHub Actions validates and
+transports evidence only and cannot mutate canonical repository or runtime state.
+
+🔒 Layer: Framework | KV

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,7 @@ current_version: 0.1.9
 current_focus: preserve verified v0.1.9 as the last published release while preparing the next Unreleased candidate for TV/TVC-only publication, deploying the merged KV Interlock/runtime-provider surfaces on admitted sovereign execution, and collecting authentic private-KV/provider evidence
 known_gaps:
   - Replacement TVC-admitted KnowledgeVault release publication runtime is not yet observed; hosted GitHub workflows are validation/evidence transport only
+  - Governed KV-to-Publisher document export source is locally validated on its feature branch, but the four-file `_System/Exports/` template delta is not installed in the connected KV and no private export/readback is observed
   - Merged KV Interlock runtime endpoint core is not yet deployed behind a live verified DEVICE-to-KV InTr boundary identity/sealing service and durable receipt store
   - Live mailbox/provider/SKAP activation and authentic provider-generated private-KV readback remain unproven
   - Coinbase and other direct-source finance normalization are source-implemented/validated but still require authentic SKAP-backed provider-session and private-KV evidence
@@ -21,6 +22,7 @@ completed_recently:
   - Closed completed source issues #39, #52, #56, #68, #106, #108, #111, #113, #115, #117, and #119 after live reconciliation
   - Reconciled specialized finance/direct-source/Coinbase handoffs from stale implementation-pending state to merged/validated source state
 next_steps:
+  - Merge the exact validated KV document-export head, install the four-file `_System/Exports/` delta through the governed connected-KV path, then prove one owner-authorized Publisher render and receipt readback
   - Treat docs/release_evidence/latest_release.json and GitHub release v0.1.9 as the immutable latest successful publication evidence until an admitted TV/TVC successor release exists
   - Use the Unreleased changelog plus validation-only hosted artifacts to determine successor candidate readiness; persistent VERSION/changelog/tag/release transitions require admitted TV/TVC release authority
   - Bind the merged KV Interlock runtime endpoint to the sovereign runtime with authentic InTr boundary verification and durable receipt persistence before Site production readback

--- a/fixtures/document-export/admitted.json
+++ b/fixtures/document-export/admitted.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "stegverse.kv.document-export-request/v1",
+  "export_id": "kv-document-export-demo-001",
+  "created_at": "2026-08-29T08:00:00Z",
+  "source": {
+    "repository": "StegVerse-Labs/continuity-vault-kit",
+    "release": "v0.1.9",
+    "vault_class": "PERSONAL_KV",
+    "verification_root": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "event_ids": ["event-note-created-001", "event-owner-approved-002"]
+  },
+  "authorization": {
+    "authority_source": "direct_instruction",
+    "authority_ref": "owner-document-export-approval-001",
+    "status": "active",
+    "scope": ["01_Notes/Exportable_Project_Summary.md"],
+    "purpose": "Create a governed project brief",
+    "destination": "GCAT-BCAT-Engine/Publisher",
+    "allowed_formats": ["markdown", "html", "pdf", "docx", "json"],
+    "expires_at": "2026-08-30T08:00:00Z",
+    "revocable": true,
+    "revoked": false
+  },
+  "document": {
+    "document_id": "project-brief-demo-001",
+    "document_type": "BRIEF",
+    "title": "Governed KnowledgeVault Export Demonstration",
+    "subtitle": "Source-bound document preparation without publication authority",
+    "authors": [{"name": "KnowledgeVault Owner", "affiliation": "StegVerse"}],
+    "template_profile": "stegverse-governed-brief-v1",
+    "sections": [
+      {
+        "section_id": "summary",
+        "heading": "Summary",
+        "body": "This owner-approved brief demonstrates a bounded KnowledgeVault export prepared for Publisher rendering.",
+        "content_class": "OWNER_AUTHORED",
+        "fidelity": "semantic_reconstruction",
+        "confidence": null,
+        "source_subject_ids": ["project-summary"]
+      },
+      {
+        "section_id": "derived-observation",
+        "heading": "Derived observation",
+        "body": "The export remains separate from publication, release, and execution authority.",
+        "content_class": "AI_DERIVED",
+        "fidelity": "inference",
+        "confidence": 0.99,
+        "source_subject_ids": ["project-summary"]
+      }
+    ]
+  },
+  "evidence": [
+    {
+      "subject_id": "project-summary",
+      "path": "01_Notes/Exportable_Project_Summary.md",
+      "retention_class": "reconstructable",
+      "fidelity": "semantic_reconstruction",
+      "superseded": false,
+      "payload_available": true,
+      "content_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "artifact_refs": ["urn:stegverse:kv:event:event-note-created-001"],
+      "derived_index": false,
+      "restricted": false,
+      "contains_credentials": false
+    }
+  ],
+  "redaction": {
+    "profile": "owner-reviewed-export-v1",
+    "review_state": "OWNER_APPROVED",
+    "removed_paths": [],
+    "restricted_content_present": false
+  },
+  "requested_formats": ["markdown", "html", "pdf", "docx", "json"]
+}

--- a/runtime/document_export.py
+++ b/runtime/document_export.py
@@ -1,0 +1,299 @@
+"""Prepare governed KnowledgeVault evidence for Publisher document rendering.
+
+This module is deliberately transport- and renderer-neutral. It validates the
+owner-authorized disclosure boundary, produces a hash-bound Publisher bundle,
+and emits a deterministic preparation receipt. It does not publish, render,
+transmit, or grant execution authority.
+"""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+
+REQUEST_SCHEMA = "stegverse.kv.document-export-request/v1"
+BUNDLE_SCHEMA = "stegverse.kv.publisher-document-export/v1"
+RECEIPT_SCHEMA = "stegverse.kv.document-export-preparation-receipt/v1"
+REVOCATION_SCHEMA = "stegverse.kv.document-export-revocation-receipt/v1"
+PUBLISHER_DESTINATION = "GCAT-BCAT-Engine/Publisher"
+SOURCE_REPOSITORY = "StegVerse-Labs/continuity-vault-kit"
+FORMATS = {"markdown", "html", "pdf", "docx", "json"}
+CONTENT_CLASSES = {"RAW_SOURCE_EXCERPT", "OWNER_AUTHORED", "AI_DERIVED"}
+FIDELITY = {"exact", "semantic_reconstruction", "inference", "integrity_only", "unavailable"}
+RETENTION = {"integrity_only", "reconstructable", "full_fidelity"}
+PROHIBITED_PREFIXES = (
+    "03_Records/",
+    "_Policy/",
+    "_System/SKAP/",
+    "_System/Secrets/",
+    "_Vault/Secrets/",
+)
+
+
+class DocumentExportError(ValueError):
+    pass
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_hex(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def sha256_uri(value: Any) -> str:
+    return "sha256:" + sha256_hex(value)
+
+
+def _is_sha256_uri(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and value.startswith("sha256:")
+        and len(value) == 71
+        and all(char in "0123456789abcdef" for char in value[7:])
+    )
+
+
+def _parse_time(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise DocumentExportError("invalid timestamp") from exc
+    if parsed.tzinfo is None:
+        raise DocumentExportError("timestamp must include timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _unique_nonempty_strings(value: Any, field: str, *, allow_empty: bool = False) -> list[str]:
+    if not isinstance(value, list) or (not allow_empty and not value):
+        raise DocumentExportError(f"{field} must be a non-empty list")
+    if any(not isinstance(item, str) or not item for item in value):
+        raise DocumentExportError(f"{field} must contain non-empty strings")
+    if len(value) != len(set(value)):
+        raise DocumentExportError(f"{field} must be unique")
+    return value
+
+
+def _validate_authority(request: dict[str, Any], now: datetime) -> None:
+    auth = request.get("authorization")
+    if not isinstance(auth, dict):
+        raise DocumentExportError("authorization required")
+    if auth.get("status") != "active" or auth.get("revoked") is not False:
+        raise DocumentExportError("authorization is not active")
+    if auth.get("revocable") is not True:
+        raise DocumentExportError("authorization must remain revocable")
+    if auth.get("destination") != PUBLISHER_DESTINATION:
+        raise DocumentExportError("destination mismatch")
+    if auth.get("authority_source") not in {"direct_instruction", "active_standing_delegation"}:
+        raise DocumentExportError("authority source invalid")
+    for field in ("authority_ref", "purpose"):
+        if not isinstance(auth.get(field), str) or not auth[field]:
+            raise DocumentExportError(f"authorization {field} required")
+    _unique_nonempty_strings(auth.get("scope"), "authorization scope")
+    allowed = set(_unique_nonempty_strings(auth.get("allowed_formats"), "allowed formats"))
+    requested = set(_unique_nonempty_strings(request.get("requested_formats"), "requested formats"))
+    if not allowed.issubset(FORMATS) or not requested.issubset(FORMATS):
+        raise DocumentExportError("unsupported format")
+    if not requested.issubset(allowed):
+        raise DocumentExportError("requested format exceeds authorization")
+    expires_at = auth.get("expires_at")
+    if expires_at is not None and _parse_time(expires_at) <= now:
+        raise DocumentExportError("authorization expired")
+
+
+def _validate_evidence(request: dict[str, Any]) -> set[str]:
+    evidence = request.get("evidence")
+    if not isinstance(evidence, list) or not evidence:
+        raise DocumentExportError("evidence required")
+    subjects: set[str] = set()
+    for index, item in enumerate(evidence):
+        if not isinstance(item, dict):
+            raise DocumentExportError(f"evidence[{index}] must be an object")
+        subject = item.get("subject_id")
+        if not isinstance(subject, str) or not subject or subject in subjects:
+            raise DocumentExportError(f"evidence[{index}] subject invalid or duplicate")
+        subjects.add(subject)
+        path = item.get("path")
+        if not isinstance(path, str) or not path:
+            raise DocumentExportError(f"evidence[{index}] path required")
+        if any(path.startswith(prefix) for prefix in PROHIBITED_PREFIXES):
+            raise DocumentExportError(f"evidence[{index}] path prohibited")
+        if item.get("restricted") is not False or item.get("contains_credentials") is not False:
+            raise DocumentExportError(f"evidence[{index}] restricted content prohibited")
+        fidelity = item.get("fidelity")
+        retention = item.get("retention_class")
+        if fidelity not in FIDELITY or retention not in RETENTION:
+            raise DocumentExportError(f"evidence[{index}] fidelity or retention invalid")
+        if item.get("superseded") is not False:
+            raise DocumentExportError(f"evidence[{index}] superseded evidence prohibited")
+        if fidelity == "exact" and item.get("payload_available") is not True:
+            raise DocumentExportError(f"evidence[{index}] exact payload unavailable")
+        if fidelity in {"integrity_only", "unavailable"} and item.get("payload_available") is True:
+            raise DocumentExportError(f"evidence[{index}] payload availability contradiction")
+        if item.get("derived_index") is not False:
+            raise DocumentExportError(f"evidence[{index}] derived index is not canonical")
+        if not _is_sha256_uri(item.get("content_hash")):
+            raise DocumentExportError(f"evidence[{index}] content hash invalid")
+    return subjects
+
+
+def _validate_document(request: dict[str, Any], evidence_subjects: set[str]) -> None:
+    document = request.get("document")
+    if not isinstance(document, dict):
+        raise DocumentExportError("document required")
+    for field in ("document_id", "document_type", "title", "template_profile"):
+        if not isinstance(document.get(field), str) or not document[field]:
+            raise DocumentExportError(f"document {field} required")
+    document_id = document["document_id"]
+    if len(document_id) > 128 or not document_id[0].isalnum() or any(
+        char not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-" for char in document_id
+    ):
+        raise DocumentExportError("document id is not filesystem-safe")
+    authors = document.get("authors")
+    if not isinstance(authors, list) or not authors:
+        raise DocumentExportError("document authors required")
+    if any(not isinstance(author, dict) or not isinstance(author.get("name"), str) or not author["name"] for author in authors):
+        raise DocumentExportError("document author invalid")
+    sections = document.get("sections")
+    if not isinstance(sections, list) or not sections:
+        raise DocumentExportError("document sections required")
+    section_ids: set[str] = set()
+    for index, section in enumerate(sections):
+        if not isinstance(section, dict):
+            raise DocumentExportError(f"section[{index}] invalid")
+        section_id = section.get("section_id")
+        if not isinstance(section_id, str) or not section_id or section_id in section_ids:
+            raise DocumentExportError(f"section[{index}] id invalid or duplicate")
+        section_ids.add(section_id)
+        for field in ("heading", "body", "content_class", "fidelity"):
+            if not isinstance(section.get(field), str) or not section[field]:
+                raise DocumentExportError(f"section[{index}] {field} required")
+        refs = _unique_nonempty_strings(
+            section.get("source_subject_ids"),
+            f"section[{index}] source_subject_ids",
+            allow_empty=section.get("content_class") == "OWNER_AUTHORED",
+        )
+        if not set(refs).issubset(evidence_subjects):
+            raise DocumentExportError(f"section[{index}] source provenance missing")
+        content_class = section.get("content_class")
+        fidelity = section.get("fidelity")
+        if content_class not in CONTENT_CLASSES or fidelity not in {"exact", "semantic_reconstruction", "inference"}:
+            raise DocumentExportError(f"section[{index}] content class or fidelity invalid")
+        if content_class != "OWNER_AUTHORED" and not refs:
+            raise DocumentExportError(f"section[{index}] source provenance missing")
+        if content_class == "AI_DERIVED" and fidelity == "exact":
+            raise DocumentExportError(f"section[{index}] AI-derived content cannot claim exact fidelity")
+        if content_class == "RAW_SOURCE_EXCERPT" and fidelity != "exact":
+            raise DocumentExportError(f"section[{index}] raw excerpt must retain exact fidelity")
+        confidence = section.get("confidence")
+        if content_class == "AI_DERIVED" and not isinstance(confidence, (int, float)):
+            raise DocumentExportError(f"section[{index}] AI-derived confidence required")
+        if confidence is not None and (isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0 <= confidence <= 1):
+            raise DocumentExportError(f"section[{index}] confidence invalid")
+
+
+def prepare_document_export(request: dict[str, Any], *, now: datetime | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Validate and prepare a bounded Publisher bundle and preparation receipt."""
+    if not isinstance(request, dict) or request.get("schema_version") != REQUEST_SCHEMA:
+        raise DocumentExportError("request schema mismatch")
+    export_id = request.get("export_id")
+    if not isinstance(export_id, str) or len(export_id) < 3 or len(export_id) > 128 or not export_id[0].isalnum() or any(
+        char not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-" for char in export_id
+    ):
+        raise DocumentExportError("export id invalid")
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    _parse_time(request.get("created_at"))
+    source = request.get("source")
+    if not isinstance(source, dict) or source.get("repository") != SOURCE_REPOSITORY:
+        raise DocumentExportError("source repository mismatch")
+    if not isinstance(source.get("release"), str) or not source["release"].startswith("v"):
+        raise DocumentExportError("source release invalid")
+    if not _is_sha256_uri(source.get("verification_root")):
+        raise DocumentExportError("verification root invalid")
+    _unique_nonempty_strings(source.get("event_ids"), "source event ids")
+    _validate_authority(request, now)
+    evidence_subjects = _validate_evidence(request)
+    _validate_document(request, evidence_subjects)
+    redaction = request.get("redaction")
+    if (
+        not isinstance(redaction, dict)
+        or redaction.get("review_state") != "OWNER_APPROVED"
+        or redaction.get("restricted_content_present") is not False
+    ):
+        raise DocumentExportError("owner-approved redaction required")
+
+    auth = request["authorization"]
+    bundle = {
+        "schema_version": BUNDLE_SCHEMA,
+        "export_id": request["export_id"],
+        "created_at": request["created_at"],
+        "source": copy.deepcopy(source),
+        "authorization": {
+            "authority_source": auth["authority_source"],
+            "authority_ref": auth["authority_ref"],
+            "status": auth["status"],
+            "scope": copy.deepcopy(auth["scope"]),
+            "purpose": auth["purpose"],
+            "destination": auth["destination"],
+            "receipt_id": auth["authority_ref"],
+            "allowed_formats": copy.deepcopy(auth["allowed_formats"]),
+            "expires_at": auth.get("expires_at"),
+            "revocable": True,
+            "revoked": False,
+        },
+        "document": copy.deepcopy(request["document"]),
+        "evidence": copy.deepcopy(request["evidence"]),
+        "redaction": copy.deepcopy(redaction),
+        "requested_formats": copy.deepcopy(request["requested_formats"]),
+        "authority_effect": "NONE",
+        "publication_authorized": False,
+        "release_authorized": False,
+        "execution_authorized": False,
+    }
+    bundle["export_sha256"] = sha256_uri(bundle)
+    receipt = {
+        "schema_version": RECEIPT_SCHEMA,
+        "receipt_type": "vault.document_export_prepared",
+        "export_id": request["export_id"],
+        "request_sha256": sha256_uri(request),
+        "export_sha256": bundle["export_sha256"],
+        "authority_ref": auth["authority_ref"],
+        "destination": PUBLISHER_DESTINATION,
+        "requested_formats": copy.deepcopy(request["requested_formats"]),
+        "result": "PREPARED_NOT_TRANSMITTED",
+        "prepared_at": request["created_at"],
+        "authority_effect": "NONE",
+        "publication_authorized": False,
+        "release_authorized": False,
+        "execution_authorized": False,
+    }
+    receipt["receipt_sha256"] = sha256_uri(receipt)
+    return bundle, receipt
+
+
+def revoke_document_export(*, export_id: str, export_sha256: str, authority_ref: str, revoked_at: str, reason: str) -> dict[str, Any]:
+    """Create a deterministic revocation receipt; transport remains separate."""
+    if not all(isinstance(value, str) and value for value in (export_id, authority_ref, reason)):
+        raise DocumentExportError("revocation fields required")
+    if not _is_sha256_uri(export_sha256):
+        raise DocumentExportError("export hash invalid")
+    _parse_time(revoked_at)
+    receipt = {
+        "schema_version": REVOCATION_SCHEMA,
+        "receipt_type": "vault.document_export_revoked",
+        "export_id": export_id,
+        "export_sha256": export_sha256,
+        "authority_ref": authority_ref,
+        "revoked_at": revoked_at,
+        "reason": reason,
+        "result": "REVOKED",
+        "authority_effect": "REVOKE_EXPORT_AUTHORITY_ONLY",
+        "artifact_deletion_authorized": False,
+        "publication_retraction_authorized": False,
+    }
+    receipt["receipt_sha256"] = sha256_uri(receipt)
+    return receipt

--- a/schemas/kv-document-export-request.schema.json
+++ b/schemas/kv-document-export-request.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-document-export-request.schema.json",
+  "title": "KnowledgeVault Governed Document Export Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "export_id",
+    "created_at",
+    "source",
+    "authorization",
+    "document",
+    "evidence",
+    "redaction",
+    "requested_formats"
+  ],
+  "properties": {
+    "schema_version": {"const": "stegverse.kv.document-export-request/v1"},
+    "export_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "release", "vault_class", "verification_root", "event_ids"],
+      "properties": {
+        "repository": {"const": "StegVerse-Labs/continuity-vault-kit"},
+        "release": {"type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+"},
+        "vault_class": {"enum": ["PERSONAL_KV", "ORGANIZATIONAL_KV", "STEGVERSE_KV", "MACHINE_KV"]},
+        "verification_root": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "event_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_source",
+        "authority_ref",
+        "status",
+        "scope",
+        "purpose",
+        "destination",
+        "allowed_formats",
+        "revocable",
+        "revoked"
+      ],
+      "properties": {
+        "authority_source": {"enum": ["direct_instruction", "active_standing_delegation"]},
+        "authority_ref": {"type": "string", "minLength": 1},
+        "status": {"const": "active"},
+        "scope": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "purpose": {"type": "string", "minLength": 1},
+        "destination": {"const": "GCAT-BCAT-Engine/Publisher"},
+        "allowed_formats": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["markdown", "html", "pdf", "docx", "json"]}
+        },
+        "expires_at": {"type": ["string", "null"], "format": "date-time"},
+        "revocable": {"const": true},
+        "revoked": {"const": false}
+      }
+    },
+    "document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["document_id", "document_type", "title", "authors", "template_profile", "sections"],
+      "properties": {
+        "document_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$"},
+        "document_type": {"enum": ["REPORT", "LETTER", "BRIEF", "PAPER", "TIMELINE", "EVIDENCE_PACKET", "LEGACY_EXPORT"]},
+        "title": {"type": "string", "minLength": 1, "maxLength": 300},
+        "subtitle": {"type": ["string", "null"], "maxLength": 500},
+        "authors": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "affiliation": {"type": ["string", "null"]}
+            }
+          }
+        },
+        "template_profile": {"type": "string", "minLength": 1},
+        "sections": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["section_id", "heading", "body", "content_class", "fidelity", "source_subject_ids"],
+            "properties": {
+              "section_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+              "heading": {"type": "string", "minLength": 1},
+              "body": {"type": "string", "minLength": 1},
+              "content_class": {"enum": ["RAW_SOURCE_EXCERPT", "OWNER_AUTHORED", "AI_DERIVED"]},
+              "fidelity": {"enum": ["exact", "semantic_reconstruction", "inference"]},
+              "confidence": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+              "source_subject_ids": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {"type": "string", "minLength": 1}
+              }
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "subject_id",
+          "path",
+          "retention_class",
+          "fidelity",
+          "superseded",
+          "payload_available",
+          "content_hash",
+          "artifact_refs",
+          "derived_index",
+          "restricted",
+          "contains_credentials"
+        ],
+        "properties": {
+          "subject_id": {"type": "string", "minLength": 1},
+          "path": {"type": "string", "minLength": 1},
+          "retention_class": {"enum": ["integrity_only", "reconstructable", "full_fidelity"]},
+          "fidelity": {"enum": ["exact", "semantic_reconstruction", "inference", "integrity_only", "unavailable"]},
+          "superseded": {"type": "boolean"},
+          "payload_available": {"type": "boolean"},
+          "content_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+          "artifact_refs": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "derived_index": {"type": "boolean"},
+          "restricted": {"type": "boolean"},
+          "contains_credentials": {"type": "boolean"}
+        }
+      }
+    },
+    "redaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "review_state", "removed_paths", "restricted_content_present"],
+      "properties": {
+        "profile": {"type": "string", "minLength": 1},
+        "review_state": {"const": "OWNER_APPROVED"},
+        "removed_paths": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "restricted_content_present": {"const": false}
+      }
+    },
+    "requested_formats": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"enum": ["markdown", "html", "pdf", "docx", "json"]}
+    }
+  }
+}

--- a/tests/test_document_export.py
+++ b/tests/test_document_export.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "runtime" / "document_export.py"
+FIXTURE = ROOT / "fixtures" / "document-export" / "admitted.json"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("document_export", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class DocumentExportTests(unittest.TestCase):
+    def setUp(self):
+        self.m = load_module()
+        self.request = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        self.now = datetime(2026, 8, 29, 8, 30, tzinfo=timezone.utc)
+
+    def prepare(self, request=None):
+        return self.m.prepare_document_export(request or self.request, now=self.now)
+
+    def test_prepares_hash_bound_publisher_bundle_and_receipt(self):
+        bundle, receipt = self.prepare()
+        self.assertEqual(bundle["schema_version"], self.m.BUNDLE_SCHEMA)
+        self.assertEqual(bundle["authorization"]["destination"], self.m.PUBLISHER_DESTINATION)
+        self.assertEqual(bundle["export_sha256"], receipt["export_sha256"])
+        unhashed = copy.deepcopy(bundle)
+        unhashed.pop("export_sha256")
+        self.assertEqual(bundle["export_sha256"], self.m.sha256_uri(unhashed))
+        self.assertEqual(receipt["result"], "PREPARED_NOT_TRANSMITTED")
+        self.assertFalse(receipt["publication_authorized"])
+        self.assertEqual(receipt["authority_effect"], "NONE")
+
+    def test_preparation_is_deterministic(self):
+        first = self.prepare()
+        second = self.prepare()
+        self.assertEqual(first, second)
+
+    def test_requested_format_cannot_exceed_owner_authorization(self):
+        request = copy.deepcopy(self.request)
+        request["authorization"]["allowed_formats"] = ["markdown"]
+        with self.assertRaisesRegex(self.m.DocumentExportError, "exceeds authorization"):
+            self.prepare(request)
+
+    def test_restricted_and_policy_paths_fail_closed(self):
+        for path in ("03_Records/medical.md", "_Policy/Data_Sharing_Policy.md", "_System/SKAP/session.json"):
+            with self.subTest(path=path):
+                request = copy.deepcopy(self.request)
+                request["evidence"][0]["path"] = path
+                with self.assertRaisesRegex(self.m.DocumentExportError, "path prohibited"):
+                    self.prepare(request)
+
+    def test_ai_derived_section_cannot_claim_exact_fidelity(self):
+        request = copy.deepcopy(self.request)
+        request["document"]["sections"][1]["fidelity"] = "exact"
+        with self.assertRaisesRegex(self.m.DocumentExportError, "cannot claim exact"):
+            self.prepare(request)
+
+    def test_missing_section_provenance_fails_closed(self):
+        request = copy.deepcopy(self.request)
+        request["document"]["sections"][0]["source_subject_ids"] = ["unknown-evidence"]
+        with self.assertRaisesRegex(self.m.DocumentExportError, "source provenance missing"):
+            self.prepare(request)
+
+    def test_unknown_content_class_and_unsafe_id_fail_closed(self):
+        unknown = copy.deepcopy(self.request)
+        unknown["document"]["sections"][0]["content_class"] = "MODEL_TRUTH"
+        with self.assertRaisesRegex(self.m.DocumentExportError, "content class"):
+            self.prepare(unknown)
+        unsafe = copy.deepcopy(self.request)
+        unsafe["document"]["document_id"] = "../outside"
+        with self.assertRaisesRegex(self.m.DocumentExportError, "filesystem-safe"):
+            self.prepare(unsafe)
+
+    def test_revoked_or_expired_authority_fails_closed(self):
+        revoked = copy.deepcopy(self.request)
+        revoked["authorization"]["revoked"] = True
+        with self.assertRaisesRegex(self.m.DocumentExportError, "not active"):
+            self.prepare(revoked)
+        expired = copy.deepcopy(self.request)
+        expired["authorization"]["expires_at"] = "2026-08-29T08:29:59Z"
+        with self.assertRaisesRegex(self.m.DocumentExportError, "expired"):
+            self.prepare(expired)
+
+    def test_revocation_receipt_is_bounded_and_deterministic(self):
+        bundle, _ = self.prepare()
+        first = self.m.revoke_document_export(
+            export_id=bundle["export_id"],
+            export_sha256=bundle["export_sha256"],
+            authority_ref=bundle["authorization"]["authority_ref"],
+            revoked_at="2026-08-29T09:00:00Z",
+            reason="Owner withdrew document export authority.",
+        )
+        second = self.m.revoke_document_export(
+            export_id=bundle["export_id"],
+            export_sha256=bundle["export_sha256"],
+            authority_ref=bundle["authorization"]["authority_ref"],
+            revoked_at="2026-08-29T09:00:00Z",
+            reason="Owner withdrew document export authority.",
+        )
+        self.assertEqual(first, second)
+        self.assertEqual(first["result"], "REVOKED")
+        self.assertFalse(first["artifact_deletion_authorized"])
+        self.assertFalse(first["publication_retraction_authorized"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),46)
+        self.assertEqual(len(workflows),47)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tests/test_reconstructive_memory_activation_workflow.py
+++ b/tests/test_reconstructive_memory_activation_workflow.py
@@ -11,32 +11,34 @@ class ProductionProviderActivationWorkflowTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.text = WORKFLOW.read_text(encoding="utf-8")
 
-    def test_is_manual_only_and_environment_protected(self) -> None:
+    def test_is_manual_only_and_non_authorizing(self) -> None:
         self.assertIn("workflow_dispatch:", self.text)
         self.assertNotIn("pull_request:", self.text)
         self.assertNotIn("push:", self.text)
-        self.assertIn("environment: production-provider-activation", self.text)
-        self.assertIn("cancel-in-progress: false", self.text)
+        self.assertIn("Production Provider Activation - Validation Only", self.text)
+        self.assertNotIn("environment: production-provider-activation", self.text)
 
-    def test_uses_oidc_and_minimum_repository_permissions(self) -> None:
+    def test_has_read_only_permissions_and_no_cloud_identity(self) -> None:
         self.assertIn("contents: read", self.text)
-        self.assertIn("id-token: write", self.text)
-        self.assertIn("aws-actions/configure-aws-credentials@v4", self.text)
-        self.assertIn("role-to-assume: ${{ vars.PROVIDER_ACTIVATION_AWS_ROLE_ARN }}", self.text)
+        self.assertNotIn("id-token: write", self.text)
+        self.assertNotIn("aws-actions/configure-aws-credentials", self.text)
+        self.assertNotIn("role-to-assume:", self.text)
         self.assertNotIn("AWS_ACCESS_KEY_ID", self.text)
         self.assertNotIn("AWS_SECRET_ACCESS_KEY", self.text)
 
-    def test_apply_requires_explicit_confirmation_and_saved_plan(self) -> None:
-        self.assertIn('CONFIRM_APPLY" != "APPLY"', self.text)
-        self.assertIn("terraform plan -input=false -out=provider-activation.tfplan", self.text)
-        self.assertIn("terraform apply -input=false -auto-approve provider-activation.tfplan", self.text)
-        self.assertNotIn("terraform apply -auto-approve\n", self.text)
+    def test_validates_source_without_plan_or_apply(self) -> None:
+        self.assertIn("terraform init -backend=false -input=false", self.text)
+        self.assertIn("terraform validate", self.text)
+        self.assertNotIn("terraform plan", self.text)
+        self.assertNotIn("terraform apply", self.text)
 
     def test_inputs_are_fail_closed_and_evidence_is_retained(self) -> None:
         self.assertIn('[[ "$SPIFFE_IDENTITY" == spiffe://* ]]', self.text)
         self.assertIn('[[ "$CHAT_ENDPOINT" == https://* ]]', self.text)
         self.assertIn('[[ "$MASTER_RECORDS_ENDPOINT" == https://* ]]', self.text)
-        self.assertIn('"decision": "FAIL_CLOSED"', self.text)
+        self.assertIn('"state": "TVC_ADMITTED_RESIDENT_PROVIDER_ACTIVATION_REQUIRED"', self.text)
+        self.assertIn('"provider_mutation_performed": False', self.text)
+        self.assertIn('"authority_effect": "NONE"', self.text)
         self.assertIn("actions/upload-artifact@v4", self.text)
         self.assertIn("retention-days: 30", self.text)
 

--- a/tools/prepare_document_export.py
+++ b/tools/prepare_document_export.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Prepare a governed KV document bundle and receipt for Publisher."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from runtime.document_export import DocumentExportError, prepare_document_export
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("request", type=Path)
+    parser.add_argument("--bundle-out", type=Path, required=True)
+    parser.add_argument("--receipt-out", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        request = json.loads(args.request.read_text(encoding="utf-8"))
+        bundle, receipt = prepare_document_export(request)
+    except (OSError, json.JSONDecodeError, DocumentExportError) as exc:
+        print(f"KV_DOCUMENT_EXPORT_REJECTED: {exc}", file=sys.stderr)
+        return 1
+    args.bundle_out.parent.mkdir(parents=True, exist_ok=True)
+    args.receipt_out.parent.mkdir(parents=True, exist_ok=True)
+    args.bundle_out.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.receipt_out.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print("KV_DOCUMENT_EXPORT_PREPARED_NOT_TRANSMITTED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vault_template/KnowledgeVault/_Policy/Legacy_and_Export.md
+++ b/vault_template/KnowledgeVault/_Policy/Legacy_and_Export.md
@@ -33,6 +33,17 @@ At any time, you can create a long-term archive by:
 Recommended format:
 ZIP archive + SHA256 checksum
 
+For a selected report, brief, paper, timeline, evidence packet, or legacy
+document, use the governed document-export path under `_System/Exports/`.
+The owner selects evidence, purpose, destination, formats, and redaction scope.
+Publisher may render an admitted bundle as Markdown, HTML, PDF, DOCX, or a JSON
+reconstruction bundle. Preparation and rendering do not themselves authorize
+publication, release, delivery, or execution.
+
+Raw source excerpts, owner-authored text, and AI-derived text must remain
+distinguishable. AI-derived text must retain supporting evidence references,
+fidelity, and confidence rather than silently becoming canonical fact.
+
 ---
 
 ## 🧬 Legacy Copy (For Family or Heirs)

--- a/vault_template/KnowledgeVault/_System/Exports/Artifacts/README.md
+++ b/vault_template/KnowledgeVault/_System/Exports/Artifacts/README.md
@@ -1,0 +1,9 @@
+# Export Artifacts
+
+Store rendered artifacts only after their Publisher manifest, content hash, and
+KV readback receipt validate. A revoked export remains historically attributable;
+revocation alone does not authorize deletion or public retraction.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_System/Exports/README.md
+++ b/vault_template/KnowledgeVault/_System/Exports/README.md
@@ -1,0 +1,21 @@
+# Governed Document Exports
+
+This directory stores private KnowledgeVault document-export state.
+
+```text
+Requests/   owner-authorized, scope-bound export requests
+Receipts/   preparation, revocation, admission, and rendering receipts
+Artifacts/  rendered artifacts admitted back into this KV
+```
+
+An export request does not publish or transmit content. Publisher may render an
+admitted bundle, but publication, release, delivery, and execution remain
+separate governed transitions. Raw evidence, AI-derived text, and owner-authored
+text retain distinct fidelity labels.
+
+Never store SKAP credentials, provider tokens, passwords, private keys, or
+unredacted restricted records in this directory.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_System/Exports/Receipts/README.md
+++ b/vault_template/KnowledgeVault/_System/Exports/Receipts/README.md
@@ -1,0 +1,9 @@
+# Export Receipts
+
+Store hash-bound preparation, revocation, Publisher admission, rendering, and
+artifact-readback receipts here. A receipt records a lifecycle transition; it
+does not silently grant publication or execution authority.
+
+---
+
+🔒 Layer: Vault Template | KV

--- a/vault_template/KnowledgeVault/_System/Exports/Requests/README.md
+++ b/vault_template/KnowledgeVault/_System/Exports/Requests/README.md
@@ -1,0 +1,8 @@
+# Export Requests
+
+Store owner-approved `stegverse.kv.document-export-request/v1` records here.
+Requests must remain purpose-, destination-, scope-, format-, and provenance-bound.
+
+---
+
+🔒 Layer: Vault Template | KV


### PR DESCRIPTION
## Outcome
Adds the owner-authorized KnowledgeVault preparation boundary for Publisher document exports.

## Included
- strict request schema and fail-closed runtime validation
- source/fidelity/provenance/redaction/format authority controls
- deterministic preparation and bounded revocation receipts
- CLI, admitted fixture, 9 unit tests, read-only validation workflow
- four-file `_System/Exports/` template destination and durable handoffs
- reconciliation of stale provider-workflow tests to the existing validation-only authority model

## Validation
- document-export tests: 9/9 pass
- workflow authority regression: pass (47 read-only workflows)
- repository-wide unittest discovery: 375 runnable tests pass; two pytest-only modules require pytest
- schema parsing, CLI demonstration, and compile checks pass
- exact committed tree matches locally validated tree `7ba6d6b7fd3e604a497fc2d321c37dbf54ef0458`

## Lifecycle boundary
This PR is IMPLEMENTED and locally VALIDATED. It does not claim connected-KV installation, transmission, Publisher admission, publication, deployment, activation, or release. `authority_effect=NONE`.