### PR TITLE
docs: record owner-authorized KV document run

### DIFF
--- a/KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md
+++ b/KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KnowledgeVault Governed Document Export Mirror Handoff
 
-Status: SOURCE_MERGED_VALIDATED / CONNECTED_KV_TEMPLATE_INSTALLED
+Status: SOURCE_MERGED_VALIDATED / CONNECTED_KV_OWNER_RUN_PARTIAL
 Repository: StegVerse-Labs/continuity-vault-kit
 Destination: GCAT-BCAT-Engine/Publisher
 Updated: 2026-08-30
@@ -49,20 +49,19 @@ IMPLEMENTED: source complete
 VALIDATED: local validation and all seven exact-head pull-request workflows pass
 MERGED: PR #127 at 9c98016b9698297110956baab744a1e77e4bc84b
 DEPLOYED: yes — four `_System/Exports/` template files installed in the connected KV
-ACTIVATED: no
-OBSERVED: yes — exact template files and scoped installation receipt read back; no owner request, transport, render, or artifact readback
-RECONSTRUCTED: synthetic fixture replay is deterministic; no retained private-KV replay evidence
+ACTIVATED: no — verified DEVICE→KV InTr transport envelope/receipt remains unobserved
+OBSERVED: yes — owner request, retained bundle, preparation/admission/render receipts, manifest, and Markdown/PDF/JSON artifacts were read back exactly from the connected KV
+RECONSTRUCTED: yes for the retained owner-authorized bundle and selected Markdown/PDF/JSON renderers; byte-identical replay PASS
 RELEASED: no
 COMPLETE: no
 ```
 
 ## Remaining gates
 
-1. Obtain one owner-authorized non-restricted KV export request and Interlock receipts.
-2. Transport the admitted scoped bundle through InTr to Publisher.
-3. Admit and render the exact authorized formats in Publisher.
-4. Read back the artifacts, manifest, and receipts into the private KV and verify hashes.
-5. Prove deterministic reconstruction from the retained private bundle.
+1. Establish and observe the authentic verified DEVICE→KV InTr transport envelope and receipt required by `KV-INTERLOCK-v1`.
+2. Repeat the already-proven retained-bundle Publisher admission/render path through that admitted InTr transport without changing the owner-authorized scope.
+3. Preserve the exact returned artifact/receipt hashes and reconstruction proof as the activation evidence.
+4. Keep publication/release as separate explicit transitions.
 
 ## Merge evidence
 
@@ -119,3 +118,50 @@ receipt sha256: b1f77fdc208be4bf132921f3df66cdd548c7bc549cc515bd66561c2a77fb8c3d
 All four installed README files remain unconverted `text/plain` and were read back exactly. The installation receipt records `source_content_exact_match=true`, `activation_effect=false`, `owner_export_request_created=false`, and `intr_transport_performed=false`.
 
 This proves **DEPLOYED** and scoped **OBSERVED** template state only. It does not prove owner authorization, InTr transmission, Publisher rendering, artifact readback, private-bundle reconstruction, publication, release, or runtime activation.
+
+## First owner-authorized connected-KV document run — 2026-08-30
+
+The owner authorized a non-restricted activation brief for the exact purpose
+`Prove the authentic governed KV → InTr → Publisher → KV document-creation and reconstruction path.`
+and limited formats to Markdown, PDF, and JSON.
+
+Observed connected-KV records:
+
+```text
+source note:                 1zGar20KrIe0fKNkPpX9Hr1I_2W7cSnKE
+request:                     1_DhXUcnnNsBblvmPT2fO-BWYwu5jLf9r
+retained Publisher bundle:   1nnB6hAtOVbWCRiyyNj-IgBx46O6X-CE1
+preparation receipt:         1XoLxpKUKoBFKvYQPm6M9vSpMaw5AA0zl
+Publisher admission receipt: 1AeJBXMy4MuGu31Qt2hAZL2kHhbnO38v-
+artifact manifest:           1c3HdjeTWjrPtxaitjQnJLzAqyld93nch
+rendering receipt:           10WMrPEPwu0wn80Tg-Qt4Iqmy5vLHh_Ba
+Markdown artifact:           1YxL-4kFGWyEb8r4SwdikRzsdhzmpAEDF
+PDF artifact:                1iNtfhUwT1buzZ6C-UsTKTyVFZQE8FrCG
+JSON artifact:               1A0VrzCyCtoHUzhQ7AF81V--2VUldLfuc
+```
+
+Semantic hashes:
+
+```text
+request_sha256:  sha256:55b3cbaa950f5440d0ae7c370220bc8f337aeac0ecab511ddd4c721adee8ed81
+export_sha256:   sha256:98622e0ba7b3335c7eea6e4ab5d7a819aa73bc74a7e5db55ced0266dba3a014d
+prepare receipt: sha256:2a6c12f0313544eedbb603872964a76322cc78c011022714de845eda3bb1e703
+manifest:        sha256:20e83ce0dedbb873284c4f2c5ebf7adb966c6151fea999c3dc92f1a0ededcb25
+render receipt:  sha256:2b0cf96e0356b3c714940e419c9755427016af1fa4ae2569aaf2f5b8e1aff78e
+```
+
+Artifact byte hashes after Drive readback:
+
+```text
+Markdown: sha256:8d44eaebe69796bca29db2762bad18de9b67e639ee72183d17c71b39c5511e0a
+PDF:      sha256:1fc18e95da0f79c2fc680457d7598b7c094c9e6b31005d6afa95b9f611449ed2
+JSON:     sha256:79998e80c83ae57ac81cdab52ea8e4db562f420d67f7b01380a60fc94d19e5ca
+```
+
+All selected renderers reproduced byte-identically from the retained private bundle.
+This advances authentic owner request, preparation, Publisher admission/render,
+artifact/receipt readback, and reconstruction evidence. It does **not** advance
+`ACTIVATED`, because `runtime/kv_interlock_endpoint.py` requires a previously
+verified DEVICE→KV InTr envelope and receipt and none was observed in this run.
+No transport receipt was fabricated or inferred. Publication, release, deployment,
+and execution authority remain false.

--- a/evidence/kv/2026-08-30-document-export-owner-run.json
+++ b/evidence/kv/2026-08-30-document-export-owner-run.json
@@ -1,0 +1,62 @@
+{
+  "schema": "stegverse.kv.document-export-owner-run-evidence/v1",
+  "observed_utc": "2026-08-30T17:56:00Z",
+  "export_id": "kv-publisher-activation-20260830-001",
+  "authority_source": "direct_instruction",
+  "purpose": "Prove the authentic governed KV → InTr → Publisher → KV document-creation and reconstruction path.",
+  "authorized_formats": ["markdown", "pdf", "json"],
+  "source_note": {
+    "drive_id": "1zGar20KrIe0fKNkPpX9Hr1I_2W7cSnKE",
+    "sha256": "de3524a3e21ab24508a56b96a4b697743a9d1fce99cc250ed9e1a04fa1be008f",
+    "restricted": false,
+    "contains_credentials": false
+  },
+  "request": {
+    "drive_id": "1_DhXUcnnNsBblvmPT2fO-BWYwu5jLf9r",
+    "semantic_sha256": "sha256:55b3cbaa950f5440d0ae7c370220bc8f337aeac0ecab511ddd4c721adee8ed81"
+  },
+  "retained_bundle": {
+    "drive_id": "1nnB6hAtOVbWCRiyyNj-IgBx46O6X-CE1",
+    "export_sha256": "sha256:98622e0ba7b3335c7eea6e4ab5d7a819aa73bc74a7e5db55ced0266dba3a014d"
+  },
+  "preparation_receipt": {
+    "drive_id": "1XoLxpKUKoBFKvYQPm6M9vSpMaw5AA0zl",
+    "receipt_sha256": "sha256:2a6c12f0313544eedbb603872964a76322cc78c011022714de845eda3bb1e703",
+    "result": "PREPARED_NOT_TRANSMITTED"
+  },
+  "publisher_admission_receipt": {
+    "drive_id": "1AeJBXMy4MuGu31Qt2hAZL2kHhbnO38v-",
+    "receipt_sha256": "8c66704a5da75df7c954d3ac3efd6d1646a10a9abd65eba865361242d4293746",
+    "result": "ADMITTED"
+  },
+  "publisher_render": {
+    "generation_id": "58f6de9dc6b28c32e0adee12",
+    "manifest_drive_id": "1c3HdjeTWjrPtxaitjQnJLzAqyld93nch",
+    "manifest_sha256": "sha256:20e83ce0dedbb873284c4f2c5ebf7adb966c6151fea999c3dc92f1a0ededcb25",
+    "rendering_receipt_drive_id": "10WMrPEPwu0wn80Tg-Qt4Iqmy5vLHh_Ba",
+    "rendering_receipt_sha256": "sha256:2b0cf96e0356b3c714940e419c9755427016af1fa4ae2569aaf2f5b8e1aff78e",
+    "result": "GENERATED_VALIDATED_NOT_PUBLISHED"
+  },
+  "artifacts": [
+    {"format": "markdown", "drive_id": "1YxL-4kFGWyEb8r4SwdikRzsdhzmpAEDF", "sha256": "sha256:8d44eaebe69796bca29db2762bad18de9b67e639ee72183d17c71b39c5511e0a", "bytes": 1098, "readback_exact": true, "reconstruction_exact": true},
+    {"format": "pdf", "drive_id": "1iNtfhUwT1buzZ6C-UsTKTyVFZQE8FrCG", "sha256": "sha256:1fc18e95da0f79c2fc680457d7598b7c094c9e6b31005d6afa95b9f611449ed2", "bytes": 1787, "readback_exact": true, "reconstruction_exact": true},
+    {"format": "json", "drive_id": "1A0VrzCyCtoHUzhQ7AF81V--2VUldLfuc", "sha256": "sha256:79998e80c83ae57ac81cdab52ea8e4db562f420d67f7b01380a60fc94d19e5ca", "bytes": 2869, "readback_exact": true, "reconstruction_exact": true}
+  ],
+  "lifecycle": {
+    "owner_request_observed": true,
+    "prepared": true,
+    "intr_transport_observed": false,
+    "publisher_admission_observed": true,
+    "publisher_render_observed": true,
+    "artifact_readback_observed": true,
+    "private_bundle_reconstruction_observed": true,
+    "activated": false,
+    "released": false,
+    "complete": false
+  },
+  "blocker": "VERIFIED_DEVICE_KV_INTR_ENVELOPE_AND_RECEIPT_NOT_OBSERVED",
+  "authority_effect": "NONE",
+  "publication_authorized": false,
+  "release_authorized": false,
+  "execution_authorized": false
+}


### PR DESCRIPTION
Records the first owner-authorized non-restricted connected-KV document run: request, retained bundle, Publisher admission/render behavior, Markdown/PDF/JSON exact KV readback, and byte-identical reconstruction. Keeps ACTIVATED=false because the required verified DEVICE→KV InTr envelope/receipt was not observed.