### PR TITLE
Integrate persistent session reconstruction with KV-INTERLOCK-v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 
 ### Added
 - persistent-session reconstruction checkpoints bound to the existing append-only conversation-recall chain, with monotonic predecessor hashing, live-verification requirements, authority non-transfer, secret/transcript rejection, and private-KV Sessions guidance
+- KV-INTERLOCK-v1 persistent-session read/candidate adapters that return bounded reconstruction context, stage only validated monotonic successors, bind current/successor/recall hashes, and fail closed on stale or ambiguous state
 - governed KV-to-Publisher document export preparation with owner-scoped formats, provenance/fidelity classes, owner-approved redaction, deterministic receipts, revocation evidence, and fail-closed tests
 - governed KnowledgeVault email-continuity ingress contract with pre-admission staging, fail-closed admission decisions, SKAP Vault credential-reference binding, deterministic mailbox mapping, and source-ready runtime validation
 - provider-neutral email account mapping runtime that prohibits raw mailbox secrets in KV state and requires `skap://` binding before provider-session verification

--- a/KV_PERSISTENT_SESSION_INTERLOCK_MIRROR_HANDOFF.md
+++ b/KV_PERSISTENT_SESSION_INTERLOCK_MIRROR_HANDOFF.md
@@ -1,0 +1,89 @@
+# KnowledgeVault Persistent Session Interlock Mirror Handoff
+
+Status: SOURCE_IMPLEMENTATION_IN_PROGRESS
+Repository: StegVerse-Labs/continuity-vault-kit
+Issue: #144
+Branch: feature/kv-session-interlock-144
+Updated: 2026-08-30
+Authority effect: NONE
+Runtime activation claimed: false
+
+## Goal
+
+Bind the merged persistent-session reconstruction model to the existing KV-INTERLOCK-v1 runtime without creating a second transport, direct canonical write authority, or transcript authority.
+
+## Upstream source of truth
+
+- `KV_PERSISTENT_SESSION_RECONSTRUCTION_MIRROR_HANDOFF.md`
+- `runtime/persistent_session_reconstruction.py`
+- `schemas/kv-persistent-session-head.schema.json`
+- `runtime/kv_interlock_endpoint.py`
+- `docs/KNOWLEDGEVAULT_INTERLOCK_PROTOCOL.md`
+- `continuity/recall.py`
+- `docs/AUTOMATED_CONVERSATION_RECALL.md`
+
+## Read path
+
+```text
+DEVICE
+  -> verified DEVICE->KV InTr envelope
+  -> KVInterlockRuntime
+  -> persistent-session policy adapter
+  -> current private-KV session head
+  -> validate head + conversation recall-chain binding
+  -> bounded reconstruction projection
+  -> receipt
+  -> KV->DEVICE response
+```
+
+Only `REQUEST` with record class `persistent-session-head:<session_id>`, scope `session_head`, and `BOUNDED_CONTEXT` may receive the reconstruction projection.
+
+## Candidate path
+
+```text
+COMMIT_CANDIDATE
+  -> existing KVInterlockRuntime candidate boundary
+  -> resolve opaque payload_ref
+  -> validate successor head
+  -> verify same session_id
+  -> verify generation +1
+  -> verify exact prior-head hash
+  -> verify no timestamp rollback
+  -> preserve conversation recall-chain binding
+  -> stage candidate only
+  -> no canonical KV mutation
+```
+
+The adapter must bind the staged candidate to current-head SHA-256, successor SHA-256, conversation-event verification root, request id, and source InTr receipt reference.
+
+## Fail-closed invariants
+
+- malformed/missing session identifier: reject;
+- missing current head: reject;
+- secret/transcript-bearing head: reject;
+- stale/replayed/wrong-head successor: reject;
+- recall-root drift within one direct successor: reject unless a future explicitly admitted event-chain advance contract exists;
+- requested destination mismatch: reject;
+- candidate store ambiguity: reject;
+- canonical_state_changed must remain false;
+- execution_authority remains NONE;
+- credential_authority remains TV/TVC;
+- authority_effect remains NONE.
+
+## Non-claims
+
+Source implementation does not prove private-KV deployment, DEVICE_KV_INTR runtime observation, live owner/session authority, canonical writeback, cold-session reconstruction, activation, or release.
+
+## Current lifecycle
+
+```text
+IMPLEMENTED: IN_PROGRESS
+VALIDATED: false
+MERGED: false
+DEPLOYED: false
+ACTIVATED: false
+OBSERVED: false
+RECONSTRUCTED: false
+RELEASED: false
+COMPLETE: false
+```

--- a/KV_PERSISTENT_SESSION_RECONSTRUCTION_MIRROR_HANDOFF.md
+++ b/KV_PERSISTENT_SESSION_RECONSTRUCTION_MIRROR_HANDOFF.md
@@ -159,3 +159,16 @@ Release integrity: 33346462740 SUCCESS
 The source layer is now merged and validated. The next implementation boundary is the KV-INTERLOCK-v1 adapter that reads/writes bounded session-head candidates without bypassing governed canonical writeback, followed by a StegOS device consumer over the existing `device-kv` Universal InTr connector.
 
 No private-KV materialization, live DEVICE_KV_INTR delivery, cold-session reconstruction, activation, release, or completion is claimed.
+
+
+## KV-INTERLOCK-v1 integration lane — issue #144
+
+Issue #144 implements the next source seam:
+
+- `runtime/persistent_session_interlock.py`;
+- `tests/test_persistent_session_interlock.py`;
+- `KV_PERSISTENT_SESSION_INTERLOCK_MIRROR_HANDOFF.md`.
+
+The adapter is injected behind the existing `KVInterlockRuntime`; it does not create a second endpoint or transport. `REQUEST` may expose only the bounded reconstruction projection. `COMMIT_CANDIDATE` resolves an opaque payload reference, verifies exact successor continuity against the current head, and stages a candidate-only record with current/successor hashes and recall-root binding.
+
+Canonical KV mutation remains separately governed and unimplemented in this lane. Private-KV deployment and live DEVICE_KV_INTR remain runtime gates.

--- a/runtime/persistent_session_interlock.py
+++ b/runtime/persistent_session_interlock.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any, Callable
 
+from runtime.kv_interlock_endpoint import KVInterlockRuntimeError
 from runtime.persistent_session_reconstruction import (
     PersistentSessionError,
     build_reconstruction_projection,
@@ -17,7 +18,7 @@ READ_SCOPE = ["session_head"]
 COMMIT_SCOPE = ["session_head_candidate"]
 
 
-class PersistentSessionInterlockError(ValueError):
+class PersistentSessionInterlockError(KVInterlockRuntimeError):
     pass
 
 

--- a/runtime/persistent_session_interlock.py
+++ b/runtime/persistent_session_interlock.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+from runtime.persistent_session_reconstruction import (
+    PersistentSessionError,
+    build_reconstruction_projection,
+    session_head_sha256,
+    validate_session_head,
+    verify_successor,
+)
+
+RECORD_PREFIX = "persistent-session-head:"
+SESSION_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,200}$")
+READ_SCOPE = ["session_head"]
+COMMIT_SCOPE = ["session_head_candidate"]
+
+
+class PersistentSessionInterlockError(ValueError):
+    pass
+
+
+def parse_session_id(record_class: Any) -> str:
+    if not isinstance(record_class, str) or not record_class.startswith(RECORD_PREFIX):
+        raise PersistentSessionInterlockError("persistent session record_class required")
+    session_id = record_class[len(RECORD_PREFIX):]
+    if not SESSION_ID_RE.fullmatch(session_id):
+        raise PersistentSessionInterlockError("session_id invalid")
+    return session_id
+
+
+def session_head_destination(session_id: str) -> str:
+    if not SESSION_ID_RE.fullmatch(session_id):
+        raise PersistentSessionInterlockError("session_id invalid")
+    return f"kv://_System/Continuity/Sessions/{session_id}/head.json"
+
+
+class PersistentSessionPolicyAdapter:
+    """Policy adapter for bounded persistent-session reads and candidate staging.
+
+    This object is intended to be injected as KVInterlockRuntime.policy_evaluator.
+    Existing KVInterlockRuntime authority and verified InTr admission checks run
+    before this adapter is invoked.
+    """
+
+    def __init__(
+        self,
+        *,
+        head_reader: Callable[[str], dict[str, Any] | None],
+    ) -> None:
+        self.head_reader = head_reader
+
+    def __call__(self, request: dict[str, Any]) -> dict[str, Any]:
+        session_id = parse_session_id(request.get("record_class"))
+        operation = request.get("operation")
+
+        if operation == "REQUEST":
+            return self._read_policy(request, session_id)
+        if operation == "COMMIT_CANDIDATE":
+            return self._candidate_policy(request, session_id)
+        return {
+            "decision": "DENY",
+            "granted_scope": [],
+            "context": {},
+            "source_refs": [],
+            "policy_profile": "KV-PERSISTENT-SESSION-v1:OPERATION_NOT_ALLOWED",
+        }
+
+    def _read_policy(self, request: dict[str, Any], session_id: str) -> dict[str, Any]:
+        if request.get("requested_scope") != READ_SCOPE:
+            raise PersistentSessionInterlockError("session read scope invalid")
+        if request.get("disclosure_mode") != "BOUNDED_CONTEXT":
+            raise PersistentSessionInterlockError("session read requires bounded context")
+
+        head = self.head_reader(session_id)
+        if head is None:
+            return {
+                "decision": "DENY",
+                "granted_scope": [],
+                "context": {},
+                "source_refs": [session_head_destination(session_id)],
+                "policy_profile": "KV-PERSISTENT-SESSION-v1:HEAD_NOT_FOUND",
+            }
+        try:
+            validated = validate_session_head(head)
+            projection = build_reconstruction_projection(validated)
+        except PersistentSessionError as exc:
+            raise PersistentSessionInterlockError("stored session head invalid") from exc
+
+        source_refs = [
+            session_head_destination(session_id),
+            validated["provenance"]["conversation_event_chain_ref"],
+        ]
+        return {
+            "decision": "ALLOW_BOUNDED_CONTEXT",
+            "granted_scope": list(READ_SCOPE),
+            "context": {"session_head": projection},
+            "source_refs": source_refs,
+            "policy_profile": "KV-PERSISTENT-SESSION-v1:BOUNDED_RECONSTRUCTION",
+            "redaction_profile": "SEMANTIC_SESSION_HEAD_ONLY",
+        }
+
+    def _candidate_policy(self, request: dict[str, Any], session_id: str) -> dict[str, Any]:
+        if request.get("requested_scope") != COMMIT_SCOPE:
+            raise PersistentSessionInterlockError("session candidate scope invalid")
+        candidate = request.get("candidate_writeback")
+        if not isinstance(candidate, dict):
+            raise PersistentSessionInterlockError("candidate_writeback required")
+        expected_type = f"{RECORD_PREFIX}{session_id}"
+        if candidate.get("candidate_type") != expected_type:
+            raise PersistentSessionInterlockError("candidate_type session binding mismatch")
+        if candidate.get("requested_destination") != session_head_destination(session_id):
+            raise PersistentSessionInterlockError("candidate destination mismatch")
+        return {
+            "decision": "ALLOW_BOUNDED_CONTEXT",
+            "granted_scope": list(COMMIT_SCOPE),
+            "context": {},
+            "source_refs": [session_head_destination(session_id)],
+            "policy_profile": "KV-PERSISTENT-SESSION-v1:CANDIDATE_STAGING_ONLY",
+            "redaction_profile": "NO_CANONICAL_MUTATION",
+        }
+
+
+class PersistentSessionCandidateStore:
+    """Validate and stage successor heads without changing canonical KV state."""
+
+    def __init__(
+        self,
+        *,
+        head_reader: Callable[[str], dict[str, Any] | None],
+        payload_reader: Callable[[str], dict[str, Any]],
+        candidate_writer: Callable[[dict[str, Any]], str],
+        recall_root_validator: Callable[[str, str, str], bool] | None = None,
+    ) -> None:
+        self.head_reader = head_reader
+        self.payload_reader = payload_reader
+        self.candidate_writer = candidate_writer
+        self.recall_root_validator = recall_root_validator
+
+    def __call__(self, candidate_record: dict[str, Any]) -> str:
+        session_id = parse_session_id(candidate_record.get("candidate_type"))
+        expected_destination = session_head_destination(session_id)
+        if candidate_record.get("requested_destination") != expected_destination:
+            raise PersistentSessionInterlockError("candidate destination mismatch")
+        if candidate_record.get("canonical_state_changed") is not False:
+            raise PersistentSessionInterlockError("candidate cannot claim canonical mutation")
+        if candidate_record.get("candidate_only") is not True:
+            raise PersistentSessionInterlockError("candidate_only required")
+        if candidate_record.get("authority_effect") != "NONE":
+            raise PersistentSessionInterlockError("candidate authority_effect must be NONE")
+
+        current = self.head_reader(session_id)
+        if current is None:
+            raise PersistentSessionInterlockError("current session head required")
+
+        payload_ref = candidate_record.get("payload_ref")
+        if not isinstance(payload_ref, str) or not payload_ref:
+            raise PersistentSessionInterlockError("payload_ref required")
+        successor = self.payload_reader(payload_ref)
+
+        try:
+            current_valid = validate_session_head(current)
+            successor_valid = verify_successor(current_valid, successor)
+        except PersistentSessionError as exc:
+            raise PersistentSessionInterlockError("session successor rejected") from exc
+
+        current_chain = current_valid["provenance"]["conversation_event_chain_ref"]
+        successor_chain = successor_valid["provenance"]["conversation_event_chain_ref"]
+        if successor_chain != current_chain:
+            raise PersistentSessionInterlockError("conversation event chain ref drift")
+
+        current_root = current_valid["provenance"]["conversation_event_verification_root"]
+        successor_root = successor_valid["provenance"]["conversation_event_verification_root"]
+        if successor_root != current_root:
+            if self.recall_root_validator is None:
+                raise PersistentSessionInterlockError(
+                    "conversation event verification root advance not admitted"
+                )
+            try:
+                admitted = self.recall_root_validator(current_root, successor_root, current_chain)
+            except Exception as exc:
+                raise PersistentSessionInterlockError(
+                    "conversation event verification root validation failed"
+                ) from exc
+            if admitted is not True:
+                raise PersistentSessionInterlockError(
+                    "conversation event verification root advance rejected"
+                )
+
+        staged = {
+            "schema": "stegverse.kv.persistent-session-candidate/v1",
+            "session_id": session_id,
+            "request_id": candidate_record.get("request_id"),
+            "authority_ref": candidate_record.get("authority_ref"),
+            "intr_receipt_ref": candidate_record.get("intr_receipt_ref"),
+            "payload_ref": payload_ref,
+            "requested_destination": expected_destination,
+            "current_head_sha256": session_head_sha256(current_valid),
+            "successor_head_sha256": session_head_sha256(successor_valid),
+            "conversation_event_chain_ref": successor_chain,
+            "conversation_event_verification_root": successor_root,
+            "canonical_state_changed": False,
+            "candidate_only": True,
+            "execution_authority": "NONE",
+            "credential_authority": "TV/TVC",
+            "authority_effect": "NONE",
+        }
+        ref = self.candidate_writer(staged)
+        if not isinstance(ref, str) or not ref:
+            raise PersistentSessionInterlockError("candidate staging did not return reference")
+        return ref

--- a/tests/test_persistent_session_interlock.py
+++ b/tests/test_persistent_session_interlock.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from runtime.kv_interlock_endpoint import KVInterlockRuntime, sha256_uri
+from runtime.persistent_session_interlock import (
+    PersistentSessionCandidateStore,
+    PersistentSessionInterlockError,
+    PersistentSessionPolicyAdapter,
+    session_head_destination,
+)
+from runtime.persistent_session_reconstruction import session_head_sha256
+
+
+def make_head(generation=0, prior=None, recall_root=None):
+    return {
+        "schema": "stegverse.kv.persistent-session-head/v1",
+        "session_id": "sv-session-001",
+        "generation": generation,
+        "prior_head_sha256": prior,
+        "created_at": f"2026-08-30T20:0{generation}:00Z",
+        "semantic_state": {
+            "active_goals": ["KV persistent session reconstruction"],
+            "authoritative_repositories": ["StegVerse-Labs/continuity-vault-kit"],
+            "handoff_refs": ["KV_PERSISTENT_SESSION_RECONSTRUCTION_MIRROR_HANDOFF.md"],
+            "blockers": ["DEVICE_KV_INTR runtime observation pending"],
+            "machine_task_refs": ["SHWP-DEVICE-KV-INTR-OBSERVATION-001"],
+            "evidence_refs": ["github:StegVerse-Labs/continuity-vault-kit#144"],
+            "last_verified_observations": [
+                {
+                    "subject": "continuity-vault-kit",
+                    "state": "SOURCE",
+                    "observed_at": "2026-08-30T20:00:00Z",
+                    "source_ref": "github:StegVerse-Labs/continuity-vault-kit#144",
+                }
+            ],
+            "authorization_boundaries": ["live repo/runtime verification required"],
+            "next_executable_action": "Continue admitted source integration.",
+        },
+        "provenance": {
+            "client_class": "ECOSYSTEM_CHAT",
+            "source_session_ref": "chat-session:opaque",
+            "conversation_event_chain_ref": "_System/Continuity/Events/events.jsonl",
+            "conversation_event_verification_root": recall_root or ("a" * 64),
+            "requires_live_verification": True,
+        },
+        "authority": {
+            "authority_transfer": False,
+            "execution_authority": "NONE",
+            "credential_authority": "TV/TVC",
+            "canonical_completion_claimed": False,
+        },
+    }
+
+
+def make_request(operation="REQUEST"):
+    request = {
+        "schema_version": "kv.interlock.request.v1",
+        "operation": operation,
+        "request_id": "req-session-001",
+        "requester": {"module": "StegOS", "component": "PersistentSessionClient"},
+        "purpose": "cold session reconstruction",
+        "record_class": "persistent-session-head:sv-session-001",
+        "requested_scope": ["session_head"] if operation == "REQUEST" else ["session_head_candidate"],
+        "minimum_necessary_justification": "resume bounded work without transcript",
+        "authority_ref": "owner-session:opaque",
+        "disclosure_mode": "BOUNDED_CONTEXT",
+    }
+    if operation == "COMMIT_CANDIDATE":
+        request["candidate_writeback"] = {
+            "candidate_type": "persistent-session-head:sv-session-001",
+            "payload_ref": "kv-candidate://session-successor",
+            "requested_destination": session_head_destination("sv-session-001"),
+        }
+    return request
+
+
+def make_envelope(request):
+    return {
+        "schema": "stegverse.kv-interlock.intr-envelope/v1",
+        "protocol": "InTr",
+        "packet_id": "packet-session-001",
+        "direction": "REQUEST",
+        "source_role": "DEVICE",
+        "next_role": "KV",
+        "request_id": request["request_id"],
+        "operation": request["operation"],
+        "payload_schema_version": "kv.interlock.request.v1",
+        "payload_hash": sha256_uri(request),
+        "sealed_material_ref": "sealed://opaque",
+        "authority": {
+            "authority_transfer": False,
+            "transport_grants_execution_authority": False,
+            "model_output_grants_execution_authority": False,
+            "credential_authority_effect": "NONE",
+        },
+        "boundary_proof": {
+            "required": True,
+            "source_identity_ref": "node://device",
+            "next_boundary_identity_ref": "kv://owner",
+            "verification_state": "VERIFIED",
+        },
+        "receipt_policy": {
+            "receipt_required": True,
+            "receipt_contains_payload_plaintext": False,
+            "receipt_chain_required": True,
+            "ambiguous_disposition": "FAIL_CLOSED",
+        },
+    }
+
+
+def test_request_returns_bounded_reconstruction_projection_through_existing_runtime():
+    current = make_head()
+    receipts = []
+    runtime = KVInterlockRuntime(
+        authority_validator=lambda *_: True,
+        policy_evaluator=PersistentSessionPolicyAdapter(
+            head_reader=lambda session_id: current if session_id == "sv-session-001" else None
+        ),
+        receipt_store=lambda receipt: receipts.append(receipt) or "receipt://session-read",
+    )
+    request = make_request()
+    response = runtime.handle(
+        request,
+        intr_envelope=make_envelope(request),
+        intr_receipt_ref="sha256:" + ("1" * 64),
+    )
+    assert response["decision"] == "ALLOW_BOUNDED_CONTEXT"
+    projection = response["context"]["session_head"]
+    assert projection["head_sha256"] == session_head_sha256(current)
+    assert projection["requires_live_verification"] is True
+    assert projection["stored_state_is_authority"] is False
+    assert projection["transcript_required"] is False
+    assert projection["execution_authority"] == "NONE"
+    assert receipts[-1]["writeback_candidate_ref"] is None
+
+
+def test_read_missing_head_denies_without_fabricating_state():
+    policy = PersistentSessionPolicyAdapter(head_reader=lambda _: None)
+    decision = policy(make_request())
+    assert decision["decision"] == "DENY"
+    assert decision["granted_scope"] == []
+    assert decision["context"] == {}
+
+
+def test_commit_candidate_stages_exact_successor_without_canonical_mutation():
+    current = make_head()
+    successor = make_head(1, session_head_sha256(current))
+    staged = []
+    store = PersistentSessionCandidateStore(
+        head_reader=lambda _: current,
+        payload_reader=lambda ref: successor,
+        candidate_writer=lambda value: staged.append(value) or "candidate://staged/001",
+    )
+    receipts = []
+    runtime = KVInterlockRuntime(
+        authority_validator=lambda *_: True,
+        policy_evaluator=PersistentSessionPolicyAdapter(head_reader=lambda _: current),
+        candidate_store=store,
+        receipt_store=lambda receipt: receipts.append(receipt) or "receipt://candidate",
+    )
+    request = make_request("COMMIT_CANDIDATE")
+    response = runtime.handle(
+        request,
+        intr_envelope=make_envelope(request),
+        intr_receipt_ref="sha256:" + ("2" * 64),
+    )
+    assert response["decision"] == "ALLOW_BOUNDED_CONTEXT"
+    assert response["context"] == {}
+    assert response["receipt"]["writeback_candidate_ref"] == "candidate://staged/001"
+    assert staged[-1]["current_head_sha256"] == session_head_sha256(current)
+    assert staged[-1]["successor_head_sha256"] == session_head_sha256(successor)
+    assert staged[-1]["canonical_state_changed"] is False
+    assert staged[-1]["execution_authority"] == "NONE"
+    assert staged[-1]["credential_authority"] == "TV/TVC"
+
+
+def test_stale_or_wrong_successor_fails_closed():
+    current = make_head()
+    bad = make_head(2, session_head_sha256(current))
+    store = PersistentSessionCandidateStore(
+        head_reader=lambda _: current,
+        payload_reader=lambda _: bad,
+        candidate_writer=lambda _: "candidate://must-not-write",
+    )
+    with pytest.raises(PersistentSessionInterlockError, match="successor rejected"):
+        store(
+            {
+                "schema": "kv.interlock.candidate.v1",
+                "request_id": "req",
+                "authority_ref": "owner",
+                "candidate_type": "persistent-session-head:sv-session-001",
+                "payload_ref": "candidate://bad",
+                "requested_destination": session_head_destination("sv-session-001"),
+                "intr_receipt_ref": "sha256:" + ("3" * 64),
+                "canonical_state_changed": False,
+                "candidate_only": True,
+                "authority_effect": "NONE",
+            }
+        )
+
+
+def test_recall_root_advance_requires_explicit_validator():
+    current = make_head()
+    successor = make_head(1, session_head_sha256(current), recall_root="b" * 64)
+    base_record = {
+        "schema": "kv.interlock.candidate.v1",
+        "request_id": "req",
+        "authority_ref": "owner",
+        "candidate_type": "persistent-session-head:sv-session-001",
+        "payload_ref": "candidate://next",
+        "requested_destination": session_head_destination("sv-session-001"),
+        "intr_receipt_ref": "sha256:" + ("4" * 64),
+        "canonical_state_changed": False,
+        "candidate_only": True,
+        "authority_effect": "NONE",
+    }
+    store = PersistentSessionCandidateStore(
+        head_reader=lambda _: current,
+        payload_reader=lambda _: successor,
+        candidate_writer=lambda _: "candidate://staged",
+    )
+    with pytest.raises(PersistentSessionInterlockError, match="root advance not admitted"):
+        store(copy.deepcopy(base_record))
+
+    staged = []
+    admitted = PersistentSessionCandidateStore(
+        head_reader=lambda _: current,
+        payload_reader=lambda _: successor,
+        candidate_writer=lambda value: staged.append(value) or "candidate://staged",
+        recall_root_validator=lambda prior, next_, chain: (
+            prior == "a" * 64
+            and next_ == "b" * 64
+            and chain == "_System/Continuity/Events/events.jsonl"
+        ),
+    )
+    assert admitted(copy.deepcopy(base_record)) == "candidate://staged"
+    assert staged[-1]["conversation_event_verification_root"] == "b" * 64
+
+
+def test_policy_rejects_destination_or_scope_drift():
+    policy = PersistentSessionPolicyAdapter(head_reader=lambda _: make_head())
+    request = make_request("COMMIT_CANDIDATE")
+    request["candidate_writeback"]["requested_destination"] = "kv://wrong"
+    with pytest.raises(PersistentSessionInterlockError, match="destination mismatch"):
+        policy(request)
+
+    request = make_request()
+    request["requested_scope"] = ["session_head", "raw_messages"]
+    with pytest.raises(PersistentSessionInterlockError, match="scope invalid"):
+        policy(request)


### PR DESCRIPTION
Closes #144.

Adds the bounded KV-INTERLOCK-v1 integration for persistent session reconstruction.

- REQUEST on persistent-session-head:<session_id> returns only the validated bounded reconstruction projection.
- COMMIT_CANDIDATE validates exact same-session monotonic successor continuity, prior-head hash, timestamp ordering, destination binding, and recall-chain continuity before staging.
- Recall-root advances require an explicit validator.
- Candidate staging records bind current/successor head hashes and recall root while preserving canonical_state_changed=false.
- Adapter errors subclass KVInterlockRuntimeError so the existing endpoint fails closed rather than leaking implementation exceptions.
- No direct canonical KV mutation, no new transport, no provider/credential/execution authority.

Private-KV deployment, live DEVICE_KV_INTR, canonical writeback, and cold-session reconstruction remain separate runtime gates.