### PR TITLE
Add read-only projection for admitted portable KV directories

### DIFF
--- a/PORTABLE_DIRECTORY_PROJECTION_MIRROR_HANDOFF.md
+++ b/PORTABLE_DIRECTORY_PROJECTION_MIRROR_HANDOFF.md
@@ -1,0 +1,33 @@
+# Portable Directory Projection Mirror Handoff
+
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: `#164`
+Branch: `feat/portable-directory-projection-164`
+State: ACTIVE_IMPLEMENTATION
+Updated: 2026-08-31T11:41:00-05:00
+Credential authority: TV/TVC
+Authority effect: NONE
+
+## Goal
+
+Expose a bounded read-only machine projection of canonical owner-controlled portable admissions for My KV directory listing and connection-health display.
+
+## Rules
+
+- canonical path must remain beneath an admitted KnowledgeVault domain;
+- only batches with `CANONICAL_ADMITTED` + exact canonical readback are listed;
+- staged-only content is excluded;
+- directory listings expose metadata and opaque canonical refs, not file bytes;
+- connection-health projection must be `VERIFIED` and non-authorizing;
+- no provider session or credential resolution is performed.
+
+## Claimed surfaces
+
+- `runtime/portable_directory_projection.py`
+- `tests/test_portable_directory_projection.py`
+- `tools/check_portable_directory_projection.py`
+- `PORTABLE_DIRECTORY_PROJECTION_MIRROR_HANDOFF.md`
+
+## Completion boundary
+
+Source validation and merge. Resident exposure through the existing DEVICE_KV runtime remains the next bounded step.

--- a/runtime/portable_directory_projection.py
+++ b/runtime/portable_directory_projection.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+ALLOWED_ROOTS={"00_Inbox","02_Research","03_Records","04_Media","05_Projects","06_Archive","_Entities"}
+ADMISSION_SCHEMA="stegverse.kv.portable-direct-source-canonical-admission/v1"
+PROVENANCE_SCHEMA="stegverse.kv.portable-direct-source-provenance/v1"
+HEALTH_SCHEMA="stegverse.kv.portable-direct-source-connection-health/v1"
+
+class PortableDirectoryProjectionError(ValueError):
+    pass
+
+def _require(ok:bool,reason:str)->None:
+    if not ok:
+        raise PortableDirectoryProjectionError(reason)
+
+def _safe_root(kv_data_root:Path)->Path:
+    root=kv_data_root.expanduser().resolve()
+    _require(root.name=="KnowledgeVault" or (root/"_System").exists() or (root/"00_Inbox").exists(),"kv_data_root_not_knowledgevault")
+    return root
+
+def _safe_canonical_path(root:Path,canonical_path:str)->Path:
+    _require(isinstance(canonical_path,str) and canonical_path,"canonical_path_required")
+    _require(not canonical_path.startswith("/") and "\" not in canonical_path,"canonical_path_invalid")
+    parts=canonical_path.split("/")
+    _require(all(part not in {"",".",".."} for part in parts),"canonical_path_traversal_forbidden")
+    _require(parts[0] in ALLOWED_ROOTS,"canonical_path_root_not_admitted")
+    candidate=(root/canonical_path).resolve()
+    _require(root in candidate.parents or candidate==root,"canonical_path_escape_forbidden")
+    return candidate
+
+def _read_json(path:Path,reason:str)->dict[str,Any]:
+    try:
+        value=json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise PortableDirectoryProjectionError(reason) from exc
+    _require(isinstance(value,dict),reason)
+    return value
+
+def _validated_batch(root:Path,batch:Path,canonical_path:str)->tuple[dict[str,Any],dict[str,Any],dict[str,Any]]:
+    admission=_read_json(batch/"admission-receipt.json","admission_receipt_unreadable")
+    provenance=_read_json(batch/"provenance.json","provenance_unreadable")
+    health=_read_json(batch/"connection-health.json","connection_health_unreadable")
+    expected_admission={
+        "schema":ADMISSION_SCHEMA,
+        "state":"CANONICAL_ADMITTED",
+        "requested_canonical_path":canonical_path,
+        "canonical_batch_path":str(batch.relative_to(root)),
+        "canonical_kv_persistence_observed":True,
+        "exact_canonical_readback_verified":True,
+        "trusted_semantic_admission":True,
+        "provider_session_required":False,
+        "provider_session_observed":False,
+        "credential_material_present":False,
+        "provider_operation_authorized":False,
+        "credential_authority":"TV/TVC",
+        "github_token_runtime_authority":"NONE",
+        "authority_effect":"NONE",
+    }
+    for key,value in expected_admission.items():
+        _require(admission.get(key)==value,"admission_receipt_binding_mismatch:"+key)
+    _require(provenance.get("schema")==PROVENANCE_SCHEMA,"provenance_schema_mismatch")
+    for key in ("materialization_id","request_hash","payload_hash","staging_receipt_sha256","ingress_receipt_sha256"):
+        _require(provenance.get(key)==admission.get(key),"provenance_binding_mismatch:"+key)
+    _require(provenance.get("canonical_batch_path")==str(batch.relative_to(root)),"provenance_canonical_batch_path_mismatch")
+    _require(provenance.get("credential_material_present") is False,"provenance_credential_material_forbidden")
+    _require(provenance.get("provider_operation_authorized") is False,"provenance_provider_operation_forbidden")
+    _require(provenance.get("authority_effect")=="NONE","provenance_authority_effect_invalid")
+    _require(health.get("schema")==HEALTH_SCHEMA,"connection_health_schema_mismatch")
+    _require(health.get("canonical_path")==canonical_path,"connection_health_path_mismatch")
+    _require(health.get("compatibility_state")=="VERIFIED","connection_health_not_verified")
+    _require(health.get("credential_material_present") is False,"connection_health_credential_material_forbidden")
+    _require(health.get("provider_operation_authorized") is False,"connection_health_provider_operation_forbidden")
+    _require(health.get("authority_effect")=="NONE","connection_health_authority_effect_invalid")
+    return admission,provenance,health
+
+def list_admitted_directory(*,kv_data_root:Path,directory_id:str,canonical_path:str)->dict[str,Any]:
+    root=_safe_root(kv_data_root)
+    directory=_safe_canonical_path(root,canonical_path)
+    _require(isinstance(directory_id,str) and directory_id,"directory_id_required")
+    entries:list[dict[str,Any]]=[]
+    health_rows:list[dict[str,Any]]=[]
+    if directory.exists():
+        _require(directory.is_dir(),"canonical_path_not_directory")
+        for batch in sorted((p for p in directory.iterdir() if p.is_dir()),key=lambda p:p.name):
+            if not (batch/"admission-receipt.json").is_file():
+                continue
+            admission,provenance,health=_validated_batch(root,batch,canonical_path)
+            _require(admission.get("directory_id")==directory_id,"directory_id_binding_mismatch")
+            files=provenance.get("files")
+            _require(isinstance(files,list),"provenance_files_invalid")
+            for item in files:
+                _require(isinstance(item,Mapping),"provenance_file_entry_invalid")
+                ref=item.get("canonical_ref")
+                _require(isinstance(ref,str) and ref,"canonical_ref_required")
+                target=(root/ref).resolve()
+                _require(root in target.parents and target.is_file(),"canonical_ref_invalid")
+                _require(str(target.relative_to(root)).startswith(str(batch.relative_to(root))+"/files/"),"canonical_ref_batch_escape")
+                entries.append({
+                    "name":item.get("name"),
+                    "kind":"file",
+                    "media_type":item.get("media_type"),
+                    "size_bytes":item.get("size_bytes"),
+                    "sha256":item.get("sha256"),
+                    "materialization_id":admission.get("materialization_id"),
+                    "canonical_ref":ref,
+                    "modified_at":admission.get("observed_at"),
+                    "authority_effect":"NONE",
+                })
+            health_rows.append(health)
+    latest_health=max(health_rows,key=lambda row:str(row.get("last_observed_at") or "")) if health_rows else None
+    return {
+        "schema":"stegverse.kv.portable-directory-projection/v1",
+        "state":"KV_LISTED",
+        "directory_id":directory_id,
+        "canonical_path":canonical_path,
+        "entries":entries,
+        "connection_health":latest_health,
+        "credential_material_present":False,
+        "provider_operation_authorized":False,
+        "authority_effect":"NONE",
+    }
+
+def get_directory_health(*,kv_data_root:Path,directory_id:str,canonical_path:str)->dict[str,Any]:
+    listing=list_admitted_directory(kv_data_root=kv_data_root,directory_id=directory_id,canonical_path=canonical_path)
+    health=listing["connection_health"]
+    if health is None:
+        return {
+            "schema":"stegverse.kv.portable-direct-source-connection-health/v1",
+            "directory_id":directory_id,
+            "canonical_path":canonical_path,
+            "compatibility_state":"UNASSEMBLED",
+            "last_observed_at":None,
+            "reason":"NO_CANONICAL_OWNER_CONTROLLED_ADMISSION",
+            "revalidation_required":False,
+            "connection_proof_ref":None,
+            "readback_proof_ref":None,
+            "credential_material_present":False,
+            "provider_operation_authorized":False,
+            "authority_effect":"NONE",
+        }
+    return dict(health)

--- a/tests/test_portable_directory_projection.py
+++ b/tests/test_portable_directory_projection.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from runtime.portable_directory_projection import (
+    PortableDirectoryProjectionError,
+    get_directory_health,
+    list_admitted_directory,
+)
+
+def write_json(path:Path,value:dict)->None:
+    path.parent.mkdir(parents=True,exist_ok=True)
+    path.write_text(json.dumps(value),encoding="utf-8")
+
+def install_batch(root:Path,mid:str="INTR-MAT-"+"a"*24)->Path:
+    batch=root/"04_Media/Pictures"/mid
+    file_path=batch/"files/one.bin"
+    file_path.parent.mkdir(parents=True,exist_ok=True)
+    file_path.write_bytes(b"abc")
+    admission={
+      "schema":"stegverse.kv.portable-direct-source-canonical-admission/v1",
+      "state":"CANONICAL_ADMITTED","materialization_id":mid,
+      "request_hash":"sha256:"+"1"*64,"transport_intent_hash":"sha256:"+"2"*64,
+      "payload_hash":"sha256:"+"3"*64,"staging_receipt_sha256":"sha256:"+"4"*64,
+      "ingress_receipt_sha256":"sha256:"+"5"*64,"directory_id":"pictures",
+      "requested_canonical_path":"04_Media/Pictures",
+      "canonical_batch_path":str(batch.relative_to(root)),
+      "canonical_kv_persistence_observed":True,"exact_canonical_readback_verified":True,
+      "trusted_semantic_admission":True,"provider_session_required":False,
+      "provider_session_observed":False,"credential_material_present":False,
+      "provider_operation_authorized":False,"credential_authority":"TV/TVC",
+      "github_token_runtime_authority":"NONE","authority_effect":"NONE",
+      "observed_at":"2026-08-31T16:00:00Z","receipt_sha256":"sha256:"+"6"*64,
+    }
+    provenance={
+      "schema":"stegverse.kv.portable-direct-source-provenance/v1",
+      "materialization_id":mid,"request_hash":admission["request_hash"],
+      "transport_intent_hash":admission["transport_intent_hash"],
+      "payload_hash":admission["payload_hash"],"staging_receipt_sha256":admission["staging_receipt_sha256"],
+      "ingress_receipt_sha256":admission["ingress_receipt_sha256"],
+      "canonical_batch_path":admission["canonical_batch_path"],
+      "credential_material_present":False,"provider_operation_authorized":False,
+      "authority_effect":"NONE",
+      "files":[{"name":"one.bin","media_type":"application/octet-stream","size_bytes":3,
+                "sha256":"sha256:"+"7"*64,"canonical_ref":str(file_path.relative_to(root))}],
+    }
+    health={
+      "schema":"stegverse.kv.portable-direct-source-connection-health/v1",
+      "directory_id":"pictures","canonical_path":"04_Media/Pictures",
+      "compatibility_state":"VERIFIED","last_observed_at":"2026-08-31T16:00:00Z",
+      "reason":"OWNER_CONTROLLED_FILE_CANONICAL_READBACK_VERIFIED",
+      "revalidation_required":False,
+      "connection_proof_ref":str((batch/"admission-receipt.json").relative_to(root)),
+      "readback_proof_ref":str((batch/"provenance.json").relative_to(root)),
+      "credential_material_present":False,"provider_operation_authorized":False,"authority_effect":"NONE",
+    }
+    write_json(batch/"admission-receipt.json",admission)
+    write_json(batch/"provenance.json",provenance)
+    write_json(batch/"connection-health.json",health)
+    return batch
+
+class PortableDirectoryProjectionTests(unittest.TestCase):
+    def test_lists_only_canonical_admitted_metadata(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)/"KnowledgeVault"; (root/"00_Inbox").mkdir(parents=True)
+            install_batch(root)
+            result=list_admitted_directory(kv_data_root=root,directory_id="pictures",canonical_path="04_Media/Pictures")
+            self.assertEqual(result["state"],"KV_LISTED")
+            self.assertEqual(len(result["entries"]),1)
+            self.assertEqual(result["entries"][0]["name"],"one.bin")
+            self.assertNotIn("content_base64",result["entries"][0])
+            self.assertEqual(result["connection_health"]["compatibility_state"],"VERIFIED")
+
+    def test_staged_only_batch_is_not_listed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)/"KnowledgeVault"; (root/"00_Inbox").mkdir(parents=True)
+            staged=root/"04_Media/Pictures"/("INTR-MAT-"+"b"*24)
+            staged.mkdir(parents=True)
+            result=list_admitted_directory(kv_data_root=root,directory_id="pictures",canonical_path="04_Media/Pictures")
+            self.assertEqual(result["entries"],[])
+            self.assertIsNone(result["connection_health"])
+
+    def test_unassembled_health_is_explicit(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)/"KnowledgeVault"; (root/"00_Inbox").mkdir(parents=True)
+            health=get_directory_health(kv_data_root=root,directory_id="pictures",canonical_path="04_Media/Pictures")
+            self.assertEqual(health["compatibility_state"],"UNASSEMBLED")
+            self.assertFalse(health["provider_operation_authorized"])
+
+    def test_receipt_authority_drift_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)/"KnowledgeVault"; (root/"00_Inbox").mkdir(parents=True)
+            batch=install_batch(root)
+            value=json.loads((batch/"admission-receipt.json").read_text())
+            value["provider_operation_authorized"]=True
+            write_json(batch/"admission-receipt.json",value)
+            with self.assertRaisesRegex(PortableDirectoryProjectionError,"provider_operation_authorized"):
+                list_admitted_directory(kv_data_root=root,directory_id="pictures",canonical_path="04_Media/Pictures")
+
+    def test_path_traversal_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)/"KnowledgeVault"; (root/"00_Inbox").mkdir(parents=True)
+            with self.assertRaises(PortableDirectoryProjectionError):
+                list_admitted_directory(kv_data_root=root,directory_id="pictures",canonical_path="../Pictures")
+
+if __name__=="__main__":
+    unittest.main()

--- a/tools/check_portable_directory_projection.py
+++ b/tools/check_portable_directory_projection.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+runtime=(ROOT/"runtime/portable_directory_projection.py").read_text()
+tests=(ROOT/"tests/test_portable_directory_projection.py").read_text()
+for marker in (
+    "def list_admitted_directory(",
+    "def get_directory_health(",
+    '"state":"KV_LISTED"',
+    '"compatibility_state":"VERIFIED"',
+    '"provider_operation_authorized":False',
+    '"credential_material_present":False',
+):
+    if marker not in runtime:
+        raise SystemExit("PORTABLE_DIRECTORY_PROJECTION_MISSING:"+marker)
+for marker in (
+    "test_lists_only_canonical_admitted_metadata",
+    "test_staged_only_batch_is_not_listed",
+    "test_unassembled_health_is_explicit",
+    "test_receipt_authority_drift_fails_closed",
+):
+    if marker not in tests:
+        raise SystemExit("PORTABLE_DIRECTORY_PROJECTION_TEST_MISSING:"+marker)
+print("PORTABLE_DIRECTORY_PROJECTION_PASS")


### PR DESCRIPTION
Implements #164. Adds a fail-closed read-only projection over canonical owner-controlled portable admissions. Only batches with CANONICAL_ADMITTED and exact canonical readback are listed; staged-only batches are excluded. Directory results expose metadata/opaque refs only and return bounded VERIFIED connection health with credential/provider-operation authority false.