### PR TITLE
Add legacy KnowledgeVault upgrade/reinstall test lane

### DIFF
--- a/LEGACY_KV_UPGRADE_MIRROR_HANDOFF.md
+++ b/LEGACY_KV_UPGRADE_MIRROR_HANDOFF.md
@@ -1,0 +1,58 @@
+# Legacy KnowledgeVault Upgrade / Reinstall Test Mirror Handoff
+
+Status: ACTIVE_IMPLEMENTATION / NON_DESTRUCTIVE_PLAN_FIRST  
+Repository: StegVerse-Labs/continuity-vault-kit  
+Issue: #174  
+Branch: feature/legacy-kv-upgrade-test-174  
+Updated: 2026-09-02  
+Authority effect: NONE
+
+## Purpose
+
+Use the owner's older iCloud KnowledgeVault, installed around 2026-05-20, as a bounded test lane for upgrading or reinstalling an older KnowledgeVault against the current continuity-vault-kit.
+
+The current Google Drive KnowledgeVault installed 2026-08-28 remains the current canonical production candidate. The iCloud vault is a test subject and is not automatically authoritative.
+
+## Governing rule
+
+A newer kit must never silently overwrite an existing vault. The test sequence is:
+
+1. inspect the legacy vault manifest, receipt, and format/version metadata;
+2. compare the legacy vault against the current template;
+3. classify source-template matches, required template updates, required additions, and legacy-only content that must be preserved;
+4. emit a deterministic plan without mutation;
+5. preserve a rollback copy before any admitted update/reinstall;
+6. apply only an explicitly admitted migration/update operation;
+7. regenerate installation evidence and verify post-update parity;
+8. require owner acceptance before treating the upgraded test copy as current.
+
+## Initial implementation
+
+`tools/plan_legacy_kv_upgrade.py` produces `stegverse.kv.legacy-upgrade-plan/v1`.
+
+The planner is deliberately non-destructive:
+
+- `mutation_performed=false`;
+- `overwrite_existing_vault=false`;
+- `owner_acceptance_required=true`;
+- `rollback_copy_required=true`;
+- `credential_material_required=false`;
+- `authority_effect=NONE_PLAN_ONLY`.
+
+It excludes the mutable template manifest from ordinary hash-equality decisions, treats the installation receipt as evidence rather than owner content, and preserves vault-only files as `legacy_only_preserve`.
+
+## Current physical test candidate
+
+- provider/location: iCloud
+- approximate installation date: 2026-05-20
+- version: unknown until manifest/format inspection
+- role: legacy upgrade/reinstall test subject
+- canonical production candidate: Google Drive KnowledgeVault installed 2026-08-28
+
+No mutation of either vault has been performed by this lane yet.
+
+## Completion boundary
+
+Source completion requires implementation, tests, exact-head validation, and merge.
+
+Runtime test completion requires an owner-selected copy of the legacy iCloud vault to be inspected, a plan to be produced, a rollback-safe admitted update/reinstall to execute, post-update parity/receipt verification, and owner acceptance. None of those runtime outcomes may be inferred from source merge.

--- a/data/session-work-claims.d/cvk-legacy-kv-upgrade-174-20260902.json
+++ b/data/session-work-claims.d/cvk-legacy-kv-upgrade-174-20260902.json
@@ -1,0 +1,33 @@
+{
+  "schema_version":"1.0.0",
+  "registry_fragment_type":"stegverse_session_work_claim_registry_fragment",
+  "repository":"StegVerse-Labs/continuity-vault-kit",
+  "claims":[{
+    "claim_id":"CVK-LEGACY-KV-UPGRADE-174-20260902",
+    "session_worker_id":"chatgpt:cvk-legacy-kv-upgrade-174-20260902",
+    "task_id":"CVK-LEGACY-KV-UPGRADE-174",
+    "originating_goal":"Use the older iCloud KnowledgeVault as a non-destructive update/reinstall test lane while preserving the newer Google Drive installation as the current canonical production candidate.",
+    "repository":"StegVerse-Labs/continuity-vault-kit",
+    "branch":"feature/legacy-kv-upgrade-test-174",
+    "role":"ACTIVE_IMPLEMENTATION",
+    "state":"CLAIMED_FOR_IMPLEMENTATION",
+    "normalized_work_key":"cvk-legacy-kv-upgrade-174",
+    "dependency_surface_keys":["kv:migration","kv:installation-receipt","kv:template-parity"],
+    "governing_dependency_keys":["kv:migration"],
+    "claimed_paths":["tools/plan_legacy_kv_upgrade.py","tests/test_legacy_kv_upgrade_plan.py","LEGACY_KV_UPGRADE_MIRROR_HANDOFF.md","data/session-work-claims.d/cvk-legacy-kv-upgrade-174-20260902.json"],
+    "handoff":"LEGACY_KV_UPGRADE_MIRROR_HANDOFF.md",
+    "handoff_revision":"PLAN_FIRST_20260902",
+    "claim_created_at":"2026-09-02T13:45:00-05:00",
+    "claim_expires_when":"Release after source validation/merge; keep runtime test open until the legacy iCloud vault is inspected and an admitted rollback-safe upgrade/reinstall is verified.",
+    "expected_evidence":["legacy manifest/version inspected","deterministic no-mutation upgrade plan produced","owner/runtime data preserved","rollback copy required","post-upgrade receipt/parity verified","owner acceptance recorded"],
+    "collision_boundaries":["Do not modify the current Google Drive production candidate","Do not silently overwrite the legacy iCloud vault","Do not treat legacy vault as authoritative automatically","Do not introduce provider credentials or hosted execution authority"],
+    "next_task_after_release":"Run the planner against an owner-selected copy of the legacy iCloud KnowledgeVault and develop the admitted apply/rollback phase from the observed delta.",
+    "credential_authority":"TV/TVC",
+    "credential_requirement":"NONE_FOR_PLAN",
+    "github_token_runtime_authority":"NONE",
+    "non_tv_tvc_secret_or_token_used":false,
+    "authority_effect":false,
+    "activation_effect":false,
+    "archive_eligible":false
+  }]
+}

--- a/tests/test_legacy_kv_upgrade_plan.py
+++ b/tests/test_legacy_kv_upgrade_plan.py
@@ -1,0 +1,47 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+import importlib.util
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("legacy_upgrade", ROOT / "tools" / "plan_legacy_kv_upgrade.py")
+MOD = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MOD)
+
+
+class LegacyUpgradePlanTests(unittest.TestCase):
+    def test_non_destructive_plan_classifies_changes(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = Path(td) / "KnowledgeVault"
+            (vault / "_Meta").mkdir(parents=True)
+            (vault / "_System").mkdir(parents=True)
+            (vault / "00_Inbox").mkdir(parents=True)
+            (vault / "_Meta" / "vault.manifest.json").write_text(json.dumps({"version": "0.0.legacy"}), encoding="utf-8")
+            (vault / "_System" / "installation.receipt.json").write_text(json.dumps({"schema_version": "1.0"}), encoding="utf-8")
+            (vault / "00_Inbox" / "README.md").write_text("legacy different", encoding="utf-8")
+            (vault / "owner-note.txt").write_text("preserve me", encoding="utf-8")
+
+            plan = MOD.build_plan(vault)
+
+            self.assertEqual(plan["schema"], "stegverse.kv.legacy-upgrade-plan/v1")
+            self.assertEqual(plan["state"], "MIGRATION_PLAN_READY")
+            self.assertEqual(plan["source_version"], "0.0.legacy")
+            self.assertFalse(plan["mutation_performed"])
+            self.assertFalse(plan["overwrite_existing_vault"])
+            self.assertTrue(plan["owner_acceptance_required"])
+            self.assertTrue(plan["rollback_copy_required"])
+            self.assertFalse(plan["credential_material_required"])
+            self.assertEqual(plan["authority_effect"], "NONE_PLAN_ONLY")
+            self.assertIn("00_Inbox/README.md", plan["template_updates_required"])
+            self.assertIn("owner-note.txt", plan["legacy_only_preserve"])
+            self.assertTrue(plan["legacy_receipt_present"])
+
+    def test_missing_vault_fails(self):
+        with self.assertRaises(ValueError):
+            MOD.build_plan(Path("/definitely/not/a/real/knowledgevault"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/plan_legacy_kv_upgrade.py
+++ b/tools/plan_legacy_kv_upgrade.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Produce a non-destructive upgrade/reinstall plan for an existing KnowledgeVault."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CURRENT_TEMPLATE = REPO_ROOT / "vault_template" / "KnowledgeVault"
+VERSION_FILE = REPO_ROOT / "VERSION"
+MUTABLE_TEMPLATE_PATHS = {"_Meta/vault.manifest.json"}
+RECEIPT_PATH = "_System/installation.receipt.json"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def inventory(root: Path) -> dict[str, dict[str, object]]:
+    rows: dict[str, dict[str, object]] = {}
+    for p in sorted(x for x in root.rglob("*") if x.is_file()):
+        rel = p.relative_to(root).as_posix()
+        rows[rel] = {"size": p.stat().st_size, "sha256": sha256_file(p)}
+    return rows
+
+
+def read_json(path: Path) -> dict[str, object] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else None
+    except Exception:
+        return None
+
+
+def detect_legacy_version(vault: Path, manifest: dict[str, object] | None) -> str:
+    for key in ("kit_version", "version", "vault_version"):
+        value = manifest.get(key) if manifest else None
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    fmt = vault / "_Meta" / "FORMAT_VERSION.md"
+    if fmt.is_file():
+        text = fmt.read_text(encoding="utf-8", errors="replace").strip()
+        if text:
+            return text
+    return "UNKNOWN"
+
+
+def build_plan(vault: Path) -> dict[str, object]:
+    if not vault.is_dir():
+        raise ValueError(f"legacy vault directory not found: {vault}")
+    if not CURRENT_TEMPLATE.is_dir():
+        raise ValueError(f"current template missing: {CURRENT_TEMPLATE}")
+
+    legacy = inventory(vault)
+    current = inventory(CURRENT_TEMPLATE)
+    manifest = read_json(vault / "_Meta" / "vault.manifest.json")
+    current_version = VERSION_FILE.read_text(encoding="utf-8").strip()
+
+    matches: list[str] = []
+    updates: list[str] = []
+    additions: list[str] = []
+
+    for path, src in current.items():
+        if path in MUTABLE_TEMPLATE_PATHS:
+            continue
+        dst = legacy.get(path)
+        if dst is None:
+            additions.append(path)
+        elif dst["sha256"] == src["sha256"]:
+            matches.append(path)
+        else:
+            updates.append(path)
+
+    preserve = sorted(
+        p for p in legacy
+        if p not in current and p != RECEIPT_PATH
+    )
+
+    receipt = read_json(vault / RECEIPT_PATH)
+
+    return {
+        "schema": "stegverse.kv.legacy-upgrade-plan/v1",
+        "state": "MIGRATION_PLAN_READY",
+        "source_vault": str(vault),
+        "source_version": detect_legacy_version(vault, manifest),
+        "target_version": current_version,
+        "current_template_root": "vault_template/KnowledgeVault",
+        "counts": {
+            "legacy_files": len(legacy),
+            "current_template_files": len(current),
+            "template_matches": len(matches),
+            "template_updates_required": len(updates),
+            "template_additions_required": len(additions),
+            "legacy_only_preserve": len(preserve),
+        },
+        "template_matches": matches,
+        "template_updates_required": updates,
+        "template_additions_required": additions,
+        "legacy_only_preserve": preserve,
+        "legacy_receipt_present": RECEIPT_PATH in legacy,
+        "legacy_receipt_schema_version": receipt.get("schema_version") if receipt else None,
+        "legacy_receipt_source_tree_sha": receipt.get("current_verified_source_tree_sha") if receipt else None,
+        "mutation_performed": False,
+        "overwrite_existing_vault": False,
+        "owner_acceptance_required": True,
+        "rollback_copy_required": True,
+        "credential_material_required": False,
+        "authority_effect": "NONE_PLAN_ONLY",
+        "next_action": "Review this plan, preserve a rollback copy, then apply only an explicitly admitted upgrade/reinstall operation.",
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("legacy_vault", type=Path)
+    ap.add_argument("--output", type=Path)
+    args = ap.parse_args()
+
+    try:
+        plan = build_plan(args.legacy_vault.expanduser().resolve())
+    except Exception as exc:
+        print(f"LEGACY_KV_UPGRADE_PLAN_FAIL: {exc}")
+        return 2
+
+    text = json.dumps(plan, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements issue #174. Adds a non-destructive legacy-KV upgrade planner and canonical mirror handoff for using the older iCloud KnowledgeVault as an update/reinstall test subject while preserving the newer 2026-08-28 Google Drive KnowledgeVault as the current production candidate. The planner inventories legacy/current template files, classifies matches/updates/additions/legacy-only preserve content, records receipt/version metadata, requires rollback + owner acceptance, and performs no mutation.