### PR TITLE
Admit canonical SV-DN-1 transport observation evidence

### DIFF
--- a/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
+++ b/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
@@ -161,6 +161,32 @@ It does not advance production Interlock activation, provider/session state, cre
 
 The HIL ingress capability may be admitted independently of the later TVC lifecycle receipt because the fact being established is specifically public HTTPS ingress capability, not completion of the HIL lifecycle.
 
-The current Hugging Face browser observer source on Site emits the v3 bundle above. Earlier session references to an older canonical-evidence filename/schema are superseded by the live Site source.
+The current Hugging Face browser observer source on Site emits the v3 bundle above. That browser bundle is normalized and canonically preserved by the `.github` evidence lane as `stegverse.sv-dn1.canonical-observation-evidence/v1`. The canonical preserved evidence is preferred for durable KV admission; the v3 bundle remains an accepted upstream/source form.
 
 No KV fact is advanced merely because the adapter exists. Authentic evidence bytes must be supplied and pass validation.
+
+
+## Canonical SV-DN-1 evidence reconciliation — issue #133
+
+The authentic preserved Hugging Face observation was located at:
+
+```text
+StegVerse-Labs/.github
+evidence/sv-dn1/first-authentic-browser-observation-20260829.json
+schema: stegverse.sv-dn1.canonical-observation-evidence/v1
+state: OBSERVED
+```
+
+The evidence records the established Node/device continuity identity, HTTP 200 source capture, exact raw-response digest, semantic exchange identity, Universal InTr adjacent-hop profile, destination validation PASS, lineage verification, journal replay PASS, terminal/reconstruction linkage PASS, same-execution reconstruction PASS, no credential use, no GitHub-token use, no new Node identity, and no runtime/production-Interlock activation claim.
+
+The KV evidence adapter now accepts both:
+
+```text
+browser source form:
+  stegverse.sv-dn1.browser-resident-observation-bundle/v3
+
+canonical durable form:
+  stegverse.sv-dn1.canonical-observation-evidence/v1
+```
+
+Both map only to `ADJACENT_EXTERNAL_API_EGRESS`. Canonical evidence is preferred for durable fact admission.

--- a/schemas/kv-transport-capability-evidence-admission.schema.json
+++ b/schemas/kv-transport-capability-evidence-admission.schema.json
@@ -14,11 +14,16 @@
     "authority_effect"
   ],
   "properties": {
-    "schema": {"const": "stegverse.kv.transport-capability-evidence-admission/v1"},
-    "state": {"const": "ADMITTED"},
+    "schema": {
+      "const": "stegverse.kv.transport-capability-evidence-admission/v1"
+    },
+    "state": {
+      "const": "ADMITTED"
+    },
     "source_schema": {
       "enum": [
         "stegverse.sv-dn1.browser-resident-observation-bundle/v3",
+        "stegverse.sv-dn1.canonical-observation-evidence/v1",
         "stegverse.hil.canonical-observation-evidence/v1"
       ]
     },
@@ -32,14 +37,20 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 1,
-      "items": {"type": "string"}
+      "items": {
+        "type": "string"
+      }
     },
     "unrelated_facts_advanced": {
       "type": "array",
       "maxItems": 0
     },
-    "activation_performed": {"const": false},
-    "authority_effect": {"const": "NONE"}
+    "activation_performed": {
+      "const": false
+    },
+    "authority_effect": {
+      "const": "NONE"
+    }
   },
   "additionalProperties": false
 }

--- a/scripts/admit_transport_capability_evidence.py
+++ b/scripts/admit_transport_capability_evidence.py
@@ -12,6 +12,7 @@ FACTS = ROOT / "specs" / "kv-activation-readiness-facts.v1.json"
 
 HF_BROWSER_SCHEMA = "stegverse.sv-dn1.browser-resident-observation-bundle/v3"
 HF_CANONICAL_SCHEMA = "stegverse.sv-dn1.canonical-observation-evidence/v1"
+HF_SCHEMA = HF_BROWSER_SCHEMA  # compatibility alias for existing tests/consumers
 HIL_SCHEMA = "stegverse.hil.canonical-observation-evidence/v1"
 
 MAPPING = {

--- a/scripts/admit_transport_capability_evidence.py
+++ b/scripts/admit_transport_capability_evidence.py
@@ -10,11 +10,13 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 FACTS = ROOT / "specs" / "kv-activation-readiness-facts.v1.json"
 
-HF_SCHEMA = "stegverse.sv-dn1.browser-resident-observation-bundle/v3"
+HF_BROWSER_SCHEMA = "stegverse.sv-dn1.browser-resident-observation-bundle/v3"
+HF_CANONICAL_SCHEMA = "stegverse.sv-dn1.canonical-observation-evidence/v1"
 HIL_SCHEMA = "stegverse.hil.canonical-observation-evidence/v1"
 
 MAPPING = {
-    HF_SCHEMA: "ADJACENT_EXTERNAL_API_EGRESS",
+    HF_BROWSER_SCHEMA: "ADJACENT_EXTERNAL_API_EGRESS",
+    HF_CANONICAL_SCHEMA: "ADJACENT_EXTERNAL_API_EGRESS",
     HIL_SCHEMA: "PUBLIC_HTTPS_INGRESS",
 }
 
@@ -26,7 +28,7 @@ def _require(condition: bool, message: str, failures: list[str]) -> None:
 
 def validate_hf(payload: dict) -> list[str]:
     failures: list[str] = []
-    _require(payload.get("schema") == HF_SCHEMA, "unexpected HF evidence schema", failures)
+    _require(payload.get("schema") == HF_BROWSER_SCHEMA, "unexpected HF evidence schema", failures)
     _require(payload.get("state") == "OBSERVED", "HF evidence must be OBSERVED", failures)
     _require(payload.get("observation_class") == "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE", "HF observation class invalid", failures)
     _require(payload.get("authority_effect") == "NONE", "HF authority_effect must be NONE", failures)
@@ -88,6 +90,77 @@ def validate_hf(payload: dict) -> list[str]:
     return failures
 
 
+def validate_hf_canonical(payload: dict) -> list[str]:
+    failures: list[str] = []
+    _require(payload.get("schema") == HF_CANONICAL_SCHEMA, "unexpected canonical HF evidence schema", failures)
+    _require(payload.get("state") == "OBSERVED", "canonical HF evidence must be OBSERVED", failures)
+    _require(
+        payload.get("observation_class") == "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE",
+        "canonical HF observation class invalid",
+        failures,
+    )
+    _require(payload.get("authority_effect") == "NONE", "canonical HF authority_effect must be NONE", failures)
+    _require(isinstance(payload.get("node_id"), str) and bool(payload.get("node_id")), "canonical HF node_id missing", failures)
+    _require(
+        isinstance(payload.get("device_continuity_id"), str) and bool(payload.get("device_continuity_id")),
+        "canonical HF device continuity missing",
+        failures,
+    )
+    _require(payload.get("resident_state") == "COMPLETE", "canonical HF resident state must be COMPLETE", failures)
+    _require(payload.get("source_http_status") == 200, "canonical HF source HTTP status must be 200", failures)
+    _require(
+        payload.get("transport_profile") == "stegverse.universal-intr.adjacent-hop/v1",
+        "canonical HF transport profile mismatch",
+        failures,
+    )
+    _require(
+        payload.get("universal_intr_policy_id") == "STEGVERSE-UNIVERSAL-INTR-TRANSPORT-001",
+        "canonical HF Universal InTr policy mismatch",
+        failures,
+    )
+    _require(payload.get("boundary_from") == "EXTERNAL_SYSTEM", "canonical HF source boundary mismatch", failures)
+    _require(payload.get("boundary_to") == "STEGOS_ECOSYSTEM", "canonical HF destination boundary mismatch", failures)
+    _require(payload.get("destination_validation") == "PASS", "canonical HF destination validation must PASS", failures)
+    _require(payload.get("lineage_verified") is True, "canonical HF lineage must be verified", failures)
+    _require(payload.get("journal_replay_state") == "PASS", "canonical HF journal replay must PASS", failures)
+    _require(payload.get("existing_node_reused") is True, "canonical HF must reuse established node", failures)
+    _require(payload.get("new_node_identity_minted") is False, "canonical HF may not mint a new node identity", failures)
+    _require(payload.get("credential_used") is False, "canonical HF credential_used must be false", failures)
+    _require(payload.get("github_token_used") is False, "canonical HF github_token_used must be false", failures)
+    _require(payload.get("runtime_activation_claimed") is False, "canonical HF runtime activation may not be claimed", failures)
+    _require(
+        payload.get("production_interlock_runtime_activated") is False,
+        "canonical HF production Interlock activation may not be claimed",
+        failures,
+    )
+    validation = payload.get("validation")
+    _require(isinstance(validation, dict), "canonical HF validation block missing", failures)
+    if isinstance(validation, dict):
+        for key in (
+            "journal_receipt_hashes",
+            "journal_entry_hashes",
+            "journal_previous_hash_chain",
+            "claim_terminal_link",
+            "terminal_reconstruction_link",
+            "reconstruction_same_execution",
+            "interlock_intr_previous_receipt_hash",
+            "intr_exchange_identity",
+            "resident_exchange_identity",
+            "resident_raw_digest_identity",
+        ):
+            _require(validation.get(key) == "PASS", f"canonical HF validation {key} must PASS", failures)
+    for key in (
+        "source_bundle_sha256",
+        "raw_response_sha256",
+        "semantic_exchange_id",
+        "source_transform_hash",
+        "intr_receipt_hash",
+        "journal_tail_sha256",
+    ):
+        _require(isinstance(payload.get(key), str) and bool(payload.get(key)), f"canonical HF {key} missing", failures)
+    return failures
+
+
 def validate_hil(payload: dict) -> list[str]:
     failures: list[str] = []
     _require(payload.get("schema") == HIL_SCHEMA, "unexpected HIL evidence schema", failures)
@@ -108,8 +181,10 @@ def validate_hil(payload: dict) -> list[str]:
 
 def admit(payload: dict, facts: dict) -> tuple[dict, dict]:
     schema = payload.get("schema")
-    if schema == HF_SCHEMA:
+    if schema == HF_BROWSER_SCHEMA:
         failures = validate_hf(payload)
+    elif schema == HF_CANONICAL_SCHEMA:
+        failures = validate_hf_canonical(payload)
     elif schema == HIL_SCHEMA:
         failures = validate_hil(payload)
     else:

--- a/tests/test_admit_transport_capability_evidence.py
+++ b/tests/test_admit_transport_capability_evidence.py
@@ -69,6 +69,58 @@ def hf_evidence():
     }
 
 
+
+def hf_canonical_evidence():
+    return {
+        "schema": module.HF_CANONICAL_SCHEMA,
+        "state": "OBSERVED",
+        "observation_class": "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE",
+        "observed_at": "2026-08-29T23:39:43.780Z",
+        "continuity_source": "LIVE_EXISTING_WEB_BOOTSTRAP",
+        "source_bundle_sha256": "bce1baa1ee8db9e185f0e40673187ba0d7ef3ed47e8c1981ec9eae5d6c3cc2f0",
+        "node_id": "stegnode-test",
+        "device_continuity_id": "stegdevice-test",
+        "resident_task_id": "SV-DN1-RESIDENT-OBSERVER-001",
+        "claim_id": "SV-DN1-stegnode-test-G5",
+        "fencing_token": 5,
+        "resident_state": "COMPLETE",
+        "source_url": "https://huggingface.co/api/models/Qwen/Qwen3-8B",
+        "source_http_status": 200,
+        "raw_response_sha256": "sha256:" + "b" * 64,
+        "semantic_exchange_id": "sha256:" + "4" * 64,
+        "source_transform_hash": "sha256:" + "a" * 64,
+        "intr_receipt_hash": "sha256:" + "e" * 64,
+        "transport_profile": "stegverse.universal-intr.adjacent-hop/v1",
+        "universal_intr_policy_id": "STEGVERSE-UNIVERSAL-INTR-TRANSPORT-001",
+        "boundary_from": "EXTERNAL_SYSTEM",
+        "boundary_to": "STEGOS_ECOSYSTEM",
+        "destination_validation": "PASS",
+        "lineage_verified": True,
+        "journal_replay_state": "PASS",
+        "journal_entries": 26,
+        "journal_tail_sha256": "8" * 64,
+        "existing_node_reused": True,
+        "new_node_identity_minted": False,
+        "credential_used": False,
+        "github_token_used": False,
+        "sdk_admitted": False,
+        "runtime_activation_claimed": False,
+        "production_interlock_runtime_activated": False,
+        "authority_effect": "NONE",
+        "validation": {
+            "journal_receipt_hashes": "PASS",
+            "journal_entry_hashes": "PASS",
+            "journal_previous_hash_chain": "PASS",
+            "claim_terminal_link": "PASS",
+            "terminal_reconstruction_link": "PASS",
+            "reconstruction_same_execution": "PASS",
+            "interlock_intr_previous_receipt_hash": "PASS",
+            "intr_exchange_identity": "PASS",
+            "resident_exchange_identity": "PASS",
+            "resident_raw_digest_identity": "PASS",
+        },
+    }
+
 def hil_evidence():
     return {
         "schema": module.HIL_SCHEMA,
@@ -151,3 +203,27 @@ def test_source_facts_are_not_mutated_in_place():
     before = copy.deepcopy(FACTS)
     module.admit(hf_evidence(), FACTS)
     assert FACTS == before
+
+
+def test_canonical_hf_admission_advances_only_adjacent_external_api_egress():
+    updated, admission = module.admit(hf_canonical_evidence(), FACTS)
+    assert admission["source_schema"] == module.HF_CANONICAL_SCHEMA
+    assert admission["capability_type"] == "ADJACENT_EXTERNAL_API_EGRESS"
+    assert updated["transport_capabilities_observed"]["ADJACENT_EXTERNAL_API_EGRESS"] is True
+    for key, value in FACTS["transport_capabilities_observed"].items():
+        if key != "ADJACENT_EXTERNAL_API_EGRESS":
+            assert updated["transport_capabilities_observed"][key] is value
+
+
+def test_canonical_hf_fails_closed_on_validation_drift():
+    evidence = hf_canonical_evidence()
+    evidence["validation"]["terminal_reconstruction_link"] = "FAIL"
+    with pytest.raises(ValueError, match="terminal_reconstruction_link must PASS"):
+        module.admit(evidence, FACTS)
+
+
+def test_canonical_hf_fails_closed_on_transport_profile_drift():
+    evidence = hf_canonical_evidence()
+    evidence["transport_profile"] = "other/v1"
+    with pytest.raises(ValueError, match="transport profile mismatch"):
+        module.admit(evidence, FACTS)


### PR DESCRIPTION
Closes #133.

Extends the typed-transport evidence adapter to accept the canonical preserved SV-DN-1 evidence schema from StegVerse-Labs/.github while retaining browser-resident bundle/v3 as an upstream form. Both map only to ADJACENT_EXTERNAL_API_EGRESS. Adds strict validation and updates the canonical handoff.