### PR TITLE
Bind KV recovery to merged shared HB runtime observability

### DIFF
--- a/KV_CROSS_PLATFORM_RECOVERY_MIRROR_HANDOFF.md
+++ b/KV_CROSS_PLATFORM_RECOVERY_MIRROR_HANDOFF.md
@@ -135,3 +135,40 @@ PR #176 exact head `ad7c146990df95c3eb75a461522ec44b3e0b2e10` passed:
 Merged as `40976e8ac4e9621360c036f2a2c35a48eb593776`.
 
 These runs validate source behavior only. Runtime recovery, provider interaction, physical-device observation, key provisioning, live Interlock/InTr, and production activation remain unobserved.
+
+
+## Shared HB / InTr runtime-observability binding — 2026-09-02
+
+This recovery lane is a consumer of the shared organization runtime-observability contract:
+
+`StegVerse-Labs/.github/docs/HB_RUNTIME_PRESENCE_RESIDENT_OBSERVABILITY_MIRROR_HANDOFF.md`
+
+The recovery lane does not own a separate heartbeat, runtime-presence signal, scheduler, resident executor, or liveness mechanism.
+
+Canonical observation chain for the eventual live recovery:
+
+```text
+shared HB runtime/reference
+-> resident/node freshness observation
+-> governed recovery/DEVICE_KV request
+-> Interlock admission
+-> InTr packet
+-> DEVICE_KV/resident consumption
+-> recovery state transition
+-> authentic receipt
+-> retained evidence
+-> reconstruction
+```
+
+Distinct predicates remain independent:
+- resident alive/current;
+- provider session active under TV/TVC;
+- recovery request consumed;
+- replacement-device enrollment observed;
+- Interlock/InTr transition observed;
+- key provisioning/rewrap observed;
+- final recovery receipt retained;
+- reconstruction passed;
+- physical-device observations complete.
+
+HB progression or HB-derived carrier publication cannot satisfy any execution/transition predicate.

--- a/PERSONAL_KV_PROVIDER_BINDING_MIRROR_HANDOFF.md
+++ b/PERSONAL_KV_PROVIDER_BINDING_MIRROR_HANDOFF.md
@@ -105,3 +105,29 @@ provider-binding source validation: PASS
 runtime provider session observed: false
 activation inferred: false
 ```
+
+
+## Shared HB / InTr runtime-observability binding — 2026-09-02
+
+Canonical shared observability owner:
+
+`StegVerse-Labs/.github/docs/HB_RUNTIME_PRESENCE_RESIDENT_OBSERVABILITY_MIRROR_HANDOFF.md`
+
+This provider-binding lane consumes the existing shared runtime projection instead of creating any Personal-KV-specific heartbeat/liveness signal.
+
+Exact unresolved runtime predicate chain:
+
+```text
+TVC-owned provider session active
+-> exact provider-root materialization observed
+-> authentic node-origin MY_KV_INSTALLATION_STATUS request
+-> DEVICE_KV receiver consumption observed
+-> HB-derived KV->DEVICE return recovered exactly
+-> retained device-kv-query-response receipt
+-> Site readback/sync observation
+-> reconstruction evidence
+```
+
+Runtime presence/freshness is observation only. HB and HB-derived carriers grant no provider, credential, admission, execution, routing, transition, receiving, custody, publication, or consequence authority.
+
+Current exact external blocker remains the TVC credential lane. Until the authoritative TVC credential-model consistency handoff admits and activates the provider-specific ephemeral Google Drive session on an eligible resident, the downstream provider materialization and DEVICE_KV runtime observations must remain unobserved.


### PR DESCRIPTION
Superseded after main advanced again between mergeability inspection and merge. The two handoff-only bindings were applied directly to current main at commits 869ef5066228e196ca72fda2d2f215ef58f37ff4 and 8671bb6ba5947b47bf28179c67b014d99dc35069.