### PR TITLE
Admit authentic SV-DN-1 egress observation into KV transport facts

### DIFF
--- a/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
+++ b/KV_ACTIVATION_READINESS_MIRROR_HANDOFF.md
@@ -6,7 +6,7 @@ Issue: #59
 Merged PR: #60
 Merge: a749c8b844b11299004990610a1b5506b2eb3ed8
 CI: KV Guardrails 33022950257 SUCCESS; Repository validation 33022950268 SUCCESS; Security Baseline 33022950263 SUCCESS
-Updated: 2026-08-26
+Updated: 2026-08-30
 
 ## Purpose
 
@@ -443,18 +443,37 @@ service with explicit external-provider dependency:
 
 Operation-specific transport types remain owned by the lane that requests them. The readiness layer does not globally force HIL `PUBLIC_HTTPS_INGRESS`, `NODE_TO_NODE_SYNC`, `KV_SKAP_INTR`, or `TVC_RELAY` onto unrelated actions.
 
-The readiness facts now expose all seven typed capability observations explicitly and currently keep each false until authentic evidence is separately admitted:
+The readiness facts expose all seven typed capability observations explicitly. The canonical SV-DN-1/Hugging Face observation has now been admitted as the first authentic typed transport fact:
 
 ```text
 KV_DISTRIBUTION_DOWNLOAD=false
 DEVICE_KV_INTR=false
 PUBLIC_HTTPS_INGRESS=false
-ADJACENT_EXTERNAL_API_EGRESS=false
+ADJACENT_EXTERNAL_API_EGRESS=true
 NODE_TO_NODE_SYNC=false
 KV_SKAP_INTR=false
 TVC_RELAY=false
 ```
 
-This source change does not downgrade the separately observed Hugging Face/SV-DN-1 transport result; it means that result has not yet been admitted as KnowledgeVault transport-capability evidence.
+`ADJACENT_EXTERNAL_API_EGRESS=true` is grounded in the canonical authentic observation preserved by `StegVerse-Labs/.github` and the durable KV admission record. No other transport fact is inferred from it.
 
 No transport, module, service, Interlock, InTr, credential, provider, or execution activation is created by these readiness facts.
+
+
+## Authentic SV-DN-1 typed transport admission — issue #135
+
+The canonical observed SV-DN-1 evidence has been admitted into readiness facts.
+
+```text
+source: StegVerse-Labs/.github/evidence/sv-dn1/first-authentic-browser-observation-20260829.json
+source Git blob: 0a73e970e66960222832d1f2cb64892e497e1eb8
+source schema: stegverse.sv-dn1.canonical-observation-evidence/v1
+source state: OBSERVED
+mapped capability: ADJACENT_EXTERNAL_API_EGRESS
+resulting fact: true
+unrelated facts advanced: NONE
+activation_performed: false
+authority_effect: NONE
+```
+
+The 46 governed module/service actions remain blocked because all require `DEVICE_KV_INTR`, production Interlock runtime remains false, and other service-specific predicates remain independently enforced. Observing one transport type therefore removes only that exact blocker where applicable; it does not authorize provider use or a governed action.

--- a/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
+++ b/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Typed Transport Capability Governance Mirror Handoff
 
-Status: IMPLEMENTED_VALIDATED_MERGED / RUNTIME_EVIDENCE_ADMISSION_PENDING
+Status: IMPLEMENTED_VALIDATED_MERGED / FIRST_RUNTIME_EVIDENCE_ADMITTED
 Repository: StegVerse-Labs/continuity-vault-kit
 Issue: #124
 Branch: docs/reconcile-typed-transport-handoff-20260830
@@ -123,7 +123,7 @@ typed transport source validation: VALIDATED
 continuity-vault-kit integration: MERGED
 StegOS read-only consumer propagation: MERGED
 authentic HF transport result: OBSERVED independently in Site
-HF observation admitted into KV typed fact: NOT YET — exact authentic bundle bytes not currently present in this repository lane
+HF observation admitted into KV typed fact: YES — ADJACENT_EXTERNAL_API_EGRESS=true from canonical .github evidence
 HIL PUBLIC_HTTPS_INGRESS source/observer: DEPLOYED in Site
 HIL PUBLIC_HTTPS_INGRESS authentic observation: NOT YET OBSERVED
 transport capability runtime activation by this source work: NONE
@@ -132,8 +132,8 @@ authority_effect: NONE
 
 ## Next executable action
 
-1. Admit the exact authentic current-format SV-DN-1/Hugging Face observation bundle when its bytes are available, advancing only `ADJACENT_EXTERNAL_API_EGRESS`.
-2. Execute the deployed HIL established-node observation when the machine-side path is fully ready; if it produces valid canonical evidence, admit only `PUBLIC_HTTPS_INGRESS`.
+1. Execute the deployed HIL established-node observation when the machine-side path is fully ready; if it produces valid canonical evidence, admit only `PUBLIC_HTTPS_INGRESS`.
+2. Establish/observe `DEVICE_KV_INTR` through its authentic device↔KV lane; this remains the universal governed-action transport blocker.
 3. Apply the same typed capability + authentic observation admission pattern to other transport-blocked lanes rather than creating bespoke transport tests.
 
 
@@ -190,3 +190,32 @@ canonical durable form:
 ```
 
 Both map only to `ADJACENT_EXTERNAL_API_EGRESS`. Canonical evidence is preferred for durable fact admission.
+
+
+## First authentic KV typed transport fact admitted — issue #135
+
+Canonical source:
+
+```text
+StegVerse-Labs/.github
+evidence/sv-dn1/first-authentic-browser-observation-20260829.json
+Git blob: 0a73e970e66960222832d1f2cb64892e497e1eb8
+schema: stegverse.sv-dn1.canonical-observation-evidence/v1
+state: OBSERVED
+observed_at: 2026-08-29T23:39:43.780Z
+```
+
+Admission result:
+
+```text
+ADJACENT_EXTERNAL_API_EGRESS=true
+all other typed transport facts unchanged
+activation_performed=false
+authority_effect=NONE
+```
+
+Durable admission record:
+
+`evidence/kv/2026-08-30-sv-dn1-adjacent-external-api-egress-admission.json`
+
+This is the first authentic runtime observation admitted into the KnowledgeVault typed transport fact set. It does not make any module/service governed-ready because `DEVICE_KV_INTR`, production Interlock runtime, and other service-specific predicates remain independently fail-closed.

--- a/evidence/kv/2026-08-30-sv-dn1-adjacent-external-api-egress-admission.json
+++ b/evidence/kv/2026-08-30-sv-dn1-adjacent-external-api-egress-admission.json
@@ -1,0 +1,51 @@
+{
+  "schema": "stegverse.kv.transport-capability-evidence-admission-record/v1",
+  "state": "ADMITTED",
+  "admitted_at": "2026-08-30T03:45:32Z",
+  "source_evidence": {
+    "repository": "StegVerse-Labs/.github",
+    "path": "evidence/sv-dn1/first-authentic-browser-observation-20260829.json",
+    "git_blob_sha": "0a73e970e66960222832d1f2cb64892e497e1eb8",
+    "schema": "stegverse.sv-dn1.canonical-observation-evidence/v1",
+    "state": "OBSERVED",
+    "observed_at": "2026-08-29T23:39:43.780Z",
+    "source_bundle_sha256": "bce1baa1ee8db9e185f0e40673187ba0d7ef3ed47e8c1981ec9eae5d6c3cc2f0",
+    "node_id": "stegnode-web-2d6daa94e496d451d16bd5619bd30a25",
+    "device_continuity_id": "stegdevice-0d0f5403f48ff804fb3d31fb346e748c94e395bc"
+  },
+  "validation_projection": {
+    "resident_state": "COMPLETE",
+    "source_http_status": 200,
+    "transport_profile": "stegverse.universal-intr.adjacent-hop/v1",
+    "universal_intr_policy_id": "STEGVERSE-UNIVERSAL-INTR-TRANSPORT-001",
+    "boundary_from": "EXTERNAL_SYSTEM",
+    "boundary_to": "STEGOS_ECOSYSTEM",
+    "destination_validation": "PASS",
+    "lineage_verified": true,
+    "journal_replay_state": "PASS",
+    "existing_node_reused": true,
+    "new_node_identity_minted": false,
+    "credential_used": false,
+    "github_token_used": false,
+    "runtime_activation_claimed": false,
+    "production_interlock_runtime_activated": false,
+    "canonical_validation_all_pass": true
+  },
+  "adapter_contract": {
+    "script": "scripts/admit_transport_capability_evidence.py",
+    "source_schema": "stegverse.sv-dn1.canonical-observation-evidence/v1",
+    "capability_type": "ADJACENT_EXTERNAL_API_EGRESS",
+    "facts_advanced": [
+      "transport_capabilities_observed.ADJACENT_EXTERNAL_API_EGRESS"
+    ],
+    "unrelated_facts_advanced": [],
+    "activation_performed": false,
+    "authority_effect": "NONE"
+  },
+  "resulting_fact": {
+    "path": "specs/kv-activation-readiness-facts.v1.json",
+    "transport_capability": "ADJACENT_EXTERNAL_API_EGRESS",
+    "observed": true
+  },
+  "authority_effect": "NONE"
+}

--- a/specs/kv-activation-readiness-facts.v1.json
+++ b/specs/kv-activation-readiness-facts.v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "stegverse.kv.activation-readiness-facts/v1",
-  "observed_at": "2026-08-27T04:08:00Z",
+  "observed_at": "2026-08-29T23:39:43.780Z",
   "baseline_intr_rc01_rc05_complete": true,
   "connected_kv_baseline_runtime_observed": true,
   "production_interlock_runtime_activated": false,
@@ -25,7 +25,7 @@
     "KV_DISTRIBUTION_DOWNLOAD": false,
     "DEVICE_KV_INTR": false,
     "PUBLIC_HTTPS_INGRESS": false,
-    "ADJACENT_EXTERNAL_API_EGRESS": false,
+    "ADJACENT_EXTERNAL_API_EGRESS": true,
     "NODE_TO_NODE_SYNC": false,
     "KV_SKAP_INTR": false,
     "TVC_RELAY": false

--- a/tests/test_kv_activation_readiness.py
+++ b/tests/test_kv_activation_readiness.py
@@ -65,6 +65,7 @@ def test_stegfin_preserves_full_production_tvc_blockers():
 def test_all_governed_entries_require_device_kv_transport_capability():
     snapshot = module.evaluate()
     assert snapshot["transport_capabilities_observed"]["DEVICE_KV_INTR"] is False
+    assert snapshot["transport_capabilities_observed"]["ADJACENT_EXTERNAL_API_EGRESS"] is True
     assert all(
         "DEVICE_KV_INTR" in entry["transport_capability_requirements"]
         for entry in snapshot["entries"]
@@ -90,7 +91,7 @@ def test_external_provider_services_require_adjacent_external_api_egress():
     for service_id in provider_backed:
         entry = entries[service_id]
         assert "ADJACENT_EXTERNAL_API_EGRESS" in entry["transport_capability_requirements"]
-        assert "transport_capability:ADJACENT_EXTERNAL_API_EGRESS" in entry["governed_blockers"]
+        assert "transport_capability:ADJACENT_EXTERNAL_API_EGRESS" not in entry["governed_blockers"]
 
 
 def test_local_only_personal_journal_does_not_require_external_api_egress():
@@ -98,3 +99,17 @@ def test_local_only_personal_journal_does_not_require_external_api_egress():
     journal = next(e for e in snapshot["entries"] if e["entry_id"] == "personal-journal")
     assert journal["transport_capability_requirements"] == ["DEVICE_KV_INTR"]
     assert "transport_capability:ADJACENT_EXTERNAL_API_EGRESS" not in journal["governed_blockers"]
+
+
+def test_observed_external_api_egress_does_not_clear_other_governance_blockers():
+    snapshot = module.evaluate()
+    provider_entries = [
+        entry for entry in snapshot["entries"]
+        if entry["entry_type"] == "SERVICE"
+        and "ADJACENT_EXTERNAL_API_EGRESS" in entry["transport_capability_requirements"]
+    ]
+    assert provider_entries
+    for entry in provider_entries:
+        assert entry["governed_action_readiness"] == "BLOCKED"
+        assert "transport_capability:DEVICE_KV_INTR" in entry["governed_blockers"]
+        assert "production_interlock_runtime_activated" in entry["governed_blockers"]


### PR DESCRIPTION
Closes #135.

Admits the canonical authentic SV-DN-1 observation preserved in StegVerse-Labs/.github into KnowledgeVault typed transport readiness. Advances only ADJACENT_EXTERNAL_API_EGRESS=true, records cross-repo provenance and the exact source Git blob, reconciles readiness tests/handoffs, and leaves every unrelated transport, activation, provider, Interlock, and authority fact unchanged.