### PR TITLE
Harden HIL transport evidence admission

### DIFF
--- a/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
+++ b/KV_TYPED_TRANSPORT_CAPABILITY_MIRROR_HANDOFF.md
@@ -136,86 +136,46 @@ authority_effect: NONE
 2. Establish/observe `DEVICE_KV_INTR` through its authentic device↔KV lane; this remains the universal governed-action transport blocker.
 3. Apply the same typed capability + authentic observation admission pattern to other transport-blocked lanes rather than creating bespoke transport tests.
 
-
 ## Authentic observation evidence admission — issue #129
 
-The typed transport model now has a bounded fail-closed evidence adapter:
+The typed transport model has a bounded fail-closed evidence adapter:
 
 - `scripts/admit_transport_capability_evidence.py`
 - `schemas/kv-transport-capability-evidence-admission.schema.json`
 - `tests/test_admit_transport_capability_evidence.py`
 
-Initial mappings:
-
-```text
-stegverse.sv-dn1.browser-resident-observation-bundle/v3
-  -> ADJACENT_EXTERNAL_API_EGRESS
-
-stegverse.hil.canonical-observation-evidence/v1
-  -> PUBLIC_HTTPS_INGRESS
-```
-
-Admission advances only the matching `transport_capabilities_observed.<TYPE>` fact.
-
-It does not advance production Interlock activation, provider/session state, credential state, module/service activation, TVC lifecycle state, execution authority, or any unrelated transport capability.
-
-The HIL ingress capability may be admitted independently of the later TVC lifecycle receipt because the fact being established is specifically public HTTPS ingress capability, not completion of the HIL lifecycle.
-
-The current Hugging Face browser observer source on Site emits the v3 bundle above. That browser bundle is normalized and canonically preserved by the `.github` evidence lane as `stegverse.sv-dn1.canonical-observation-evidence/v1`. The canonical preserved evidence is preferred for durable KV admission; the v3 bundle remains an accepted upstream/source form.
-
-No KV fact is advanced merely because the adapter exists. Authentic evidence bytes must be supplied and pass validation.
-
+Mappings include canonical SV-DN-1/Hugging Face evidence -> `ADJACENT_EXTERNAL_API_EGRESS` and canonical HIL evidence -> `PUBLIC_HTTPS_INGRESS`. Admission advances only the matching transport fact and cannot advance production Interlock activation, provider/session state, credential state, module/service activation, TVC lifecycle state, execution authority, or unrelated transport capabilities.
 
 ## Canonical SV-DN-1 evidence reconciliation — issue #133
 
-The authentic preserved Hugging Face observation was located at:
-
-```text
-StegVerse-Labs/.github
-evidence/sv-dn1/first-authentic-browser-observation-20260829.json
-schema: stegverse.sv-dn1.canonical-observation-evidence/v1
-state: OBSERVED
-```
-
-The evidence records the established Node/device continuity identity, HTTP 200 source capture, exact raw-response digest, semantic exchange identity, Universal InTr adjacent-hop profile, destination validation PASS, lineage verification, journal replay PASS, terminal/reconstruction linkage PASS, same-execution reconstruction PASS, no credential use, no GitHub-token use, no new Node identity, and no runtime/production-Interlock activation claim.
-
-The KV evidence adapter now accepts both:
-
-```text
-browser source form:
-  stegverse.sv-dn1.browser-resident-observation-bundle/v3
-
-canonical durable form:
-  stegverse.sv-dn1.canonical-observation-evidence/v1
-```
-
-Both map only to `ADJACENT_EXTERNAL_API_EGRESS`. Canonical evidence is preferred for durable fact admission.
-
+Canonical durable Hugging Face evidence is preserved in `StegVerse-Labs/.github/evidence/sv-dn1/first-authentic-browser-observation-20260829.json` and is preferred for durable KV admission.
 
 ## First authentic KV typed transport fact admitted — issue #135
 
-Canonical source:
+`ADJACENT_EXTERNAL_API_EGRESS=true` is admitted from the canonical observed SV-DN-1 evidence. Every other typed transport fact remains independently governed. Durable admission record: `evidence/kv/2026-08-30-sv-dn1-adjacent-external-api-egress-admission.json`.
+
+## HIL evidence-admission hardening — issue #138
+
+Before `PUBLIC_HTTPS_INGRESS` may be advanced from a HIL browser observation, the admission validator now requires the canonical HIL bundle to preserve the observation surface's explicit non-claims and identity predicates:
 
 ```text
-StegVerse-Labs/.github
-evidence/sv-dn1/first-authentic-browser-observation-20260829.json
-Git blob: 0a73e970e66960222832d1f2cb64892e497e1eb8
-schema: stegverse.sv-dn1.canonical-observation-evidence/v1
-state: OBSERVED
-observed_at: 2026-08-29T23:39:43.780Z
+state=OBSERVED
+observation_class=AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE
+existing_node_reused=true
+new_node_identity_minted=false
+credential_used=false
+github_token_used=false
+participant_research_submission=false
+runtime_activation_claimed=false
+tvc_lifecycle_intent_observed=true
+tvc_receiving_receipt_observed=false
+receiver_restart_reconstruction_observed=false
+custody_state=EXACT_BYTES_PERSISTED
+registry_state=RECORDED
+exact_byte_reconstruction=PASS
+controlled_pdf_sha256 == retrieved_pdf_sha256
+next_required_transition=HIL_CUSTODY_TVC_INTERLOCK_ADMISSION
+journal replay / claim-terminal / terminal-reconstruction / InTr-chain / exact-byte validation markers = PASS
 ```
 
-Admission result:
-
-```text
-ADJACENT_EXTERNAL_API_EGRESS=true
-all other typed transport facts unchanged
-activation_performed=false
-authority_effect=NONE
-```
-
-Durable admission record:
-
-`evidence/kv/2026-08-30-sv-dn1-adjacent-external-api-egress-admission.json`
-
-This is the first authentic runtime observation admitted into the KnowledgeVault typed transport fact set. It does not make any module/service governed-ready because `DEVICE_KV_INTR`, production Interlock runtime, and other service-specific predicates remain independently fail-closed.
+The adapter also requires the receiver/submission/receipt-chain hash identities to be present. This hardening prevents a malformed or over-claimed HIL observation from advancing `PUBLIC_HTTPS_INGRESS`; it does not require the downstream TVC receiving receipt to exist, because that is a different lifecycle predicate.

--- a/scripts/admit_transport_capability_evidence.py
+++ b/scripts/admit_transport_capability_evidence.py
@@ -12,7 +12,7 @@ FACTS = ROOT / "specs" / "kv-activation-readiness-facts.v1.json"
 
 HF_BROWSER_SCHEMA = "stegverse.sv-dn1.browser-resident-observation-bundle/v3"
 HF_CANONICAL_SCHEMA = "stegverse.sv-dn1.canonical-observation-evidence/v1"
-HF_SCHEMA = HF_BROWSER_SCHEMA  # compatibility alias for existing tests/consumers
+HF_SCHEMA = HF_BROWSER_SCHEMA
 HIL_SCHEMA = "stegverse.hil.canonical-observation-evidence/v1"
 
 MAPPING = {
@@ -33,13 +33,11 @@ def validate_hf(payload: dict) -> list[str]:
     _require(payload.get("state") == "OBSERVED", "HF evidence must be OBSERVED", failures)
     _require(payload.get("observation_class") == "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE", "HF observation class invalid", failures)
     _require(payload.get("authority_effect") == "NONE", "HF authority_effect must be NONE", failures)
-
     node = payload.get("node_registration")
     _require(isinstance(node, dict), "HF node registration missing", failures)
     if isinstance(node, dict):
         _require(node.get("state") == "ESTABLISHED", "HF node must be ESTABLISHED", failures)
         _require(node.get("credential_authority") == "TV/TVC", "HF credential authority must be TV/TVC", failures)
-
     resident = payload.get("resident_receipt")
     _require(isinstance(resident, dict), "HF resident receipt missing", failures)
     if isinstance(resident, dict):
@@ -47,7 +45,6 @@ def validate_hf(payload: dict) -> list[str]:
         _require(resident.get("credential_used") is False, "HF credential_used must be false", failures)
         _require(resident.get("github_token_used") is False, "HF github_token_used must be false", failures)
         _require(resident.get("authority_effect") == "NONE", "HF resident authority_effect must be NONE", failures)
-
     intr = payload.get("intr_receipt")
     _require(isinstance(intr, dict), "HF InTr receipt missing", failures)
     if isinstance(intr, dict):
@@ -62,22 +59,14 @@ def validate_hf(payload: dict) -> list[str]:
             _require(claims.get("credential_used") is False, "HF InTr credential_used must be false", failures)
             _require(claims.get("runtime_activation_claimed") is False, "HF runtime activation may not be claimed", failures)
             _require(claims.get("production_interlock_runtime_activated") is False, "HF production Interlock activation may not be claimed", failures)
-
     assertions = payload.get("assertions")
     _require(isinstance(assertions, dict), "HF assertions missing", failures)
     if isinstance(assertions, dict):
-        for key in (
-            "existing_node_reused",
-            "public_source_live_fetch",
-            "exact_raw_bytes_hashed",
-            "universal_intr_adjacent_hop_executed",
-            "lineage_verified",
-        ):
+        for key in ("existing_node_reused", "public_source_live_fetch", "exact_raw_bytes_hashed", "universal_intr_adjacent_hop_executed", "lineage_verified"):
             _require(assertions.get(key) is True, f"HF assertion {key} must be true", failures)
         _require(assertions.get("new_node_identity_minted") is False, "HF may not mint a new node identity", failures)
         _require(assertions.get("destination_validation") == "PASS", "HF destination validation assertion must PASS", failures)
         _require(assertions.get("global_runtime_activation_claimed") is False, "HF global runtime activation may not be claimed", failures)
-
     replay = payload.get("journal_replay")
     _require(isinstance(replay, dict) and replay.get("state") == "PASS", "HF journal replay must PASS", failures)
     recon = payload.get("reconstruction_entry")
@@ -87,7 +76,6 @@ def validate_hf(payload: dict) -> list[str]:
         _require(receipt.get("same_execution") is True, "HF reconstruction must preserve same execution", failures)
     else:
         failures.append("HF reconstruction entry missing")
-
     return failures
 
 
@@ -95,30 +83,14 @@ def validate_hf_canonical(payload: dict) -> list[str]:
     failures: list[str] = []
     _require(payload.get("schema") == HF_CANONICAL_SCHEMA, "unexpected canonical HF evidence schema", failures)
     _require(payload.get("state") == "OBSERVED", "canonical HF evidence must be OBSERVED", failures)
-    _require(
-        payload.get("observation_class") == "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE",
-        "canonical HF observation class invalid",
-        failures,
-    )
+    _require(payload.get("observation_class") == "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE", "canonical HF observation class invalid", failures)
     _require(payload.get("authority_effect") == "NONE", "canonical HF authority_effect must be NONE", failures)
     _require(isinstance(payload.get("node_id"), str) and bool(payload.get("node_id")), "canonical HF node_id missing", failures)
-    _require(
-        isinstance(payload.get("device_continuity_id"), str) and bool(payload.get("device_continuity_id")),
-        "canonical HF device continuity missing",
-        failures,
-    )
+    _require(isinstance(payload.get("device_continuity_id"), str) and bool(payload.get("device_continuity_id")), "canonical HF device continuity missing", failures)
     _require(payload.get("resident_state") == "COMPLETE", "canonical HF resident state must be COMPLETE", failures)
     _require(payload.get("source_http_status") == 200, "canonical HF source HTTP status must be 200", failures)
-    _require(
-        payload.get("transport_profile") == "stegverse.universal-intr.adjacent-hop/v1",
-        "canonical HF transport profile mismatch",
-        failures,
-    )
-    _require(
-        payload.get("universal_intr_policy_id") == "STEGVERSE-UNIVERSAL-INTR-TRANSPORT-001",
-        "canonical HF Universal InTr policy mismatch",
-        failures,
-    )
+    _require(payload.get("transport_profile") == "stegverse.universal-intr.adjacent-hop/v1", "canonical HF transport profile mismatch", failures)
+    _require(payload.get("universal_intr_policy_id") == "STEGVERSE-UNIVERSAL-INTR-TRANSPORT-001", "canonical HF Universal InTr policy mismatch", failures)
     _require(payload.get("boundary_from") == "EXTERNAL_SYSTEM", "canonical HF source boundary mismatch", failures)
     _require(payload.get("boundary_to") == "STEGOS_ECOSYSTEM", "canonical HF destination boundary mismatch", failures)
     _require(payload.get("destination_validation") == "PASS", "canonical HF destination validation must PASS", failures)
@@ -129,35 +101,13 @@ def validate_hf_canonical(payload: dict) -> list[str]:
     _require(payload.get("credential_used") is False, "canonical HF credential_used must be false", failures)
     _require(payload.get("github_token_used") is False, "canonical HF github_token_used must be false", failures)
     _require(payload.get("runtime_activation_claimed") is False, "canonical HF runtime activation may not be claimed", failures)
-    _require(
-        payload.get("production_interlock_runtime_activated") is False,
-        "canonical HF production Interlock activation may not be claimed",
-        failures,
-    )
+    _require(payload.get("production_interlock_runtime_activated") is False, "canonical HF production Interlock activation may not be claimed", failures)
     validation = payload.get("validation")
     _require(isinstance(validation, dict), "canonical HF validation block missing", failures)
     if isinstance(validation, dict):
-        for key in (
-            "journal_receipt_hashes",
-            "journal_entry_hashes",
-            "journal_previous_hash_chain",
-            "claim_terminal_link",
-            "terminal_reconstruction_link",
-            "reconstruction_same_execution",
-            "interlock_intr_previous_receipt_hash",
-            "intr_exchange_identity",
-            "resident_exchange_identity",
-            "resident_raw_digest_identity",
-        ):
+        for key in ("journal_receipt_hashes", "journal_entry_hashes", "journal_previous_hash_chain", "claim_terminal_link", "terminal_reconstruction_link", "reconstruction_same_execution", "interlock_intr_previous_receipt_hash", "intr_exchange_identity", "resident_exchange_identity", "resident_raw_digest_identity"):
             _require(validation.get(key) == "PASS", f"canonical HF validation {key} must PASS", failures)
-    for key in (
-        "source_bundle_sha256",
-        "raw_response_sha256",
-        "semantic_exchange_id",
-        "source_transform_hash",
-        "intr_receipt_hash",
-        "journal_tail_sha256",
-    ):
+    for key in ("source_bundle_sha256", "raw_response_sha256", "semantic_exchange_id", "source_transform_hash", "intr_receipt_hash", "journal_tail_sha256"):
         _require(isinstance(payload.get(key), str) and bool(payload.get(key)), f"canonical HF {key} missing", failures)
     return failures
 
@@ -172,11 +122,30 @@ def validate_hil(payload: dict) -> list[str]:
     _require(payload.get("new_node_identity_minted") is False, "HIL may not mint new node identity", failures)
     _require(payload.get("credential_used") is False, "HIL credential_used must be false", failures)
     _require(payload.get("github_token_used") is False, "HIL github_token_used must be false", failures)
+    _require(payload.get("participant_research_submission") is False, "HIL participant research submission must be false", failures)
+    _require(payload.get("runtime_activation_claimed") is False, "HIL runtime activation may not be claimed", failures)
+    _require(payload.get("tvc_lifecycle_intent_observed") is True, "HIL TVC lifecycle intent must be observed", failures)
+    _require(payload.get("tvc_receiving_receipt_observed") is False, "HIL TVC receiving receipt must remain unobserved", failures)
+    _require(payload.get("receiver_restart_reconstruction_observed") is False, "HIL receiver restart reconstruction must remain unobserved", failures)
     _require(payload.get("exact_byte_reconstruction") == "PASS", "HIL exact-byte reconstruction must PASS", failures)
     _require(payload.get("custody_state") == "EXACT_BYTES_PERSISTED", "HIL custody must be exact bytes", failures)
     _require(payload.get("registry_state") == "RECORDED", "HIL registry state must be RECORDED", failures)
     _require(payload.get("journal_replay_state") == "PASS", "HIL journal replay must PASS", failures)
     _require(payload.get("next_required_transition") == "HIL_CUSTODY_TVC_INTERLOCK_ADMISSION", "HIL next transition mismatch", failures)
+
+    controlled = payload.get("controlled_pdf_sha256")
+    retrieved = payload.get("retrieved_pdf_sha256")
+    _require(isinstance(controlled, str) and controlled.startswith("sha256:") and len(controlled) == 71, "HIL controlled PDF digest missing", failures)
+    _require(isinstance(retrieved, str) and retrieved.startswith("sha256:") and len(retrieved) == 71, "HIL retrieved PDF digest missing", failures)
+    _require(controlled == retrieved, "HIL submitted/retrieved digest identity mismatch", failures)
+    for key in ("receiver_receipt_id", "submission_id", "intr_chain_hash", "device_stegos_ingress_receipt_hash", "hil_custody_receipt_hash", "journal_tail_sha256"):
+        _require(isinstance(payload.get(key), str) and bool(payload.get(key)), f"HIL {key} missing", failures)
+
+    validation = payload.get("validation")
+    _require(isinstance(validation, dict), "HIL validation block missing", failures)
+    if isinstance(validation, dict):
+        for key in ("journal_receipt_hashes", "journal_entry_hashes", "journal_previous_hash_chain", "claim_terminal_link", "terminal_reconstruction_link", "intr_receipt_chain", "exact_byte_retrieval"):
+            _require(validation.get(key) == "PASS", f"HIL validation {key} must PASS", failures)
     return failures
 
 
@@ -190,16 +159,13 @@ def admit(payload: dict, facts: dict) -> tuple[dict, dict]:
         failures = validate_hil(payload)
     else:
         raise ValueError("unsupported transport observation schema")
-
     if failures:
         raise ValueError("; ".join(failures))
-
     capability = MAPPING[schema]
     updated = deepcopy(facts)
     observed = updated.get("transport_capabilities_observed")
     if not isinstance(observed, dict) or capability not in observed:
         raise ValueError("KV readiness facts do not contain mapped transport capability")
-
     observed[capability] = True
     admission = {
         "schema": "stegverse.kv.transport-capability-evidence-admission/v1",
@@ -221,7 +187,6 @@ def main() -> int:
     parser.add_argument("--output", type=Path)
     parser.add_argument("--admission-output", type=Path)
     args = parser.parse_args()
-
     evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
     facts = json.loads(args.facts.read_text(encoding="utf-8"))
     try:
@@ -230,12 +195,10 @@ def main() -> int:
         print("KV_TRANSPORT_CAPABILITY_EVIDENCE_ADMISSION_FAIL")
         print(str(exc))
         return 1
-
     if args.output:
         args.output.write_text(json.dumps(updated, indent=2) + "\n", encoding="utf-8")
     if args.admission_output:
         args.admission_output.write_text(json.dumps(admission, indent=2) + "\n", encoding="utf-8")
-
     print("KV_TRANSPORT_CAPABILITY_EVIDENCE_ADMISSION_PASS")
     print(f"CAPABILITY_TYPE={admission['capability_type']}")
     print("ACTIVATION_PERFORMED=false")

--- a/tests/test_admit_transport_capability_evidence.py
+++ b/tests/test_admit_transport_capability_evidence.py
@@ -14,9 +14,7 @@ module = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(module)
 
-FACTS = json.loads(
-    (ROOT / "specs" / "kv-activation-readiness-facts.v1.json").read_text(encoding="utf-8")
-)
+FACTS = json.loads((ROOT / "specs" / "kv-activation-readiness-facts.v1.json").read_text(encoding="utf-8"))
 
 
 def hf_evidence():
@@ -24,28 +22,14 @@ def hf_evidence():
         "schema": module.HF_SCHEMA,
         "observation_class": "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE",
         "state": "OBSERVED",
-        "node_registration": {
-            "node_id": "stegnode-test",
-            "device_continuity_id": "stegdevice-test",
-            "state": "ESTABLISHED",
-            "credential_authority": "TV/TVC",
-        },
-        "resident_receipt": {
-            "state": "COMPLETE",
-            "credential_used": False,
-            "github_token_used": False,
-            "authority_effect": "NONE",
-        },
+        "node_registration": {"node_id": "stegnode-test", "device_continuity_id": "stegdevice-test", "state": "ESTABLISHED", "credential_authority": "TV/TVC"},
+        "resident_receipt": {"state": "COMPLETE", "credential_used": False, "github_token_used": False, "authority_effect": "NONE"},
         "intr_receipt": {
             "state": "COMPLETE",
             "transport_profile": "stegverse.universal-intr.adjacent-hop/v1",
             "destination_validation": "PASS",
             "lineage_verified": True,
-            "claims": {
-                "credential_used": False,
-                "runtime_activation_claimed": False,
-                "production_interlock_runtime_activated": False,
-            },
+            "claims": {"credential_used": False, "runtime_activation_claimed": False, "production_interlock_runtime_activated": False},
             "authority_effect": "NONE",
         },
         "assertions": {
@@ -59,15 +43,9 @@ def hf_evidence():
             "global_runtime_activation_claimed": False,
         },
         "journal_replay": {"state": "PASS"},
-        "reconstruction_entry": {
-            "receipt": {
-                "state": "PASS",
-                "same_execution": True,
-            }
-        },
+        "reconstruction_entry": {"receipt": {"state": "PASS", "same_execution": True}},
         "authority_effect": "NONE",
     }
-
 
 
 def hf_canonical_evidence():
@@ -121,22 +99,46 @@ def hf_canonical_evidence():
         },
     }
 
+
 def hil_evidence():
+    digest = "sha256:" + "a" * 64
     return {
         "schema": module.HIL_SCHEMA,
         "state": "OBSERVED",
         "observation_class": "AUTHENTIC_ESTABLISHED_STEGVERSE_WEB_NODE",
+        "node_id": "stegnode-test",
+        "device_continuity_id": "stegdevice-test",
         "existing_node_reused": True,
         "new_node_identity_minted": False,
         "credential_used": False,
         "github_token_used": False,
+        "participant_research_submission": False,
+        "runtime_activation_claimed": False,
         "exact_byte_reconstruction": "PASS",
         "custody_state": "EXACT_BYTES_PERSISTED",
         "registry_state": "RECORDED",
         "journal_replay_state": "PASS",
         "next_required_transition": "HIL_CUSTODY_TVC_INTERLOCK_ADMISSION",
+        "tvc_lifecycle_intent_observed": True,
         "tvc_receiving_receipt_observed": False,
         "receiver_restart_reconstruction_observed": False,
+        "controlled_pdf_sha256": digest,
+        "retrieved_pdf_sha256": digest,
+        "receiver_receipt_id": "HIL-RECEIPT-test",
+        "submission_id": "HIL-SUBMISSION-test",
+        "intr_chain_hash": "sha256:" + "b" * 64,
+        "device_stegos_ingress_receipt_hash": "sha256:" + "c" * 64,
+        "hil_custody_receipt_hash": "sha256:" + "d" * 64,
+        "journal_tail_sha256": "e" * 64,
+        "validation": {
+            "journal_receipt_hashes": "PASS",
+            "journal_entry_hashes": "PASS",
+            "journal_previous_hash_chain": "PASS",
+            "claim_terminal_link": "PASS",
+            "terminal_reconstruction_link": "PASS",
+            "intr_receipt_chain": "PASS",
+            "exact_byte_retrieval": "PASS",
+        },
         "authority_effect": "NONE",
     }
 
@@ -144,9 +146,7 @@ def hil_evidence():
 def test_hf_admission_advances_only_adjacent_external_api_egress():
     updated, admission = module.admit(hf_evidence(), FACTS)
     assert admission["capability_type"] == "ADJACENT_EXTERNAL_API_EGRESS"
-    assert admission["facts_advanced"] == [
-        "transport_capabilities_observed.ADJACENT_EXTERNAL_API_EGRESS"
-    ]
+    assert admission["facts_advanced"] == ["transport_capabilities_observed.ADJACENT_EXTERNAL_API_EGRESS"]
     assert admission["unrelated_facts_advanced"] == []
     assert admission["activation_performed"] is False
     assert admission["authority_effect"] == "NONE"
@@ -165,12 +165,43 @@ def test_hil_admission_advances_only_public_https_ingress():
         assert after[key] is (True if key == "PUBLIC_HTTPS_INGRESS" else value)
 
 
-def test_hil_ingress_capability_does_not_require_downstream_tvc_receipt():
+def test_hil_ingress_capability_requires_downstream_tvc_receipt_to_remain_unobserved():
     evidence = hil_evidence()
     assert evidence["tvc_receiving_receipt_observed"] is False
     updated, admission = module.admit(evidence, FACTS)
     assert updated["transport_capabilities_observed"]["PUBLIC_HTTPS_INGRESS"] is True
     assert admission["activation_performed"] is False
+    evidence["tvc_receiving_receipt_observed"] = True
+    with pytest.raises(ValueError, match="must remain unobserved"):
+        module.admit(evidence, FACTS)
+
+
+def test_hil_fails_closed_on_runtime_activation_claim():
+    evidence = hil_evidence()
+    evidence["runtime_activation_claimed"] = True
+    with pytest.raises(ValueError, match="runtime activation"):
+        module.admit(evidence, FACTS)
+
+
+def test_hil_fails_closed_on_participant_research_submission():
+    evidence = hil_evidence()
+    evidence["participant_research_submission"] = True
+    with pytest.raises(ValueError, match="participant research submission"):
+        module.admit(evidence, FACTS)
+
+
+def test_hil_fails_closed_on_digest_identity_drift():
+    evidence = hil_evidence()
+    evidence["retrieved_pdf_sha256"] = "sha256:" + "f" * 64
+    with pytest.raises(ValueError, match="digest identity mismatch"):
+        module.admit(evidence, FACTS)
+
+
+def test_hil_fails_closed_on_validation_drift():
+    evidence = hil_evidence()
+    evidence["validation"]["intr_receipt_chain"] = "FAIL"
+    with pytest.raises(ValueError, match="intr_receipt_chain must PASS"):
+        module.admit(evidence, FACTS)
 
 
 def test_hf_fails_closed_if_observation_is_not_observed():


### PR DESCRIPTION
Closes #138.

Tightens canonical HIL evidence admission so `PUBLIC_HTTPS_INGRESS` can advance only when the HIL observation preserves the deployed observer's explicit non-claims, exact submitted/retrieved digest identity, required receiver/InTr hash identities, and all journal/InTr/exact-byte validation PASS markers. This remains non-authorizing and does not require or infer the downstream TVC receiving receipt.