### PR TITLE
Expose bounded KnowledgeVault installation status

### DIFF
--- a/KV_INSTALLATION_STATUS_PROJECTION_MIRROR_HANDOFF.md
+++ b/KV_INSTALLATION_STATUS_PROJECTION_MIRROR_HANDOFF.md
@@ -1,0 +1,68 @@
+# KnowledgeVault Installation Status Projection Mirror Handoff
+
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Branch: `feat/kv-installation-status-projection-20260831`
+Updated: 2026-08-31T21:11:00-05:00
+State: ACTIVE_IMPLEMENTATION
+Credential authority: TV/TVC
+Authority effect: NONE
+
+## Goal
+
+Expose one bounded read-only projection of the canonical resident KnowledgeVault installation receipt so the existing DEVICE_KV query/return lane can determine whether the current resident KV root is a validated canonical installation.
+
+Canonical path:
+
+```text
+<STEGVERSE_KV_ROOT>/_System/installation.receipt.json
+```
+
+This projection is for My KV onboarding Step 2. It is not Step 5 cloud-provider revalidation.
+
+## Required semantics
+
+A successful projection requires the current resident KV root to contain a canonical installation receipt with:
+
+- `schema_version=1.1`;
+- canonical Continuity Vault Kit source binding;
+- verified source tree SHA;
+- destination ending in `/KnowledgeVault`;
+- full recursive/source-defined file+directory presence;
+- `full_template_parity=VALIDATED`;
+- `authority_effect=NONE`;
+- `activation_effect=false`;
+- non-empty source census.
+
+Returned projection must exclude provider file/folder IDs, credentials, secrets, private file contents, and full destination path.
+
+## Output
+
+```text
+schema=stegverse.kv.installation-status-projection/v1
+state=KV_INSTALLATION_VERIFIED | KV_INSTALLATION_NOT_VERIFIED
+resident_kv_root_observed=true
+installation_receipt_present=true|false
+source_tree_sha=<bounded hash|null>
+receipt_sha256=<content digest|null>
+receipt_verified_utc=<timestamp|null>
+full_template_parity=VALIDATED|null
+source_census=<bounded counts|null>
+destination_kind=<bounded scheme/category|null>
+current_cloud_provider_observation=false
+credential_material_present=false
+provider_operation_authorized=false
+authority_effect=NONE
+```
+
+The projection proves only what is observable from the current resident KV root. It does not claim current provider/session observation, credential authority, mutation authority, or runtime activation.
+
+## Claimed surfaces
+
+- `runtime/portable_directory_projection.py`
+- `tests/test_portable_directory_projection.py`
+- `tools/check_portable_directory_projection.py`
+- this handoff
+
+## Completion boundary
+
+Source implementation, deterministic validation, merge. DEVICE_KV transport exposure and Site Step 2 consumption are separate downstream integrations.

--- a/runtime/portable_directory_projection.py
+++ b/runtime/portable_directory_projection.py
@@ -9,6 +9,84 @@ ADMISSION_SCHEMA="stegverse.kv.portable-direct-source-canonical-admission/v1"
 PROVENANCE_SCHEMA="stegverse.kv.portable-direct-source-provenance/v1"
 HEALTH_SCHEMA="stegverse.kv.portable-direct-source-connection-health/v1"
 
+INSTALLATION_STATUS_SCHEMA="stegverse.kv.installation-status-projection/v1"
+INSTALLATION_RECEIPT_REL=Path("_System/installation.receipt.json")
+
+def _sha256_file(path:Path)->str:
+    import hashlib
+    h=hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda:handle.read(65536),b""):
+            h.update(chunk)
+    return "sha256:"+h.hexdigest()
+
+def _validate_installation_receipt(receipt:dict[str,Any])->dict[str,Any]:
+    _require(receipt.get("schema_version")=="1.1","installation_receipt_schema_invalid")
+    source=receipt.get("source")
+    _require(isinstance(source,str) and "continuity-vault-kit:vault_template/KnowledgeVault" in source,"installation_receipt_source_invalid")
+    tree=receipt.get("current_verified_source_tree_sha")
+    _require(isinstance(tree,str) and len(tree)==40 and all(ch in "0123456789abcdefABCDEF" for ch in tree),"installation_receipt_tree_sha_invalid")
+    destination=receipt.get("destination")
+    _require(isinstance(destination,str) and destination.endswith("/KnowledgeVault"),"installation_receipt_destination_invalid")
+    verification=receipt.get("verification")
+    _require(isinstance(verification,dict),"installation_receipt_verification_missing")
+    _require(verification.get("full_recursive_source_path_presence") is True,"installation_receipt_recursive_presence_invalid")
+    _require(verification.get("source_defined_directories_present") is True,"installation_receipt_directory_presence_invalid")
+    _require(verification.get("source_defined_files_present") is True,"installation_receipt_file_presence_invalid")
+    _require(verification.get("full_template_parity")=="VALIDATED","installation_receipt_template_parity_invalid")
+    _require(receipt.get("authority_effect")=="NONE","installation_receipt_authority_effect_invalid")
+    _require(receipt.get("activation_effect") is False,"installation_receipt_activation_effect_invalid")
+    census=receipt.get("source_census")
+    _require(isinstance(census,dict),"installation_receipt_source_census_missing")
+    _require(isinstance(census.get("files"),int) and census["files"]>0,"installation_receipt_file_census_invalid")
+    _require(isinstance(census.get("directories"),int) and census["directories"]>0,"installation_receipt_directory_census_invalid")
+    return receipt
+
+def get_installation_status(*,kv_data_root:Path)->dict[str,Any]:
+    root=_safe_root(kv_data_root)
+    receipt_path=(root/INSTALLATION_RECEIPT_REL).resolve()
+    _require(root in receipt_path.parents,"installation_receipt_path_escape")
+    if not receipt_path.is_file():
+        return {
+            "schema":INSTALLATION_STATUS_SCHEMA,
+            "state":"KV_INSTALLATION_NOT_VERIFIED",
+            "resident_kv_root_observed":True,
+            "installation_receipt_present":False,
+            "source_tree_sha":None,
+            "receipt_sha256":None,
+            "receipt_verified_utc":None,
+            "full_template_parity":None,
+            "source_census":None,
+            "destination_kind":None,
+            "current_cloud_provider_observation":False,
+            "credential_material_present":False,
+            "provider_operation_authorized":False,
+            "authority_effect":"NONE",
+        }
+    receipt=_validate_installation_receipt(_read_json(receipt_path,"installation_receipt_unreadable"))
+    destination=str(receipt.get("destination") or "")
+    destination_kind=destination.split(":",1)[0] if ":" in destination else "OWNER_CONTROLLED_STORAGE"
+    return {
+        "schema":INSTALLATION_STATUS_SCHEMA,
+        "state":"KV_INSTALLATION_VERIFIED",
+        "resident_kv_root_observed":True,
+        "installation_receipt_present":True,
+        "source_tree_sha":receipt["current_verified_source_tree_sha"],
+        "receipt_sha256":_sha256_file(receipt_path),
+        "receipt_verified_utc":receipt.get("verified_utc"),
+        "full_template_parity":"VALIDATED",
+        "source_census":{
+            "files":receipt["source_census"]["files"],
+            "directories":receipt["source_census"]["directories"],
+        },
+        "destination_kind":destination_kind,
+        "current_cloud_provider_observation":False,
+        "credential_material_present":False,
+        "provider_operation_authorized":False,
+        "authority_effect":"NONE",
+    }
+
+
 class PortableDirectoryProjectionError(ValueError):
     pass
 

--- a/tests/test_portable_directory_projection.py
+++ b/tests/test_portable_directory_projection.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from runtime.portable_directory_projection import (
     PortableDirectoryProjectionError,
     get_directory_health,
+    get_installation_status,
     list_admitted_directory,
 )
 
@@ -61,6 +62,27 @@ def install_batch(root:Path,mid:str="INTR-MAT-"+"a"*24)->Path:
     write_json(batch/"connection-health.json",health)
     return batch
 
+def install_receipt(root:Path,*,authority_effect:str="NONE")->Path:
+    receipt={
+      "schema_version":"1.1",
+      "source":"continuity-vault-kit:vault_template/KnowledgeVault@fixture",
+      "current_verified_source_tree_sha":"a"*40,
+      "destination":"owner-storage:/KnowledgeVault",
+      "verified_utc":"2026-08-31T20:00:00Z",
+      "verification":{
+        "full_recursive_source_path_presence":True,
+        "source_defined_directories_present":True,
+        "source_defined_files_present":True,
+        "full_template_parity":"VALIDATED",
+      },
+      "authority_effect":authority_effect,
+      "activation_effect":False,
+      "source_census":{"files":133,"directories":53},
+    }
+    path=root/"_System/installation.receipt.json"
+    write_json(path,receipt)
+    return path
+
 class PortableDirectoryProjectionTests(unittest.TestCase):
     def test_lists_only_canonical_admitted_metadata(self):
         with tempfile.TemporaryDirectory() as td:
@@ -104,6 +126,44 @@ class PortableDirectoryProjectionTests(unittest.TestCase):
             root=Path(td)/"KnowledgeVault"; (root/"00_Inbox").mkdir(parents=True)
             with self.assertRaises(PortableDirectoryProjectionError):
                 list_admitted_directory(kv_data_root=root,directory_id="pictures",canonical_path="../Pictures")
+
+
+    def test_installation_status_projects_bounded_verified_receipt(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)/"KnowledgeVault"; (root/"00_Inbox").mkdir(parents=True)
+            install_receipt(root)
+            result=get_installation_status(kv_data_root=root)
+            self.assertEqual(result["schema"],"stegverse.kv.installation-status-projection/v1")
+            self.assertEqual(result["state"],"KV_INSTALLATION_VERIFIED")
+            self.assertTrue(result["resident_kv_root_observed"])
+            self.assertTrue(result["installation_receipt_present"])
+            self.assertEqual(result["source_tree_sha"],"a"*40)
+            self.assertTrue(result["receipt_sha256"].startswith("sha256:"))
+            self.assertEqual(result["full_template_parity"],"VALIDATED")
+            self.assertEqual(result["source_census"],{"files":133,"directories":53})
+            self.assertEqual(result["destination_kind"],"owner-storage")
+            self.assertFalse(result["current_cloud_provider_observation"])
+            self.assertFalse(result["credential_material_present"])
+            self.assertFalse(result["provider_operation_authorized"])
+            self.assertEqual(result["authority_effect"],"NONE")
+            self.assertNotIn("destination",result)
+
+    def test_installation_status_missing_receipt_is_explicit_not_verified(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)/"KnowledgeVault"; (root/"00_Inbox").mkdir(parents=True)
+            result=get_installation_status(kv_data_root=root)
+            self.assertEqual(result["state"],"KV_INSTALLATION_NOT_VERIFIED")
+            self.assertTrue(result["resident_kv_root_observed"])
+            self.assertFalse(result["installation_receipt_present"])
+            self.assertIsNone(result["receipt_sha256"])
+            self.assertFalse(result["current_cloud_provider_observation"])
+
+    def test_installation_status_authority_drift_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td)/"KnowledgeVault"; (root/"00_Inbox").mkdir(parents=True)
+            install_receipt(root,authority_effect="WRITE")
+            with self.assertRaisesRegex(PortableDirectoryProjectionError,"authority_effect"):
+                get_installation_status(kv_data_root=root)
 
 if __name__=="__main__":
     unittest.main()

--- a/tools/check_portable_directory_projection.py
+++ b/tools/check_portable_directory_projection.py
@@ -6,6 +6,10 @@ tests=(ROOT/"tests/test_portable_directory_projection.py").read_text()
 for marker in (
     "def list_admitted_directory(",
     "def get_directory_health(",
+    "def get_installation_status(",
+    '"schema":"stegverse.kv.installation-status-projection/v1"',
+    '"state":"KV_INSTALLATION_VERIFIED"',
+    '"current_cloud_provider_observation":False',
     '"state":"KV_LISTED"',
     '"compatibility_state":"VERIFIED"',
     '"provider_operation_authorized":False',
@@ -18,6 +22,9 @@ for marker in (
     "test_staged_only_batch_is_not_listed",
     "test_unassembled_health_is_explicit",
     "test_receipt_authority_drift_fails_closed",
+    "test_installation_status_projects_bounded_verified_receipt",
+    "test_installation_status_missing_receipt_is_explicit_not_verified",
+    "test_installation_status_authority_drift_fails_closed",
 ):
     if marker not in tests:
         raise SystemExit("PORTABLE_DIRECTORY_PROJECTION_TEST_MISSING:"+marker)


### PR DESCRIPTION
Adds a read-only get_installation_status() projection from the canonical resident _System/installation.receipt.json. It validates schema/source/tree/destination/template parity/authority/census and returns only bounded installation status needed by My KV Step 2. It explicitly does not claim current cloud-provider observation, provider authority, credentials, or activation.