### PR TITLE
Retain private KV export bundle for Publisher return validation

### DIFF
--- a/KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md
+++ b/KV_DOCUMENT_EXPORT_MIRROR_HANDOFF.md
@@ -201,3 +201,22 @@ remains `VALIDATED_IMPORT_CANDIDATE_NOT_COMMITTED`.
 This source does not construct StegOS transport intents/hop receipts or claim
 forward/return transport. It is the KV application contract consumed by the
 sovereign Universal InTr runtime.
+
+
+## Private export-bundle retention for reverse InTr validation — issue #153
+
+The governed document lane now includes a write-once private retention helper:
+
+```text
+runtime.document_intr_transfer.retain_private_export_bundle(bundle, root=...)
+```
+
+It first revalidates the prepared owner-authorized Publisher bundle, then writes
+canonical JSON as `<export_id>.json` beneath a caller-selected KV-private local
+root. Identical retry is idempotent; a different payload at the same export ID
+fails closed with a write-once collision.
+
+This satisfies the reverse Publisher -> KV consumer's provenance dependency
+without placing the original private bundle in Publisher's return transport.
+Retention itself grants no transport, publication, release, execution, or
+canonical KV mutation authority.

--- a/runtime/document_intr_transfer.py
+++ b/runtime/document_intr_transfer.py
@@ -5,6 +5,7 @@ the Publisher application payload and validates returned application bytes.
 """
 from __future__ import annotations
 import base64, copy, hashlib, json
+from pathlib import Path
 from typing import Any, Mapping
 from runtime.document_export import BUNDLE_SCHEMA, PUBLISHER_DESTINATION
 
@@ -123,3 +124,24 @@ def build_import_receipt(candidate:Mapping[str,Any],*,return_transport_terminal_
       "execution_authorized":False,"authority_effect":"NONE",
     }
     return {**body,"receipt_sha256":sha256_value(body)}
+
+
+def retain_private_export_bundle(bundle:Mapping[str,Any], *, root:Path) -> Path:
+    """Persist one verified private export bundle write-once for return validation."""
+    verify_bundle(bundle)
+    export_id=bundle.get("export_id")
+    if not isinstance(export_id,str) or not export_id or any(ch not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-" for ch in export_id):
+        raise DocumentInTrTransferError("export_id invalid for private retention")
+    target_root=root.expanduser().resolve()
+    target_root.mkdir(parents=True,exist_ok=True)
+    path=target_root/f"{export_id}.json"
+    raw=(json.dumps(dict(bundle),sort_keys=True,indent=2,ensure_ascii=False)+"\n").encode("utf-8")
+    if path.exists():
+        existing=path.read_bytes()
+        if existing==raw:
+            return path
+        raise DocumentInTrTransferError("private export bundle write-once collision")
+    path.write_bytes(raw)
+    if path.read_bytes()!=raw:
+        raise DocumentInTrTransferError("private export bundle persistence verification failed")
+    return path

--- a/tests/test_document_intr_transfer.py
+++ b/tests/test_document_intr_transfer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-import base64, copy, json, unittest
+import base64, copy, json, tempfile, unittest
 from datetime import datetime, timezone
+from pathlib import Path
 from runtime import document_export as de
 from runtime import document_intr_transfer as intr
 
@@ -44,5 +45,18 @@ class DocumentInTrTransferTests(unittest.TestCase):
         b=bundle(); b["requested_formats"]=["markdown"]; unhashed=copy.deepcopy(b); unhashed.pop("export_sha256"); b["export_sha256"]=intr.sha256_value(unhashed)
         with self.assertRaisesRegex(intr.DocumentInTrTransferError,"formats differ"):
             intr.validate_artifact_return(publisher_return(b),source_bundle=b)
+
+    def test_private_bundle_retention_is_write_once_and_idempotent(self):
+        b=bundle()
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)
+            first=intr.retain_private_export_bundle(b,root=root)
+            second=intr.retain_private_export_bundle(b,root=root)
+            self.assertEqual(first,second)
+            self.assertEqual(json.loads(first.read_text()),b)
+            altered=copy.deepcopy(b); altered["document"]["title"]="collision"
+            unhashed=copy.deepcopy(altered); unhashed.pop("export_sha256"); altered["export_sha256"]=intr.sha256_value(unhashed)
+            with self.assertRaisesRegex(intr.DocumentInTrTransferError,"write-once collision"):
+                intr.retain_private_export_bundle(altered,root=root)
 
 if __name__=="__main__": unittest.main()


### PR DESCRIPTION
Closes #153. Adds write-once, idempotent private KV-local retention for an already-verified owner-authorized Publisher export bundle. Collisions fail closed. The retained bundle supplies provenance to the reverse Publisher->KV import consumer without echoing private source state through return transport. No transport/publication/release/execution/KV-mutation authority is created.