### PR TITLE
Add canonical private-KV conversation event store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- private-KV canonical conversation-event store using the existing append-only recall chain, compare-and-swap persistence, exact readback verification, secret/transcript rejection, and persistent-session verification-root binding
 - persistent-session reconstruction checkpoints bound to the existing append-only conversation-recall chain, with monotonic predecessor hashing, live-verification requirements, authority non-transfer, secret/transcript rejection, and private-KV Sessions guidance
 - KV-INTERLOCK-v1 persistent-session read/candidate adapters that return bounded reconstruction context, stage only validated monotonic successors, bind current/successor/recall hashes, and fail closed on stale or ambiguous state
 - governed KV-to-Publisher document export preparation with owner-scoped formats, provenance/fidelity classes, owner-approved redaction, deterministic receipts, revocation evidence, and fail-closed tests

--- a/KV_CONVERSATION_EVENT_STORE_MIRROR_HANDOFF.md
+++ b/KV_CONVERSATION_EVENT_STORE_MIRROR_HANDOFF.md
@@ -1,0 +1,97 @@
+# KnowledgeVault Conversation Event Store Mirror Handoff
+
+Status: SOURCE_IMPLEMENTATION_IN_PROGRESS
+Repository: StegVerse-Labs/continuity-vault-kit
+Issue: #146
+Branch: feature/kv-conversation-event-store-146
+Updated: 2026-08-30
+Authority effect: NONE
+Runtime activation claimed: false
+
+## Goal
+
+Materialize the canonical append-only conversation continuity event chain used by persistent-session reconstruction inside the private KnowledgeVault without creating a second history model.
+
+## Canonical upstream
+
+- `schemas/conversation-event.schema.json`
+- `continuity/recall.py`
+- `docs/AUTOMATED_CONVERSATION_RECALL.md`
+- `KV_PERSISTENT_SESSION_RECONSTRUCTION_MIRROR_HANDOFF.md`
+
+The existing event model and `continuity.recall.validate_chain` semantics remain canonical.
+
+## Canonical private-KV path
+
+```text
+KnowledgeVault/
+  _System/
+    Continuity/
+      Events/
+        README.md
+        events.jsonl
+```
+
+Public source contains only runtime, tests, and guidance. Real event contents remain private KV state.
+
+## Store contract
+
+The event store:
+
+1. reads the exact current JSONL bytes from injected private storage;
+2. parses non-empty lines as canonical event objects;
+3. validates the complete existing chain;
+4. rejects secret/transcript-bearing content;
+5. binds the new event's `previous_event_hash` to the exact canonical hash of the current terminal event;
+6. validates the candidate full chain before persistence;
+7. writes the complete successor JSONL through an injected compare-and-swap writer bound to the exact prior verification root;
+8. reads the committed bytes back;
+9. revalidates the complete chain and exact terminal event;
+10. returns the new event hash, verification root, event count, and opaque storage reference.
+
+The store does not infer authority from storage access and cannot execute a downstream task.
+
+## Fail-closed invariants
+
+- duplicate event id: reject;
+- malformed JSONL: reject;
+- broken previous-event hash: reject;
+- timestamp rollback: reject;
+- content hash mismatch: reject;
+- recoverable-fidelity claim without retained content: reject;
+- password/token/cookie/private-key/seed/mnemonic/recovery material fields: reject;
+- transcript/raw-message/conversation-dump fields: reject;
+- ambiguous compare-and-swap result: reject;
+- write without exact readback: reject;
+- authority transfer: none;
+- execution authority: none;
+- credential authority: TV/TVC.
+
+## Relationship to persistent-session heads
+
+The event chain is canonical continuity history. A persistent-session head is a disposable bounded checkpoint derived from that history plus live repository/runtime evidence.
+
+The head binds to:
+
+```text
+conversation_event_chain_ref=_System/Continuity/Events/events.jsonl
+conversation_event_verification_root=<terminal event hash>
+```
+
+## Activation boundary
+
+Source implementation, CI, merge, or private folder materialization does not prove DEVICE_KV_INTR, a cross-session read, cold reconstruction, duplicate-safe task continuation, governed session-head writeback, or activation.
+
+## Current lifecycle
+
+```text
+IMPLEMENTED: IN_PROGRESS
+VALIDATED: false
+MERGED: false
+DEPLOYED_PRIVATE_KV_SURFACE: false
+EVENT_CHAIN_OBSERVED: false
+ACTIVATED: false
+RECONSTRUCTED: false
+RELEASED: false
+COMPLETE: false
+```

--- a/KV_PERSISTENT_SESSION_RECONSTRUCTION_MIRROR_HANDOFF.md
+++ b/KV_PERSISTENT_SESSION_RECONSTRUCTION_MIRROR_HANDOFF.md
@@ -209,3 +209,19 @@ authority_effect: NONE
 A non-exact Google-Docs staging attempt was discarded before finalization; only the exact UTF-8 source-aligned text/plain README remains in the canonical Sessions folder.
 
 This satisfies the private-KV **surface materialization** gate only. It does not satisfy the event-chain, session-head, Interlock/InTr transport, canonical writeback, cold reconstruction, duplicate-safe continuation, or activation gates.
+
+
+## Canonical conversation-event store — issue #146
+
+Issue #146 is the bounded implementation lane for the canonical private event chain referenced by persistent-session heads.
+
+```text
+canonical chain ref: _System/Continuity/Events/events.jsonl
+runtime: runtime/conversation_event_store.py
+guidance: vault_template/KnowledgeVault/_System/Continuity/Events/README.md
+handoff: KV_CONVERSATION_EVENT_STORE_MIRROR_HANDOFF.md
+```
+
+The store reuses `continuity/recall.py` chain validation, appends with exact prior-root compare-and-swap semantics, performs exact readback, and rejects transcript/secret-bearing content. It creates no execution or credential authority.
+
+Until source merges and a real private event chain is written/read back, the event-chain activation gate remains open.

--- a/runtime/conversation_event_store.py
+++ b/runtime/conversation_event_store.py
@@ -1,0 +1,224 @@
+"""Private-KV append-only conversation event store.
+
+This module reuses the canonical continuity.recall chain semantics. Storage is
+injected so source code cannot silently acquire Drive, provider, credential, or
+execution authority.
+"""
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime
+from typing import Any, Callable
+
+from continuity.recall import event_hash, validate_chain
+
+CHAIN_REF = "_System/Continuity/Events/events.jsonl"
+FORBIDDEN_FIELD_TOKENS = {
+    "password",
+    "token",
+    "cookie",
+    "private_key",
+    "privatekey",
+    "credential_value",
+    "credential_secret",
+    "seed",
+    "mnemonic",
+    "recovery_code",
+    "raw_biometric",
+    "transcript",
+    "raw_message",
+    "conversation_dump",
+    "chat_dump",
+}
+
+
+class ConversationEventStoreError(ValueError):
+    pass
+
+
+def _contains_forbidden_name(name: str) -> bool:
+    lowered = name.lower()
+    return any(token in lowered for token in FORBIDDEN_FIELD_TOKENS)
+
+
+def _reject_forbidden_fields(value: Any, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise ConversationEventStoreError(f"non-string field at {path}")
+            if _contains_forbidden_name(key):
+                raise ConversationEventStoreError(f"forbidden field at {path}.{key}")
+            _reject_forbidden_fields(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_forbidden_fields(child, f"{path}[{index}]")
+
+
+def parse_events_jsonl(text: str) -> list[dict[str, Any]]:
+    if not isinstance(text, str):
+        raise ConversationEventStoreError("event store content must be text")
+    events: list[dict[str, Any]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ConversationEventStoreError(
+                f"invalid event JSON at line {lineno}"
+            ) from exc
+        if not isinstance(event, dict):
+            raise ConversationEventStoreError(
+                f"event line {lineno} must be an object"
+            )
+        _reject_forbidden_fields(event)
+        events.append(event)
+    try:
+        return validate_chain(events)
+    except ValueError as exc:
+        raise ConversationEventStoreError(str(exc)) from exc
+
+
+def serialize_events_jsonl(events: list[dict[str, Any]]) -> str:
+    try:
+        validated = validate_chain(events)
+    except ValueError as exc:
+        raise ConversationEventStoreError(str(exc)) from exc
+    for event in validated:
+        _reject_forbidden_fields(event)
+    if not validated:
+        return ""
+    return "".join(
+        json.dumps(
+            event,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        + "\n"
+        for event in validated
+    )
+
+
+def verification_root(events: list[dict[str, Any]]) -> str | None:
+    if not events:
+        return None
+    try:
+        validated = validate_chain(events)
+    except ValueError as exc:
+        raise ConversationEventStoreError(str(exc)) from exc
+    return event_hash(validated[-1])
+
+
+def append_event_candidate(
+    current_events: list[dict[str, Any]],
+    event: dict[str, Any],
+) -> tuple[list[dict[str, Any]], str]:
+    try:
+        current = validate_chain(current_events)
+    except ValueError as exc:
+        raise ConversationEventStoreError(str(exc)) from exc
+
+    candidate = copy.deepcopy(event)
+    _reject_forbidden_fields(candidate)
+
+    if current:
+        candidate["previous_event_hash"] = event_hash(current[-1])
+        try:
+            if datetime.fromisoformat(
+                candidate["timestamp"].replace("Z", "+00:00")
+            ) < datetime.fromisoformat(
+                current[-1]["timestamp"].replace("Z", "+00:00")
+            ):
+                raise ConversationEventStoreError("event timestamp rollback")
+        except KeyError as exc:
+            raise ConversationEventStoreError("event timestamp required") from exc
+    else:
+        if candidate.get("previous_event_hash") is not None:
+            raise ConversationEventStoreError(
+                "genesis event previous_event_hash must be null"
+            )
+        candidate["previous_event_hash"] = None
+
+    successor = [*copy.deepcopy(current), candidate]
+    try:
+        successor = validate_chain(successor)
+    except ValueError as exc:
+        raise ConversationEventStoreError(str(exc)) from exc
+    return successor, event_hash(successor[-1])
+
+
+class ConversationEventStore:
+    """Compare-and-swap private event-chain store.
+
+    reader returns the current exact JSONL string and an opaque storage ref.
+    writer receives expected prior root plus exact successor text and must
+    return an opaque write ref. readback then independently returns current
+    exact JSONL text and opaque storage ref.
+    """
+
+    def __init__(
+        self,
+        *,
+        reader: Callable[[], tuple[str, str]],
+        writer: Callable[[str | None, str], str],
+        readback: Callable[[], tuple[str, str]],
+    ) -> None:
+        self.reader = reader
+        self.writer = writer
+        self.readback = readback
+
+    def append(self, event: dict[str, Any]) -> dict[str, Any]:
+        try:
+            current_text, current_ref = self.reader()
+        except Exception as exc:
+            raise ConversationEventStoreError("event store read failed") from exc
+        if not isinstance(current_ref, str) or not current_ref:
+            raise ConversationEventStoreError("current storage reference required")
+
+        current = parse_events_jsonl(current_text)
+        prior_root = verification_root(current)
+        successor, new_event_hash = append_event_candidate(current, event)
+        successor_text = serialize_events_jsonl(successor)
+
+        try:
+            write_ref = self.writer(prior_root, successor_text)
+        except Exception as exc:
+            raise ConversationEventStoreError("event store compare-and-swap failed") from exc
+        if not isinstance(write_ref, str) or not write_ref:
+            raise ConversationEventStoreError("event store write reference required")
+
+        try:
+            readback_text, readback_ref = self.readback()
+        except Exception as exc:
+            raise ConversationEventStoreError("event store readback failed") from exc
+        if not isinstance(readback_ref, str) or not readback_ref:
+            raise ConversationEventStoreError("event store readback reference required")
+        if readback_text != successor_text:
+            raise ConversationEventStoreError("event store exact readback mismatch")
+
+        observed = parse_events_jsonl(readback_text)
+        observed_root = verification_root(observed)
+        if observed_root != new_event_hash:
+            raise ConversationEventStoreError("event store verification root mismatch")
+        if observed[-1] != successor[-1]:
+            raise ConversationEventStoreError("event store terminal event mismatch")
+
+        return {
+            "schema": "stegverse.kv.conversation-event-append-receipt/v1",
+            "chain_ref": CHAIN_REF,
+            "event_id": observed[-1]["event_id"],
+            "event_hash": new_event_hash,
+            "prior_verification_root": prior_root,
+            "verification_root": observed_root,
+            "event_count": len(observed),
+            "prior_storage_ref": current_ref,
+            "write_ref": write_ref,
+            "readback_ref": readback_ref,
+            "exact_readback_verified": True,
+            "authority_transfer": False,
+            "execution_authority": "NONE",
+            "credential_authority": "TV/TVC",
+            "authority_effect": "NONE",
+        }

--- a/tests/test_conversation_event_store.py
+++ b/tests/test_conversation_event_store.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+
+import pytest
+
+from continuity.recall import sha256
+from runtime.conversation_event_store import (
+    CHAIN_REF,
+    ConversationEventStore,
+    ConversationEventStoreError,
+    append_event_candidate,
+    parse_events_jsonl,
+    serialize_events_jsonl,
+    verification_root,
+)
+
+
+def event(event_id="evt-001", timestamp="2026-08-30T20:00:00Z", content=None):
+    if content is None:
+        content = {
+            "goal": "KV persistent session reconstruction",
+            "status": "active",
+        }
+    return {
+        "event_id": event_id,
+        "previous_event_hash": None,
+        "timestamp": timestamp,
+        "actor": "assistant",
+        "event_type": "implementation_recorded",
+        "topic": "persistent session reconstruction",
+        "subject_id": "kv-persistent-session-reconstruction",
+        "supersedes": None,
+        "content": content,
+        "content_hash": sha256(content),
+        "resulting_state_hash": hashlib.sha256(
+            json.dumps(
+                {"goal": "kv-persistent-session-reconstruction", "event": event_id},
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest(),
+        "retention_class": "reconstructable",
+        "fidelity": "semantic_reconstruction",
+        "artifact_refs": [
+            "KV_PERSISTENT_SESSION_RECONSTRUCTION_MIRROR_HANDOFF.md"
+        ],
+        "authority_context": {
+            "execution_authority": "NONE",
+            "credential_authority": "TV/TVC",
+        },
+        "policy_context": None,
+    }
+
+
+def test_genesis_append_and_jsonl_roundtrip():
+    successor, root = append_event_candidate([], event())
+    assert successor[0]["previous_event_hash"] is None
+    text = serialize_events_jsonl(successor)
+    parsed = parse_events_jsonl(text)
+    assert parsed == successor
+    assert verification_root(parsed) == root
+
+
+def test_successor_is_bound_to_exact_prior_event_hash():
+    first, first_root = append_event_candidate([], event())
+    second, second_root = append_event_candidate(
+        first,
+        event("evt-002", "2026-08-30T20:01:00Z"),
+    )
+    assert second[1]["previous_event_hash"] == first_root
+    assert second_root != first_root
+
+
+def test_duplicate_and_timestamp_rollback_fail_closed():
+    first, _ = append_event_candidate([], event())
+    with pytest.raises(ConversationEventStoreError, match="duplicate event_id"):
+        append_event_candidate(first, event())
+
+    with pytest.raises(ConversationEventStoreError, match="timestamp rollback"):
+        append_event_candidate(
+            first,
+            event("evt-002", "2026-08-30T19:59:59Z"),
+        )
+
+
+def test_content_hash_and_secret_or_transcript_fields_fail_closed():
+    bad = event()
+    bad["content_hash"] = "0" * 64
+    with pytest.raises(ConversationEventStoreError, match="content hash mismatch"):
+        append_event_candidate([], bad)
+
+    bad = event(content={"transcript": "raw conversation"})
+    with pytest.raises(ConversationEventStoreError, match="forbidden field"):
+        append_event_candidate([], bad)
+
+    bad = event(content={"token_hint": "forbidden"})
+    with pytest.raises(ConversationEventStoreError, match="forbidden field"):
+        append_event_candidate([], bad)
+
+
+def test_store_requires_compare_and_swap_and_exact_readback():
+    state = {"text": "", "ref": "kv://events/current"}
+    writes = []
+
+    def reader():
+        return state["text"], state["ref"]
+
+    def writer(expected_root, successor_text):
+        assert expected_root is None
+        writes.append((expected_root, successor_text))
+        state["text"] = successor_text
+        state["ref"] = "kv://events/version/1"
+        return "kv://events/write/1"
+
+    def readback():
+        return state["text"], state["ref"]
+
+    receipt = ConversationEventStore(
+        reader=reader,
+        writer=writer,
+        readback=readback,
+    ).append(event())
+
+    assert receipt["chain_ref"] == CHAIN_REF
+    assert receipt["event_count"] == 1
+    assert receipt["exact_readback_verified"] is True
+    assert receipt["event_hash"] == receipt["verification_root"]
+    assert receipt["authority_transfer"] is False
+    assert receipt["execution_authority"] == "NONE"
+    assert receipt["credential_authority"] == "TV/TVC"
+    assert writes
+
+
+def test_store_rejects_ambiguous_write_and_readback_drift():
+    state = {"text": "", "ref": "kv://events/current"}
+
+    store = ConversationEventStore(
+        reader=lambda: (state["text"], state["ref"]),
+        writer=lambda _root, _text: "",
+        readback=lambda: (state["text"], state["ref"]),
+    )
+    with pytest.raises(ConversationEventStoreError, match="write reference"):
+        store.append(event())
+
+    def writer(_root, successor):
+        state["text"] = successor + "\n"
+        return "kv://events/write/1"
+
+    store = ConversationEventStore(
+        reader=lambda: ("", "kv://events/current"),
+        writer=writer,
+        readback=lambda: (state["text"], "kv://events/version/1"),
+    )
+    with pytest.raises(ConversationEventStoreError, match="exact readback mismatch"):
+        store.append(event())

--- a/vault_template/KnowledgeVault/_System/Continuity/Events/README.md
+++ b/vault_template/KnowledgeVault/_System/Continuity/Events/README.md
@@ -1,0 +1,19 @@
+# Canonical Conversation Continuity Events
+
+This private KnowledgeVault directory holds the canonical append-only conversation continuity event chain used by automated recall and persistent-session reconstruction.
+
+Canonical file:
+
+```text
+events.jsonl
+```
+
+Each non-empty line is one `schemas/conversation-event.schema.json` event. The chain semantics are owned by `continuity/recall.py`.
+
+The event chain is canonical history. Persistent-session `head.json` files are bounded derived checkpoints and may be rebuilt from this chain plus durable repository/runtime evidence.
+
+Do not store transcript dumps, raw chat messages, passwords, tokens, cookies, private keys, credential values, recovery material, raw biometric material, or other reusable secrets here.
+
+Every append must validate the current chain, bind `previous_event_hash` to the exact terminal event hash, validate the successor chain, persist with compare-and-swap semantics, read the exact bytes back, and verify the same terminal root.
+
+Storage access creates no credential, execution, provider, governance, or completion authority.


### PR DESCRIPTION
Closes #146.

Adds the canonical private-KV conversation event-chain store used by persistent-session reconstruction.

- Reuses schemas/conversation-event.schema.json and continuity/recall.py; no second event model.
- Canonical private path: _System/Continuity/Events/events.jsonl.
- Validates current chain before append and successor chain before write.
- Binds previous_event_hash to the exact canonical terminal event hash.
- Uses injected compare-and-swap storage and requires exact readback before success.
- Returns event hash, verification root, event count, and opaque storage refs.
- Rejects transcript/raw-message and secret-like fields.
- No provider, credential, execution, or authority-transfer semantics.

Source/CI/merge do not prove a real private event chain, DEVICE_KV_INTR, cold-session reconstruction, or activation.