### PR TITLE
Add bounded directory selector to KV-INTERLOCK requests

### DIFF
--- a/KV_INTERLOCK_DIRECTORY_SELECTOR_MIRROR_HANDOFF.md
+++ b/KV_INTERLOCK_DIRECTORY_SELECTOR_MIRROR_HANDOFF.md
@@ -1,0 +1,42 @@
+# KV Interlock Directory Selector Mirror Handoff
+
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Issue: `#166`
+Branch: `feat/kv-interlock-directory-selector-166`
+State: ACTIVE_IMPLEMENTATION
+Updated: 2026-08-31T13:20:00-05:00
+Authority effect: NONE
+
+## Goal
+
+Add one bounded request selector to the canonical `kv.interlock.request.v1` contract so read requests can identify an exact KnowledgeVault directory without overloading purpose or scope strings.
+
+## Contract
+
+Optional:
+
+```json
+"selector": {
+  "directory_id": "pictures",
+  "canonical_path": "04_Media/Pictures"
+}
+```
+
+Rules:
+- allowed only when `operation=REQUEST`;
+- exactly these two fields;
+- both non-empty strings;
+- selector never establishes authority;
+- the existing injected authority validator and policy evaluator remain mandatory.
+
+## Claimed surfaces
+
+- `schemas/kv-interlock-request.schema.json`
+- `runtime/kv_interlock_endpoint.py`
+- `tests/test_kv_interlock_runtime_endpoint.py`
+- `docs/KNOWLEDGEVAULT_INTERLOCK_PROTOCOL.md`
+- `KV_INTERLOCK_DIRECTORY_SELECTOR_MIRROR_HANDOFF.md`
+
+## Completion boundary
+
+Schema/runtime/tests/contract validation and merge.

--- a/docs/KNOWLEDGEVAULT_INTERLOCK_PROTOCOL.md
+++ b/docs/KNOWLEDGEVAULT_INTERLOCK_PROTOCOL.md
@@ -61,9 +61,12 @@ A requester supplies:
 - requested record class;
 - minimum required fields or query scope;
 - time/scope constraints;
+- optional bounded selector (`directory_id`, `canonical_path`) for exact directory reads;
 - requested disclosure mode;
 - authority/delegation reference;
 - correlation/request id.
+
+A selector does not establish authority. It is valid only for `REQUEST`, must contain exactly `directory_id` and `canonical_path`, and is evaluated only after the same verified InTr admission and injected authority validation as every other restricted-record request.
 
 ### RETURN
 

--- a/runtime/kv_interlock_endpoint.py
+++ b/runtime/kv_interlock_endpoint.py
@@ -17,7 +17,7 @@ REQUEST_REQUIRED = {
     "record_class", "requested_scope", "minimum_necessary_justification",
     "authority_ref", "disclosure_mode",
 }
-REQUEST_ALLOWED = REQUEST_REQUIRED | {"time_scope", "candidate_writeback"}
+REQUEST_ALLOWED = REQUEST_REQUIRED | {"time_scope", "candidate_writeback", "selector"}
 ENVELOPE_REQUIRED = {
     "schema", "protocol", "packet_id", "direction", "source_role", "next_role",
     "request_id", "operation", "payload_schema_version", "payload_hash",
@@ -193,6 +193,16 @@ class KVInterlockRuntime:
             "BOUNDED_CONTEXT", "SOURCE_REFERENCE_ONLY", "ORIGINAL_ARTIFACT_REVIEW"
         }:
             raise KVInterlockRuntimeError("disclosure_mode invalid")
+        selector = request.get("selector")
+        if selector is not None:
+            if request["operation"] != "REQUEST":
+                raise KVInterlockRuntimeError("selector only allowed for REQUEST")
+            if (
+                not isinstance(selector, dict)
+                or set(selector) != {"directory_id", "canonical_path"}
+                or not all(isinstance(selector.get(key), str) and selector.get(key) for key in ("directory_id", "canonical_path"))
+            ):
+                raise KVInterlockRuntimeError("selector invalid")
         candidate = request.get("candidate_writeback")
         if request["operation"] == "COMMIT_CANDIDATE":
             if (

--- a/schemas/kv-interlock-request.schema.json
+++ b/schemas/kv-interlock-request.schema.json
@@ -18,47 +18,137 @@
     "disclosure_mode"
   ],
   "properties": {
-    "schema_version": {"const": "kv.interlock.request.v1"},
-    "operation": {"enum": ["DISCOVER", "REQUEST", "COMMIT_CANDIDATE"]},
-    "request_id": {"type": "string", "minLength": 1},
+    "schema_version": {
+      "const": "kv.interlock.request.v1"
+    },
+    "operation": {
+      "enum": [
+        "DISCOVER",
+        "REQUEST",
+        "COMMIT_CANDIDATE"
+      ]
+    },
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
     "requester": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["module", "component"],
+      "required": [
+        "module",
+        "component"
+      ],
       "properties": {
-        "module": {"type": "string", "minLength": 1},
-        "component": {"type": "string", "minLength": 1}
+        "module": {
+          "type": "string",
+          "minLength": 1
+        },
+        "component": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
-    "purpose": {"type": "string", "minLength": 1},
-    "record_class": {"type": "string", "minLength": 1},
+    "purpose": {
+      "type": "string",
+      "minLength": 1
+    },
+    "record_class": {
+      "type": "string",
+      "minLength": 1
+    },
     "requested_scope": {
       "type": "array",
-      "items": {"type": "string", "minLength": 1},
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
       "minItems": 1,
       "uniqueItems": true
     },
     "time_scope": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "additionalProperties": false,
       "properties": {
-        "start": {"type": ["string", "null"]},
-        "end": {"type": ["string", "null"]}
+        "start": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "end": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       }
     },
-    "minimum_necessary_justification": {"type": "string", "minLength": 1},
-    "authority_ref": {"type": "string", "minLength": 1},
+    "minimum_necessary_justification": {
+      "type": "string",
+      "minLength": 1
+    },
+    "authority_ref": {
+      "type": "string",
+      "minLength": 1
+    },
     "disclosure_mode": {
-      "enum": ["BOUNDED_CONTEXT", "SOURCE_REFERENCE_ONLY", "ORIGINAL_ARTIFACT_REVIEW"]
+      "enum": [
+        "BOUNDED_CONTEXT",
+        "SOURCE_REFERENCE_ONLY",
+        "ORIGINAL_ARTIFACT_REVIEW"
+      ]
     },
     "candidate_writeback": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "additionalProperties": false,
-      "required": ["candidate_type", "payload_ref"],
+      "required": [
+        "candidate_type",
+        "payload_ref"
+      ],
       "properties": {
-        "candidate_type": {"type": "string", "minLength": 1},
-        "payload_ref": {"type": "string", "minLength": 1},
-        "requested_destination": {"type": ["string", "null"]}
+        "candidate_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "payload_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requested_destination": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "selector": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "directory_id",
+        "canonical_path"
+      ],
+      "properties": {
+        "directory_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_path": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     }
   }

--- a/tests/test_kv_interlock_runtime_endpoint.py
+++ b/tests/test_kv_interlock_runtime_endpoint.py
@@ -256,6 +256,35 @@ class KVInterlockRuntimeTests(unittest.TestCase):
         with self.assertRaisesRegex(self.m.KVInterlockRuntimeError, "only allowed"):
             self.execute(request, envelope)
 
+    def test_request_selector_is_bounded_and_authority_neutral(self):
+        request = self.request()
+        request["selector"] = {
+            "directory_id": "pictures",
+            "canonical_path": "04_Media/Pictures",
+        }
+        response = self.execute(request, self.envelope(request))
+        self.assertEqual(response["decision"], "ALLOW_BOUNDED_CONTEXT")
+        self.assertEqual(request["authority_ref"], "owner-assertion-1")
+
+    def test_selector_rejects_extra_fields(self):
+        request = self.request()
+        request["selector"] = {
+            "directory_id": "pictures",
+            "canonical_path": "04_Media/Pictures",
+            "extra": True,
+        }
+        with self.assertRaisesRegex(self.m.KVInterlockRuntimeError, "selector invalid"):
+            self.execute(request, self.envelope(request))
+
+    def test_selector_is_request_only(self):
+        request = self.request("COMMIT_CANDIDATE")
+        request["selector"] = {
+            "directory_id": "pictures",
+            "canonical_path": "04_Media/Pictures",
+        }
+        with self.assertRaisesRegex(self.m.KVInterlockRuntimeError, "selector only allowed for REQUEST"):
+            self.execute(request, self.envelope(request))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements #166. Adds one optional `selector` to `kv.interlock.request.v1` containing exactly `directory_id` and `canonical_path`. It is accepted only for `REQUEST`, remains authority-neutral, and is still subject to the existing verified InTr admission plus injected authority/policy evaluation.