### PR TITLE
Admit authentic node transport observation evidence into KV readiness

### DIFF
--- a/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
+++ b/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
@@ -92,3 +92,32 @@ The HIL runtime observation remains a separate live gate.
 ## Next executable action
 
 Implement and validate the typed transport capability registry, then reconcile it into KnowledgeVault readiness and downstream StegOS consumption without promoting source state to runtime activation.
+
+
+## Authentic observation evidence admission — issue #129
+
+The typed transport model now has a bounded fail-closed evidence adapter:
+
+- `scripts/admit_transport_capability_evidence.py`
+- `schemas/kv-transport-capability-evidence-admission.schema.json`
+- `tests/test_admit_transport_capability_evidence.py`
+
+Initial mappings:
+
+```text
+stegverse.sv-dn1.browser-resident-observation-bundle/v3
+  -> ADJACENT_EXTERNAL_API_EGRESS
+
+stegverse.hil.canonical-observation-evidence/v1
+  -> PUBLIC_HTTPS_INGRESS
+```
+
+Admission advances only the matching `transport_capabilities_observed.<TYPE>` fact.
+
+It does not advance production Interlock activation, provider/session state, credential state, module/service activation, TVC lifecycle state, execution authority, or any unrelated transport capability.
+
+The HIL ingress capability may be admitted independently of the later TVC lifecycle receipt because the fact being established is specifically public HTTPS ingress capability, not completion of the HIL lifecycle.
+
+The current Hugging Face browser observer source on Site emits the v3 bundle above. Earlier session references to an older canonical-evidence filename/schema are superseded by the live Site source.
+
+No KV fact is advanced merely because the adapter exists. Authentic evidence bytes must be supplied and pass validation.

--- a/schemas/kv-transport-capability-evidence-admission.schema.json
+++ b/schemas/kv-transport-capability-evidence-admission.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-transport-capability-evidence-admission.schema.json",
+  "title": "KnowledgeVault transport capability evidence admission",
+  "type": "object",
+  "required": [
+    "schema",
+    "state",
+    "source_schema",
+    "capability_type",
+    "facts_advanced",
+    "unrelated_facts_advanced",
+    "activation_performed",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.kv.transport-capability-evidence-admission/v1"},
+    "state": {"const": "ADMITTED"},
+    "source_schema": {
+      "enum": [
+        "stegverse.sv-dn1.browser-resident-observation-bundle/v3",
+        "stegverse.hil.canonical-observation-evidence/v1"
+      ]
+    },
+    "capability_type": {
+      "enum": [
+        "ADJACENT_EXTERNAL_API_EGRESS",
+        "PUBLIC_HTTPS_INGRESS"
+      ]
+    },
+    "facts_advanced": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {"type": "string"}
+    },
+    "unrelated_facts_advanced": {
+      "type": "array",
+      "maxItems": 0
+    },
+    "activation_performed": {"const": false},
+    "authority_effect": {"const": "NONE"}
+  },
+  "additionalProperties": false
+}

--- a/scripts/admit_transport_capability_evidence.py
+++ b/scripts/admit_transport_capability_evidence.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Admit authentic Device-Node transport observation evidence into KV readiness facts."""
+from __future__ import annotations
+
+import argparse
+import json
+from copy import deepcopy
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FACTS = ROOT / "specs" / "kv-activation-readiness-facts.v1.json"
+
+HF_SCHEMA = "stegverse.sv-dn1.browser-resident-observation-bundle/v3"
+HIL_SCHEMA = "stegverse.hil.canonical-observation-evidence/v1"
+
+MAPPING = {
+    HF_SCHEMA: "ADJACENT_EXTERNAL_API_EGRESS",
+    HIL_SCHEMA: "PUBLIC_HTTPS_INGRESS",
+}
+
+
+def _require(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def validate_hf(payload: dict) -> list[str]:
+    failures: list[str] = []
+    _require(payload.get("schema") == HF_SCHEMA, "unexpected HF evidence schema", failures)
+    _require(payload.get("state") == "OBSERVED", "HF evidence must be OBSERVED", failures)
+    _require(payload.get("observation_class") == "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE", "HF observation class invalid", failures)
+    _require(payload.get("authority_effect") == "NONE", "HF authority_effect must be NONE", failures)
+
+    node = payload.get("node_registration")
+    _require(isinstance(node, dict), "HF node registration missing", failures)
+    if isinstance(node, dict):
+        _require(node.get("state") == "ESTABLISHED", "HF node must be ESTABLISHED", failures)
+        _require(node.get("credential_authority") == "TV/TVC", "HF credential authority must be TV/TVC", failures)
+
+    resident = payload.get("resident_receipt")
+    _require(isinstance(resident, dict), "HF resident receipt missing", failures)
+    if isinstance(resident, dict):
+        _require(resident.get("state") == "COMPLETE", "HF resident receipt must be COMPLETE", failures)
+        _require(resident.get("credential_used") is False, "HF credential_used must be false", failures)
+        _require(resident.get("github_token_used") is False, "HF github_token_used must be false", failures)
+        _require(resident.get("authority_effect") == "NONE", "HF resident authority_effect must be NONE", failures)
+
+    intr = payload.get("intr_receipt")
+    _require(isinstance(intr, dict), "HF InTr receipt missing", failures)
+    if isinstance(intr, dict):
+        _require(intr.get("state") == "COMPLETE", "HF InTr receipt must be COMPLETE", failures)
+        _require(intr.get("transport_profile") == "stegverse.universal-intr.adjacent-hop/v1", "HF transport profile mismatch", failures)
+        _require(intr.get("destination_validation") == "PASS", "HF destination validation must PASS", failures)
+        _require(intr.get("lineage_verified") is True, "HF lineage must be verified", failures)
+        _require(intr.get("authority_effect") == "NONE", "HF InTr authority_effect must be NONE", failures)
+        claims = intr.get("claims")
+        _require(isinstance(claims, dict), "HF InTr claims missing", failures)
+        if isinstance(claims, dict):
+            _require(claims.get("credential_used") is False, "HF InTr credential_used must be false", failures)
+            _require(claims.get("runtime_activation_claimed") is False, "HF runtime activation may not be claimed", failures)
+            _require(claims.get("production_interlock_runtime_activated") is False, "HF production Interlock activation may not be claimed", failures)
+
+    assertions = payload.get("assertions")
+    _require(isinstance(assertions, dict), "HF assertions missing", failures)
+    if isinstance(assertions, dict):
+        for key in (
+            "existing_node_reused",
+            "public_source_live_fetch",
+            "exact_raw_bytes_hashed",
+            "universal_intr_adjacent_hop_executed",
+            "lineage_verified",
+        ):
+            _require(assertions.get(key) is True, f"HF assertion {key} must be true", failures)
+        _require(assertions.get("new_node_identity_minted") is False, "HF may not mint a new node identity", failures)
+        _require(assertions.get("destination_validation") == "PASS", "HF destination validation assertion must PASS", failures)
+        _require(assertions.get("global_runtime_activation_claimed") is False, "HF global runtime activation may not be claimed", failures)
+
+    replay = payload.get("journal_replay")
+    _require(isinstance(replay, dict) and replay.get("state") == "PASS", "HF journal replay must PASS", failures)
+    recon = payload.get("reconstruction_entry")
+    if isinstance(recon, dict):
+        receipt = recon.get("receipt", recon)
+        _require(receipt.get("state") == "PASS", "HF reconstruction must PASS", failures)
+        _require(receipt.get("same_execution") is True, "HF reconstruction must preserve same execution", failures)
+    else:
+        failures.append("HF reconstruction entry missing")
+
+    return failures
+
+
+def validate_hil(payload: dict) -> list[str]:
+    failures: list[str] = []
+    _require(payload.get("schema") == HIL_SCHEMA, "unexpected HIL evidence schema", failures)
+    _require(payload.get("state") == "OBSERVED", "HIL evidence must be OBSERVED", failures)
+    _require(payload.get("observation_class") == "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE", "HIL observation class invalid", failures)
+    _require(payload.get("authority_effect") == "NONE", "HIL authority_effect must be NONE", failures)
+    _require(payload.get("existing_node_reused") is True, "HIL must reuse established node", failures)
+    _require(payload.get("new_node_identity_minted") is False, "HIL may not mint new node identity", failures)
+    _require(payload.get("credential_used") is False, "HIL credential_used must be false", failures)
+    _require(payload.get("github_token_used") is False, "HIL github_token_used must be false", failures)
+    _require(payload.get("exact_byte_reconstruction") == "PASS", "HIL exact-byte reconstruction must PASS", failures)
+    _require(payload.get("custody_state") == "EXACT_BYTES_PERSISTED", "HIL custody must be exact bytes", failures)
+    _require(payload.get("registry_state") == "RECORDED", "HIL registry state must be RECORDED", failures)
+    _require(payload.get("journal_replay_state") == "PASS", "HIL journal replay must PASS", failures)
+    _require(payload.get("next_required_transition") == "HIL_CUSTODY_TVC_INTERLOCK_ADMISSION", "HIL next transition mismatch", failures)
+    return failures
+
+
+def admit(payload: dict, facts: dict) -> tuple[dict, dict]:
+    schema = payload.get("schema")
+    if schema == HF_SCHEMA:
+        failures = validate_hf(payload)
+    elif schema == HIL_SCHEMA:
+        failures = validate_hil(payload)
+    else:
+        raise ValueError("unsupported transport observation schema")
+
+    if failures:
+        raise ValueError("; ".join(failures))
+
+    capability = MAPPING[schema]
+    updated = deepcopy(facts)
+    observed = updated.get("transport_capabilities_observed")
+    if not isinstance(observed, dict) or capability not in observed:
+        raise ValueError("KV readiness facts do not contain mapped transport capability")
+
+    observed[capability] = True
+    admission = {
+        "schema": "stegverse.kv.transport-capability-evidence-admission/v1",
+        "state": "ADMITTED",
+        "source_schema": schema,
+        "capability_type": capability,
+        "facts_advanced": [f"transport_capabilities_observed.{capability}"],
+        "unrelated_facts_advanced": [],
+        "activation_performed": False,
+        "authority_effect": "NONE",
+    }
+    return updated, admission
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("evidence", type=Path)
+    parser.add_argument("--facts", type=Path, default=FACTS)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--admission-output", type=Path)
+    args = parser.parse_args()
+
+    evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
+    facts = json.loads(args.facts.read_text(encoding="utf-8"))
+    try:
+        updated, admission = admit(evidence, facts)
+    except ValueError as exc:
+        print("KV_TRANSPORT_CAPABILITY_EVIDENCE_ADMISSION_FAIL")
+        print(str(exc))
+        return 1
+
+    if args.output:
+        args.output.write_text(json.dumps(updated, indent=2) + "\n", encoding="utf-8")
+    if args.admission_output:
+        args.admission_output.write_text(json.dumps(admission, indent=2) + "\n", encoding="utf-8")
+
+    print("KV_TRANSPORT_CAPABILITY_EVIDENCE_ADMISSION_PASS")
+    print(f"CAPABILITY_TYPE={admission['capability_type']}")
+    print("ACTIVATION_PERFORMED=false")
+    print("AUTHORITY_EFFECT=NONE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_admit_transport_capability_evidence.py
+++ b/tests/test_admit_transport_capability_evidence.py
@@ -1,0 +1,153 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "admit_transport_capability_evidence",
+    ROOT / "scripts" / "admit_transport_capability_evidence.py",
+)
+module = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(module)
+
+FACTS = json.loads(
+    (ROOT / "specs" / "kv-activation-readiness-facts.v1.json").read_text(encoding="utf-8")
+)
+
+
+def hf_evidence():
+    return {
+        "schema": module.HF_SCHEMA,
+        "observation_class": "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE",
+        "state": "OBSERVED",
+        "node_registration": {
+            "node_id": "stegnode-test",
+            "device_continuity_id": "stegdevice-test",
+            "state": "ESTABLISHED",
+            "credential_authority": "TV/TVC",
+        },
+        "resident_receipt": {
+            "state": "COMPLETE",
+            "credential_used": False,
+            "github_token_used": False,
+            "authority_effect": "NONE",
+        },
+        "intr_receipt": {
+            "state": "COMPLETE",
+            "transport_profile": "stegverse.universal-intr.adjacent-hop/v1",
+            "destination_validation": "PASS",
+            "lineage_verified": True,
+            "claims": {
+                "credential_used": False,
+                "runtime_activation_claimed": False,
+                "production_interlock_runtime_activated": False,
+            },
+            "authority_effect": "NONE",
+        },
+        "assertions": {
+            "existing_node_reused": True,
+            "new_node_identity_minted": False,
+            "public_source_live_fetch": True,
+            "exact_raw_bytes_hashed": True,
+            "universal_intr_adjacent_hop_executed": True,
+            "destination_validation": "PASS",
+            "lineage_verified": True,
+            "global_runtime_activation_claimed": False,
+        },
+        "journal_replay": {"state": "PASS"},
+        "reconstruction_entry": {
+            "receipt": {
+                "state": "PASS",
+                "same_execution": True,
+            }
+        },
+        "authority_effect": "NONE",
+    }
+
+
+def hil_evidence():
+    return {
+        "schema": module.HIL_SCHEMA,
+        "state": "OBSERVED",
+        "observation_class": "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE",
+        "existing_node_reused": True,
+        "new_node_identity_minted": False,
+        "credential_used": False,
+        "github_token_used": False,
+        "exact_byte_reconstruction": "PASS",
+        "custody_state": "EXACT_BYTES_PERSISTED",
+        "registry_state": "RECORDED",
+        "journal_replay_state": "PASS",
+        "next_required_transition": "HIL_CUSTODY_TVC_INTERLOCK_ADMISSION",
+        "tvc_receiving_receipt_observed": False,
+        "receiver_restart_reconstruction_observed": False,
+        "authority_effect": "NONE",
+    }
+
+
+def test_hf_admission_advances_only_adjacent_external_api_egress():
+    updated, admission = module.admit(hf_evidence(), FACTS)
+    assert admission["capability_type"] == "ADJACENT_EXTERNAL_API_EGRESS"
+    assert admission["facts_advanced"] == [
+        "transport_capabilities_observed.ADJACENT_EXTERNAL_API_EGRESS"
+    ]
+    assert admission["unrelated_facts_advanced"] == []
+    assert admission["activation_performed"] is False
+    assert admission["authority_effect"] == "NONE"
+    before = FACTS["transport_capabilities_observed"]
+    after = updated["transport_capabilities_observed"]
+    for key, value in before.items():
+        assert after[key] is (True if key == "ADJACENT_EXTERNAL_API_EGRESS" else value)
+
+
+def test_hil_admission_advances_only_public_https_ingress():
+    updated, admission = module.admit(hil_evidence(), FACTS)
+    assert admission["capability_type"] == "PUBLIC_HTTPS_INGRESS"
+    before = FACTS["transport_capabilities_observed"]
+    after = updated["transport_capabilities_observed"]
+    for key, value in before.items():
+        assert after[key] is (True if key == "PUBLIC_HTTPS_INGRESS" else value)
+
+
+def test_hil_ingress_capability_does_not_require_downstream_tvc_receipt():
+    evidence = hil_evidence()
+    assert evidence["tvc_receiving_receipt_observed"] is False
+    updated, admission = module.admit(evidence, FACTS)
+    assert updated["transport_capabilities_observed"]["PUBLIC_HTTPS_INGRESS"] is True
+    assert admission["activation_performed"] is False
+
+
+def test_hf_fails_closed_if_observation_is_not_observed():
+    evidence = hf_evidence()
+    evidence["state"] = "NOT_OBSERVED"
+    with pytest.raises(ValueError, match="must be OBSERVED"):
+        module.admit(evidence, FACTS)
+
+
+def test_hf_fails_closed_on_new_node_identity():
+    evidence = hf_evidence()
+    evidence["assertions"]["new_node_identity_minted"] = True
+    with pytest.raises(ValueError, match="may not mint"):
+        module.admit(evidence, FACTS)
+
+
+def test_hil_fails_closed_without_exact_byte_custody():
+    evidence = hil_evidence()
+    evidence["custody_state"] = "UNKNOWN"
+    with pytest.raises(ValueError, match="exact bytes"):
+        module.admit(evidence, FACTS)
+
+
+def test_unsupported_schema_fails_closed():
+    with pytest.raises(ValueError, match="unsupported"):
+        module.admit({"schema": "unknown/v1"}, FACTS)
+
+
+def test_source_facts_are_not_mutated_in_place():
+    before = copy.deepcopy(FACTS)
+    module.admit(hf_evidence(), FACTS)
+    assert FACTS == before


### PR DESCRIPTION
Closes #129.

Adds a fail-closed evidence adapter mapping the current SV-DN-1 browser-resident observation bundle/v3 to ADJACENT_EXTERNAL_API_EGRESS and HIL canonical observation evidence/v1 to PUBLIC_HTTPS_INGRESS. Exactly one transport fact may advance per valid observation; unrelated lifecycle, provider, credential, Interlock, and authority facts remain unchanged.