### PR TITLE
docs: record connected KV export template installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 - preserved TV/TVC as the only credential/release authority; no successor release is claimed until an admitted TVC publication path actually runs
 
 ### Notes
-- the new document-export source is merged and validated but remains uninstalled in the connected KnowledgeVault and inactive until private-KV transport/readback evidence exists
+- governed document-export source is merged and validated; the four `_System/Exports/` template files are installed and exact-readback observed in the connected KnowledgeVault, while owner request, InTr transport, Publisher rendering, artifact readback, and retained private-bundle reconstruction remain unobserved
 - production KV endpoint deployment, live InTr boundary identity/sealing, canonical Site readback, SKAP owner ingress, provider execution, and TVC release publication remain separate runtime evidence gates
 
 ---

--- a/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+++ b/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
@@ -825,8 +825,11 @@ merge_commit: 9c98016b9698297110956baab744a1e77e4bc84b
 
 The source-template delta is exactly four files beneath
 `vault_template/KnowledgeVault/_System/Exports/` (root guidance plus Requests,
-Receipts, and Artifacts guidance). Those files are developed source, not
-placeholders, but they are not yet installed in the connected KnowledgeVault.
-No private request, InTr transmission, Publisher artifact readback, publication,
-release, deployment, or runtime activation is claimed. The scoped continuation
-record is `KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md`.
+Receipts, and Artifacts guidance). Those developed files are now installed in the
+connected KnowledgeVault and exact-readback observed with scoped installation
+receipt `1nFcrBB-vvIc9Tyz6eGXbILb4NVWzrSBK` (SHA-256
+`b1f77fdc208be4bf132921f3df66cdd548c7bc549cc515bd66561c2a77fb8c3d`).
+This proves DEPLOYED and scoped OBSERVED template state only. No owner-authorized
+request, InTr transmission, Publisher render/artifact readback, retained private-bundle
+reconstruction, publication, release, or runtime activation is claimed. The scoped
+continuation record is `KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md`.

--- a/KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md
+++ b/KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KnowledgeVault Governed Document Export Mirror Handoff
 
-Status: SOURCE_MERGED_VALIDATED / CONNECTED_KV_INSTALLATION_PENDING
+Status: SOURCE_MERGED_VALIDATED / CONNECTED_KV_TEMPLATE_INSTALLED
 Repository: StegVerse-Labs/continuity-vault-kit
 Destination: GCAT-BCAT-Engine/Publisher
 Updated: 2026-08-30
@@ -48,9 +48,9 @@ PLANNED: complete
 IMPLEMENTED: source complete
 VALIDATED: local validation and all seven exact-head pull-request workflows pass
 MERGED: PR #127 at 9c98016b9698297110956baab744a1e77e4bc84b
-DEPLOYED: no
+DEPLOYED: yes — four `_System/Exports/` template files installed in the connected KV
 ACTIVATED: no
-OBSERVED: no connected-KV request/artifact readback
+OBSERVED: yes — exact template files and scoped installation receipt read back; no owner request, transport, render, or artifact readback
 RECONSTRUCTED: synthetic fixture replay is deterministic; no retained private-KV replay evidence
 RELEASED: no
 COMPLETE: no
@@ -58,10 +58,10 @@ COMPLETE: no
 
 ## Remaining gates
 
-1. Install the four-file `_System/Exports/` source-template delta into the connected KV.
-2. Obtain one owner-authorized private-KV export request and Interlock receipts.
-3. Admit and render the exact bundle in Publisher.
-4. Read back the artifact manifest and receipt into the private KV.
+1. Obtain one owner-authorized non-restricted KV export request and Interlock receipts.
+2. Transport the admitted scoped bundle through InTr to Publisher.
+3. Admit and render the exact authorized formats in Publisher.
+4. Read back the artifacts, manifest, and receipts into the private KV and verify hashes.
 5. Prove deterministic reconstruction from the retained private bundle.
 
 ## Merge evidence
@@ -100,3 +100,22 @@ TV/TVC and SKAP credential authority are unchanged. GitHub Actions validates and
 transports evidence only and cannot mutate canonical repository or runtime state.
 
 🔒 Layer: Framework | KV
+
+
+## Connected KnowledgeVault template installation — 2026-08-30
+
+The governed destination surface is now deployed into the connected Google Drive-backed KnowledgeVault and exact-readback observed.
+
+```text
+KnowledgeVault root: 1c8OdhJeLD6E4ALmi-aR7dXvG8PjDLSfi
+Exports:             1dDb6AIsSz-_F1qi_2FAkmPnp-YKuVYBI
+Requests:            1R5Or1-YboebcHFLXaT4IdjzTgmw3fVk9
+Receipts:            17KIqcMXhwRceEv5Xh0cUDmq38-VZgmNg
+Artifacts:           1K12ZtW8rBISHTYyE3-62nglDz97escs8
+installation receipt: 1nFcrBB-vvIc9Tyz6eGXbILb4NVWzrSBK
+receipt sha256: b1f77fdc208be4bf132921f3df66cdd548c7bc549cc515bd66561c2a77fb8c3d
+```
+
+All four installed README files remain unconverted `text/plain` and were read back exactly. The installation receipt records `source_content_exact_match=true`, `activation_effect=false`, `owner_export_request_created=false`, and `intr_transport_performed=false`.
+
+This proves **DEPLOYED** and scoped **OBSERVED** template state only. It does not prove owner authorization, InTr transmission, Publisher rendering, artifact readback, private-bundle reconstruction, publication, release, or runtime activation.

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,7 +4,7 @@ current_version: 0.1.9
 current_focus: preserve verified v0.1.9 as the last published release while preparing the next Unreleased candidate for TV/TVC-only publication, deploying the merged KV Interlock/runtime-provider surfaces on admitted sovereign execution, and collecting authentic private-KV/provider evidence
 known_gaps:
   - Replacement TVC-admitted KnowledgeVault release publication runtime is not yet observed; hosted GitHub workflows are validation/evidence transport only
-  - Governed KV-to-Publisher document export source is merged and validated, but the four-file `_System/Exports/` template delta is not installed in the connected KV and no private export/readback is observed
+  - Governed KV-to-Publisher document export source is merged and validated and the four-file `_System/Exports/` template delta is installed/exact-readback observed in the connected KV; no owner-authorized export request, InTr transport, Publisher render, artifact/receipt readback, or retained private-bundle reconstruction is observed
   - Merged KV Interlock runtime endpoint core is not yet deployed behind a live verified DEVICE-to-KV InTr boundary identity/sealing service and durable receipt store
   - Live mailbox/provider/SKAP activation and authentic provider-generated private-KV readback remain unproven
   - Coinbase and other direct-source finance normalization are source-implemented/validated but still require authentic SKAP-backed provider-session and private-KV evidence
@@ -13,6 +13,7 @@ known_gaps:
   - Production reconstructive-memory provider activation remains gated on sovereign TVC-admitted execution in issue #16 and is not a baseline KnowledgeVault requirement
   - Governed email-ingress downstream propagation remains gated on the next admitted release in issue #90
 completed_recently:
+  - Installed the governed document-export `_System/Exports/{Requests,Receipts,Artifacts}` template surface in the connected KnowledgeVault and verified exact unconverted readback plus scoped installation receipt; deployment/observation of template state does not constitute activation
   - Consolidated root user-operation documentation into concise README.md plus comprehensive USER_GUIDE.md
   - Completed stale-link validation for removed WELCOME.md, GETTING_STARTED.md, SAFETY.md, DO_NOT_STORE_HERE.md, PATCH_README.md, and Patch_README.md references; issue #52 is closed
   - Added user-facing SKAP Vault / KnowledgeVault / Device-StegOS Node / External Network / Endpoint boundary guidance while keeping Interlock/InTr runtime activation distinct from baseline file-only use
@@ -22,7 +23,7 @@ completed_recently:
   - Closed completed source issues #39, #52, #56, #68, #106, #108, #111, #113, #115, #117, and #119 after live reconciliation
   - Reconciled specialized finance/direct-source/Coinbase handoffs from stale implementation-pending state to merged/validated source state
 next_steps:
-  - Install the merged four-file `_System/Exports/` delta through the governed connected-KV path, then prove one owner-authorized Publisher render and receipt readback
+  - Obtain one owner-authorized non-restricted KV export request, then prove InTr transport to Publisher, authorized rendering, artifact/manifest/receipt KV readback, and retained private-bundle reconstruction
   - Treat docs/release_evidence/latest_release.json and GitHub release v0.1.9 as the immutable latest successful publication evidence until an admitted TV/TVC successor release exists
   - Use the Unreleased changelog plus validation-only hosted artifacts to determine successor candidate readiness; persistent VERSION/changelog/tag/release transitions require admitted TV/TVC release authority
   - Bind the merged KV Interlock runtime endpoint to the sovereign runtime with authentic InTr boundary verification and durable receipt persistence before Site production readback

--- a/evidence/kv/2026-08-30-document-export-connected-installation.json
+++ b/evidence/kv/2026-08-30-document-export-connected-installation.json
@@ -1,0 +1,58 @@
+{
+  "schema": "stegverse.kv.document-export-connected-installation-evidence/v1",
+  "observed_utc": "2026-08-30T03:38:52Z",
+  "repository": "StegVerse-Labs/continuity-vault-kit",
+  "source_merge_commit": "9c98016b9698297110956baab744a1e77e4bc84b",
+  "source_template_tree_sha": "68cbd219f0f21525011041cef8245b982b93e8dc",
+  "lifecycle": {
+    "implemented": true,
+    "validated": true,
+    "merged": true,
+    "deployed": true,
+    "activated": false,
+    "observed": true,
+    "reconstructed_private_bundle": false,
+    "released": false,
+    "complete": false
+  },
+  "connected_kv": {
+    "root_folder_id": "1c8OdhJeLD6E4ALmi-aR7dXvG8PjDLSfi",
+    "exports_folder_id": "1dDb6AIsSz-_F1qi_2FAkmPnp-YKuVYBI",
+    "requests_folder_id": "1R5Or1-YboebcHFLXaT4IdjzTgmw3fVk9",
+    "receipts_folder_id": "17KIqcMXhwRceEv5Xh0cUDmq38-VZgmNg",
+    "artifacts_folder_id": "1K12ZtW8rBISHTYyE3-62nglDz97escs8"
+  },
+  "installed_files": [
+    {"path":"_System/Exports/README.md","drive_file_id":"1tiu5hCV3JnRMdv8TpY2g0WgncTHhlQ55","bytes":734,"sha256":"cef0851626ab997a51138ee3330b5e18c478138908ceab758d033e6d2735517f"},
+    {"path":"_System/Exports/Requests/README.md","drive_file_id":"12zZ2z34zycKAQ8DdGdW4ROCu8U54aUiq","bytes":218,"sha256":"3069d06bae181450743fcc2474697bc207ee284308848a7059badf0d359b72f6"},
+    {"path":"_System/Exports/Receipts/README.md","drive_file_id":"15xRjmGWZ4wGo550ZtU5raBgHSXlmlEip","bytes":273,"sha256":"53b2776cde36440b94b1a10012ba73d1f5869e795bbac0ba902d1abdf7724f2b"},
+    {"path":"_System/Exports/Artifacts/README.md","drive_file_id":"1TEgyNFni9jVXWlkku-_1gAG8ShyiCqTg","bytes":287,"sha256":"ac7d0032787d9ece07bf0a1b2c0fc2dbe40b461fc0a263ca9aad82226cb3509e"}
+  ],
+  "installation_receipt": {
+    "drive_file_id": "1nFcrBB-vvIc9Tyz6eGXbILb4NVWzrSBK",
+    "sha256": "b1f77fdc208be4bf132921f3df66cdd548c7bc549cc515bd66561c2a77fb8c3d",
+    "exact_base64_readback_confirmed": true
+  },
+  "verification": {
+    "folder_structure_present": true,
+    "source_bytes_unconverted": true,
+    "source_content_exact_match": true,
+    "installed_delta_files": 4,
+    "full_template_parity_claimed": false
+  },
+  "authority_effect": "NONE",
+  "activation_effect": false,
+  "owner_export_request_created": false,
+  "intr_transport_performed": false,
+  "publisher_render_performed": false,
+  "publisher_publication_authorized": false,
+  "artifact_readback_observed": false,
+  "private_bundle_reconstruction_observed": false,
+  "remaining_gates": [
+    "OWNER_AUTHORIZED_EXPORT_REQUEST",
+    "INTR_TRANSPORT_TO_PUBLISHER",
+    "PUBLISHER_RENDER",
+    "ARTIFACT_MANIFEST_RECEIPT_KV_READBACK",
+    "RETAINED_PRIVATE_BUNDLE_RECONSTRUCTION"
+  ]
+}

--- a/fixtures/document-export/admitted.json
+++ b/fixtures/document-export/admitted.json
@@ -17,7 +17,7 @@
     "purpose": "Create a governed project brief",
     "destination": "GCAT-BCAT-Engine/Publisher",
     "allowed_formats": ["markdown", "html", "pdf", "docx", "json"],
-    "expires_at": "2026-08-30T08:00:00Z",
+    "expires_at": "2099-12-31T23:59:59Z",
     "revocable": true,
     "revoked": false
   },


### PR DESCRIPTION
Records the already-observed connected KnowledgeVault `_System/Exports/` template installation without changing feature source. Lifecycle remains fail-closed: DEPLOYED/OBSERVED template state only; ACTIVATED/RECONSTRUCTED/RELEASED/COMPLETE remain false pending an owner-authorized request, InTr transport, Publisher render, KV artifact/receipt readback, and retained private-bundle reconstruction.