### PR TITLE
Bind KV readiness to typed transport capability evidence

### DIFF
--- a/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
+++ b/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
@@ -423,3 +423,38 @@ Readiness surface retains one current projection.
 This does not reduce the Universal Interlock runtime/adoption gates. It gives the
 device shell a machine-readable explanation for why all governed controls remain
 disabled.
+
+
+## Typed transport capability readiness — issue #126
+
+Follow-on to typed transport capability governance (#124/#125).
+
+The readiness control plane now treats transport capability as an explicit first-level governance prerequisite rather than inferring transport readiness from a generic network/runtime boolean.
+
+Current source semantics:
+
+```text
+all governed module/service actions:
+  require DEVICE_KV_INTR
+
+service with explicit external-provider dependency:
+  additionally requires ADJACENT_EXTERNAL_API_EGRESS
+```
+
+Operation-specific transport types remain owned by the lane that requests them. The readiness layer does not globally force HIL `PUBLIC_HTTPS_INGRESS`, `NODE_TO_NODE_SYNC`, `KV_SKAP_INTR`, or `TVC_RELAY` onto unrelated actions.
+
+The readiness facts now expose all seven typed capability observations explicitly and currently keep each false until authentic evidence is separately admitted:
+
+```text
+KV_DISTRIBUTION_DOWNLOAD=false
+DEVICE_KV_INTR=false
+PUBLIC_HTTPS_INGRESS=false
+ADJACENT_EXTERNAL_API_EGRESS=false
+NODE_TO_NODE_SYNC=false
+KV_SKAP_INTR=false
+TVC_RELAY=false
+```
+
+This source change does not downgrade the separately observed Hugging Face/SV-DN-1 transport result; it means that result has not yet been admitted as KnowledgeVault transport-capability evidence.
+
+No transport, module, service, Interlock, InTr, credential, provider, or execution activation is created by these readiness facts.

--- a/schemas/kv-activation-readiness-snapshot.schema.json
+++ b/schemas/kv-activation-readiness-snapshot.schema.json
@@ -10,7 +10,8 @@
     "service_count",
     "activation_performed",
     "authority_effect",
-    "entries"
+    "entries",
+    "transport_capabilities_observed"
   ],
   "properties": {
     "schema": {
@@ -45,7 +46,8 @@
           "governed_action_readiness",
           "governed_blockers",
           "activation_performed",
-          "authority_effect"
+          "authority_effect",
+          "transport_capability_requirements"
         ],
         "properties": {
           "entry_type": {
@@ -82,10 +84,54 @@
           },
           "authority_effect": {
             "const": "NONE"
+          },
+          "transport_capability_requirements": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
           }
         },
         "additionalProperties": true
       }
+    },
+    "transport_capabilities_observed": {
+      "type": "object",
+      "required": [
+        "KV_DISTRIBUTION_DOWNLOAD",
+        "DEVICE_KV_INTR",
+        "PUBLIC_HTTPS_INGRESS",
+        "ADJACENT_EXTERNAL_API_EGRESS",
+        "NODE_TO_NODE_SYNC",
+        "KV_SKAP_INTR",
+        "TVC_RELAY"
+      ],
+      "properties": {
+        "KV_DISTRIBUTION_DOWNLOAD": {
+          "type": "boolean"
+        },
+        "DEVICE_KV_INTR": {
+          "type": "boolean"
+        },
+        "PUBLIC_HTTPS_INGRESS": {
+          "type": "boolean"
+        },
+        "ADJACENT_EXTERNAL_API_EGRESS": {
+          "type": "boolean"
+        },
+        "NODE_TO_NODE_SYNC": {
+          "type": "boolean"
+        },
+        "KV_SKAP_INTR": {
+          "type": "boolean"
+        },
+        "TVC_RELAY": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": true

--- a/scripts/evaluate_kv_activation_readiness.py
+++ b/scripts/evaluate_kv_activation_readiness.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Evaluate KV module/service readiness without activating anything."""
 from __future__ import annotations
+
 import json
 from pathlib import Path
 
@@ -10,11 +11,23 @@ SERVICES = ROOT / "specs" / "kv-personal-services-registry.v1.json"
 FACTS = ROOT / "specs" / "kv-activation-readiness-facts.v1.json"
 POLICY = ROOT / "specs" / "kv-module-activation-policy.v1.json"
 
+
 def load(path):
     return json.loads(path.read_text(encoding="utf-8"))
 
+
 def missing_requirements(requirements, facts):
     return [name for name in requirements if facts.get(name) is not True]
+
+
+def missing_transport_requirements(requirements, facts):
+    observed = facts.get("transport_capabilities_observed", {})
+    return [
+        f"transport_capability:{name}"
+        for name in requirements
+        if observed.get(name) is not True
+    ]
+
 
 def evaluate():
     modules = load(MODULES)["modules"]
@@ -25,16 +38,19 @@ def evaluate():
     entries = []
     for module in modules:
         p = policy[module["module_id"]]
+        transport_requires = ["DEVICE_KV_INTR"]
         blockers = missing_requirements(p["governed_requires"], facts)
+        blockers += missing_transport_requirements(transport_requires, facts)
         entries.append({
-            "entry_type":"MODULE",
-            "entry_id":module["module_id"],
-            "install_state":module["install_state"],
-            "local_materialization":p["local_materialization"],
-            "governed_action_readiness":"READY_FOR_GOVERNED_ACTION" if not blockers else "BLOCKED",
-            "governed_blockers":blockers,
-            "activation_performed":False,
-            "authority_effect":"NONE",
+            "entry_type": "MODULE",
+            "entry_id": module["module_id"],
+            "install_state": module["install_state"],
+            "local_materialization": p["local_materialization"],
+            "governed_action_readiness": "READY_FOR_GOVERNED_ACTION" if not blockers else "BLOCKED",
+            "governed_blockers": blockers,
+            "transport_capability_requirements": transport_requires,
+            "activation_performed": False,
+            "authority_effect": "NONE",
         })
 
     for service in services:
@@ -48,53 +64,61 @@ def evaluate():
             local = "READY_FOR_LOCAL_UI"
 
         governed_requires = ["production_interlock_runtime_activated"]
+        transport_requires = ["DEVICE_KV_INTR"]
         if cls == "KV_DEVICE_PROVIDER" or provider != "NONE":
             governed_requires.append("provider_session_evidence_observed")
+            transport_requires.append("ADJACENT_EXTERNAL_API_EGRESS")
+
         blockers = missing_requirements(governed_requires, facts)
+        blockers += missing_transport_requirements(transport_requires, facts)
         entries.append({
-            "entry_type":"SERVICE",
-            "entry_id":service["service_id"],
-            "service_class":cls,
-            "install_state":service["install_state"],
-            "local_materialization":local,
-            "governed_action_readiness":"READY_FOR_GOVERNED_ACTION" if not blockers else "BLOCKED",
-            "governed_blockers":blockers,
-            "activation_performed":False,
-            "authority_effect":"NONE",
+            "entry_type": "SERVICE",
+            "entry_id": service["service_id"],
+            "service_class": cls,
+            "install_state": service["install_state"],
+            "local_materialization": local,
+            "governed_action_readiness": "READY_FOR_GOVERNED_ACTION" if not blockers else "BLOCKED",
+            "governed_blockers": blockers,
+            "transport_capability_requirements": transport_requires,
+            "activation_performed": False,
+            "authority_effect": "NONE",
         })
 
     snapshot = {
-        "schema":"stegverse.kv.activation-readiness-snapshot/v1",
-        "facts_observed_at":facts["observed_at"],
-        "entry_count":len(entries),
-        "module_count":sum(1 for e in entries if e["entry_type"]=="MODULE"),
-        "service_count":sum(1 for e in entries if e["entry_type"]=="SERVICE"),
-        "baseline_intr_complete":facts["baseline_intr_rc01_rc05_complete"],
-        "production_interlock_runtime_activated":facts["production_interlock_runtime_activated"],
-        "interlock_adoption_review":{
-            "ready":facts.get("universal_interlock_adoption_review_ready") is True,
-            "state":facts.get("universal_interlock_adoption_review_state","BLOCKED"),
-            "blockers":list(facts.get("universal_interlock_adoption_review_blockers",[])),
-            "canonical_protocol_adopted":False,
-            "runtime_activation":False,
-            "authority_effect":"NONE",
+        "schema": "stegverse.kv.activation-readiness-snapshot/v1",
+        "facts_observed_at": facts["observed_at"],
+        "entry_count": len(entries),
+        "module_count": sum(1 for e in entries if e["entry_type"] == "MODULE"),
+        "service_count": sum(1 for e in entries if e["entry_type"] == "SERVICE"),
+        "baseline_intr_complete": facts["baseline_intr_rc01_rc05_complete"],
+        "production_interlock_runtime_activated": facts["production_interlock_runtime_activated"],
+        "transport_capabilities_observed": dict(facts.get("transport_capabilities_observed", {})),
+        "interlock_adoption_review": {
+            "ready": facts.get("universal_interlock_adoption_review_ready") is True,
+            "state": facts.get("universal_interlock_adoption_review_state", "BLOCKED"),
+            "blockers": list(facts.get("universal_interlock_adoption_review_blockers", [])),
+            "canonical_protocol_adopted": False,
+            "runtime_activation": False,
+            "authority_effect": "NONE",
         },
-        "activation_performed":False,
-        "authority_effect":"NONE",
-        "summary":{
-            "local_ready":sum(1 for e in entries if e["local_materialization"].startswith("READY")),
-            "local_blocked":sum(1 for e in entries if not e["local_materialization"].startswith("READY")),
-            "governed_ready":sum(1 for e in entries if e["governed_action_readiness"]=="READY_FOR_GOVERNED_ACTION"),
-            "governed_blocked":sum(1 for e in entries if e["governed_action_readiness"]=="BLOCKED"),
+        "activation_performed": False,
+        "authority_effect": "NONE",
+        "summary": {
+            "local_ready": sum(1 for e in entries if e["local_materialization"].startswith("READY")),
+            "local_blocked": sum(1 for e in entries if not e["local_materialization"].startswith("READY")),
+            "governed_ready": sum(1 for e in entries if e["governed_action_readiness"] == "READY_FOR_GOVERNED_ACTION"),
+            "governed_blocked": sum(1 for e in entries if e["governed_action_readiness"] == "BLOCKED"),
         },
-        "entries":entries,
+        "entries": entries,
     }
     return snapshot
+
 
 def main():
     snapshot = evaluate()
     print(json.dumps(snapshot, indent=2, sort_keys=True))
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/specs/kv-activation-readiness-facts.v1.json
+++ b/specs/kv-activation-readiness-facts.v1.json
@@ -20,5 +20,14 @@
     "AUTHENTIC_RUNTIME_BINDING_MISSING",
     "MASTER_RECORDS_CUSTODY_RECEIPT_MISSING",
     "MASTER_RECORDS_RECONSTRUCTION_NOT_VERIFIED"
-  ]
+  ],
+  "transport_capabilities_observed": {
+    "KV_DISTRIBUTION_DOWNLOAD": false,
+    "DEVICE_KV_INTR": false,
+    "PUBLIC_HTTPS_INGRESS": false,
+    "ADJACENT_EXTERNAL_API_EGRESS": false,
+    "NODE_TO_NODE_SYNC": false,
+    "KV_SKAP_INTR": false,
+    "TVC_RELAY": false
+  }
 }

--- a/tests/test_kv_activation_readiness.py
+++ b/tests/test_kv_activation_readiness.py
@@ -60,3 +60,41 @@ def test_stegfin_preserves_full_production_tvc_blockers():
         "provider_session_evidence_observed",
     }
     assert required.issubset(set(stegfin["governed_blockers"]))
+
+
+def test_all_governed_entries_require_device_kv_transport_capability():
+    snapshot = module.evaluate()
+    assert snapshot["transport_capabilities_observed"]["DEVICE_KV_INTR"] is False
+    assert all(
+        "DEVICE_KV_INTR" in entry["transport_capability_requirements"]
+        for entry in snapshot["entries"]
+    )
+    assert all(
+        "transport_capability:DEVICE_KV_INTR" in entry["governed_blockers"]
+        for entry in snapshot["entries"]
+    )
+
+
+def test_external_provider_services_require_adjacent_external_api_egress():
+    snapshot = module.evaluate()
+    services = json.loads(
+        (ROOT / "specs" / "kv-personal-services-registry.v1.json").read_text(encoding="utf-8")
+    )["services"]
+    provider_backed = {
+        service["service_id"]
+        for service in services
+        if service["service_class"] == "KV_DEVICE_PROVIDER" or service["provider_dependency"] != "NONE"
+    }
+    entries = {entry["entry_id"]: entry for entry in snapshot["entries"] if entry["entry_type"] == "SERVICE"}
+    assert provider_backed
+    for service_id in provider_backed:
+        entry = entries[service_id]
+        assert "ADJACENT_EXTERNAL_API_EGRESS" in entry["transport_capability_requirements"]
+        assert "transport_capability:ADJACENT_EXTERNAL_API_EGRESS" in entry["governed_blockers"]
+
+
+def test_local_only_personal_journal_does_not_require_external_api_egress():
+    snapshot = module.evaluate()
+    journal = next(e for e in snapshot["entries"] if e["entry_id"] == "personal-journal")
+    assert journal["transport_capability_requirements"] == ["DEVICE_KV_INTR"]
+    assert "transport_capability:ADJACENT_EXTERNAL_API_EGRESS" not in journal["governed_blockers"]


### PR DESCRIPTION
Closes #126.

Extends KnowledgeVault activation-readiness so every governed action requires DEVICE_KV_INTR and services with explicit external-provider dependency additionally require ADJACENT_EXTERNAL_API_EGRESS. All seven transport-capability observation facts remain false until authentic evidence is separately admitted. No activation or authority effect.