### PR TITLE
Complete KV provider relocation contract for #177

### DIFF
--- a/.github/workflows/kv-cross-platform-recovery.yml
+++ b/.github/workflows/kv-cross-platform-recovery.yml
@@ -6,14 +6,19 @@ on:
     paths:
       - "schemas/kv-cross-platform-recovery-*.json"
       - "schemas/kv-physical-recovery-evidence.schema.json"
+      - "schemas/kv-provider-relocation-*.json"
       - "runtime/cross_platform_recovery.py"
       - "runtime/physical_recovery_evidence.py"
+      - "runtime/provider_relocation.py"
       - "fixtures/kv_cross_platform_recovery_cases.json"
       - "tests/test_cross_platform_recovery.py"
       - "tests/test_physical_recovery_evidence.py"
+      - "tests/test_provider_relocation.py"
       - "tools/run_cross_platform_recovery_probe.py"
       - "tools/run_physical_recovery_reconstruction.py"
+      - "tools/run_provider_relocation_probe.py"
       - "KV_CROSS_PLATFORM_RECOVERY_MIRROR_HANDOFF.md"
+      - "KV_PROVIDER_RELOCATION_MIRROR_HANDOFF.md"
       - ".github/workflows/kv-cross-platform-recovery.yml"
   pull_request:
     paths:
@@ -45,18 +50,23 @@ jobs:
         run: |
           python -m py_compile runtime/cross_platform_recovery.py
           python -m py_compile runtime/physical_recovery_evidence.py
+          python -m py_compile runtime/provider_relocation.py
           python -m py_compile tests/test_cross_platform_recovery.py
           python -m py_compile tests/test_physical_recovery_evidence.py
+          python -m py_compile tests/test_provider_relocation.py
           python -m py_compile tools/run_cross_platform_recovery_probe.py
           python -m py_compile tools/run_physical_recovery_reconstruction.py
+          python -m py_compile tools/run_provider_relocation_probe.py
       - name: Run recovery tests
         run: |
           python -m unittest tests.test_cross_platform_recovery -v
           python -m unittest tests.test_physical_recovery_evidence -v
+          python -m unittest tests.test_provider_relocation -v
       - name: Emit deterministic recovery receipt
         run: |
           mkdir -p recovery-evidence
           python tools/run_cross_platform_recovery_probe.py > recovery-evidence/kv-cross-platform-recovery.receipt.json
+          python tools/run_provider_relocation_probe.py > recovery-evidence/kv-provider-relocation.receipt.json
       - uses: actions/upload-artifact@v4
         with:
           name: kv-cross-platform-recovery-evidence

--- a/KV_PROVIDER_RELOCATION_MIRROR_HANDOFF.md
+++ b/KV_PROVIDER_RELOCATION_MIRROR_HANDOFF.md
@@ -1,0 +1,68 @@
+# KV Provider Relocation Mirror Handoff
+
+Status: SOURCE_IMPLEMENTED_VALIDATION_PENDING
+Repository: StegVerse-Labs/continuity-vault-kit
+Issue: #177
+Branch: feature/kv-provider-relocation-177-v2
+Authority effect: NONE
+Credential authority: TV/TVC
+
+## Goal
+
+Prove a KnowledgeVault storage-provider relocation without transferring KV, device, credential, execution, recovery, governance, or continuity authority to either provider.
+
+Initial deterministic case:
+
+`iCloud -> Google Drive`
+
+## Canonical invariants
+
+- provider access != KV authority;
+- storage relocation != device enrollment;
+- KV identity persists across provider change;
+- continuity root is preserved or advances only through an explicit governed transition;
+- Interlock/InTr binds the relocation transition;
+- TV/TVC remains credential authority;
+- provider credentials are never exported through the relocation evidence contract;
+- source/CI/merge do not prove a live provider migration.
+
+## Installed source on branch
+
+- `schemas/kv-provider-relocation-request.schema.json`
+- `schemas/kv-provider-relocation-evidence.schema.json`
+- `schemas/kv-provider-relocation-receipt.schema.json`
+- `runtime/provider_relocation.py`
+- `tests/test_provider_relocation.py`
+- `tools/run_provider_relocation_probe.py`
+
+The deterministic path returns `ALLOW_WITH_SIGNOFF` because source validation cannot prove provider execution.
+
+A supplied observation evidence bundle may return `ALLOW` only when:
+- provider authority remains false;
+- provider credentials were not exported;
+- InTr packet/receipt references exist;
+- continuity receipt reference exists;
+- source and destination exact-byte readback hashes match.
+
+Missing or contradictory evidence fails closed or escalates.
+
+## Shared HB / InTr runtime binding
+
+Provider relocation is a consumer of:
+`StegVerse-Labs/.github/docs/HB_RUNTIME_PRESENCE_RESIDENT_OBSERVABILITY_MIRROR_HANDOFF.md`
+
+No provider-relocation-specific heartbeat, resident scheduler, liveness signal, credential broker, or execution authority is introduced.
+
+A future live relocation must independently observe its provider operation, governed InTr transition, exact readback, continuity receipt, retained evidence, and reconstruction. HB provides synchronization/freshness only.
+
+## Current state
+
+```text
+source implementation: IMPLEMENTED_ON_BRANCH
+hosted validation: PENDING
+merged: NO
+live iCloud -> Google Drive migration: NOT OBSERVED
+provider credential/session activation: NOT OBSERVED
+runtime activation: NOT CLAIMED
+authority_effect: NONE
+```

--- a/runtime/provider_relocation.py
+++ b/runtime/provider_relocation.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+OUTCOMES={"ALLOW","ALLOW_WITH_SIGNOFF","DENY","FAIL_CLOSED","REDIRECT","ESCALATE"}
+
+def _hash(value: dict[str, Any]) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+def evaluate(request: dict[str, Any], evidence: dict[str, Any] | None = None) -> dict[str, Any]:
+    src=request["source_provider"]
+    dst=request["destination_provider"]
+    decision="ALLOW_WITH_SIGNOFF"
+    reason="provider relocation admissible with governed continuity signoff"
+    exact_readback_match=False
+
+    if src == dst:
+        decision,reason="REDIRECT","source and destination providers are identical"
+    elif request["authority"]["source_provider_is_kv_authority"] or request["authority"]["destination_provider_is_kv_authority"]:
+        decision,reason="FAIL_CLOSED","storage provider may not become KV authority"
+    elif request["authority"]["credential_authority"] != "TV/TVC":
+        decision,reason="FAIL_CLOSED","credential authority must remain TV/TVC"
+    elif not request["kv_identity_preserved"]:
+        decision,reason="FAIL_CLOSED","KV identity continuity must be preserved"
+    elif request["continuity_transition"]=="PRESERVED" and request["source_continuity_root"] != request["destination_continuity_root"]:
+        decision,reason="ESCALATE","preserved continuity transition requires identical roots"
+    elif request["continuity_transition"]=="GOVERNED_ADVANCE" and request["source_continuity_root"] == request["destination_continuity_root"]:
+        decision,reason="ESCALATE","governed advance requires a changed continuity root"
+    elif not request["transport"]["interlock_verified"] or not request["transport"]["intr_bound"]:
+        decision,reason="FAIL_CLOSED","verified Interlock/InTr binding is required"
+    elif evidence is None:
+        decision,reason="ALLOW_WITH_SIGNOFF","deterministic relocation admissible; live provider evidence still required"
+    else:
+        required_refs=("intr_packet_ref","intr_receipt_ref","continuity_receipt_ref")
+        if evidence.get("relocation_id") != request["relocation_id"]:
+            decision,reason="FAIL_CLOSED","evidence relocation id mismatch"
+        elif evidence.get("provider_credentials_exported") is not False or evidence.get("provider_authority_transferred") is not False:
+            decision,reason="FAIL_CLOSED","provider credentials/authority may not transfer"
+        elif any(not evidence.get(k) for k in required_refs):
+            decision,reason="FAIL_CLOSED","required relocation evidence reference missing"
+        else:
+            exact_readback_match=evidence.get("source_readback_sha256")==evidence.get("destination_readback_sha256")
+            if not exact_readback_match:
+                decision,reason="FAIL_CLOSED","destination exact-byte readback differs from source"
+            else:
+                decision,reason="ALLOW","observed relocation evidence reconstructs exactly"
+
+    core={
+        "schema":"stegverse.kv.provider-relocation-receipt/v1",
+        "relocation_id":request["relocation_id"],
+        "decision":decision,
+        "kv_id":request["kv_id"],
+        "source_provider":src,
+        "destination_provider":dst,
+        "kv_identity_preserved":request["kv_identity_preserved"] if decision in {"ALLOW","ALLOW_WITH_SIGNOFF"} else False,
+        "continuity_transition":request["continuity_transition"],
+        "exact_readback_match":exact_readback_match,
+        "transport_protocol":"InTr",
+        "source_provider_is_kv_authority":False,
+        "destination_provider_is_kv_authority":False,
+        "credential_authority":"TV/TVC",
+        "authority_effect":"NONE",
+        "reason":reason,
+    }
+    core["receipt_sha256"]=_hash(core)
+    return core

--- a/schemas/kv-provider-relocation-evidence.schema.json
+++ b/schemas/kv-provider-relocation-evidence.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/kv-provider-relocation-evidence.schema.json",
+  "title":"KnowledgeVault Provider Relocation Evidence",
+  "type":"object",
+  "additionalProperties":false,
+  "required":["schema","relocation_id","request_sha256","source_readback_sha256","destination_readback_sha256","intr_packet_ref","intr_receipt_ref","continuity_receipt_ref","provider_credentials_exported","provider_authority_transferred"],
+  "properties":{
+    "schema":{"const":"stegverse.kv.provider-relocation-evidence/v1"},
+    "relocation_id":{"type":"string","minLength":1},
+    "request_sha256":{"pattern":"^[a-f0-9]{64}$"},
+    "source_readback_sha256":{"pattern":"^[a-f0-9]{64}$"},
+    "destination_readback_sha256":{"pattern":"^[a-f0-9]{64}$"},
+    "intr_packet_ref":{"type":"string","minLength":1},
+    "intr_receipt_ref":{"type":"string","minLength":1},
+    "continuity_receipt_ref":{"type":"string","minLength":1},
+    "provider_credentials_exported":{"const":false},
+    "provider_authority_transferred":{"const":false}
+  }
+}

--- a/schemas/kv-provider-relocation-receipt.schema.json
+++ b/schemas/kv-provider-relocation-receipt.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/kv-provider-relocation-receipt.schema.json",
+  "title":"KnowledgeVault Provider Relocation Receipt",
+  "type":"object",
+  "additionalProperties":false,
+  "required":["schema","relocation_id","decision","kv_id","source_provider","destination_provider","kv_identity_preserved","continuity_transition","exact_readback_match","transport_protocol","source_provider_is_kv_authority","destination_provider_is_kv_authority","credential_authority","authority_effect","receipt_sha256"],
+  "properties":{
+    "schema":{"const":"stegverse.kv.provider-relocation-receipt/v1"},
+    "relocation_id":{"type":"string","minLength":1},
+    "decision":{"enum":["ALLOW","ALLOW_WITH_SIGNOFF","DENY","FAIL_CLOSED","REDIRECT","ESCALATE"]},
+    "kv_id":{"type":"string","minLength":1},
+    "source_provider":{"type":"string","minLength":1},
+    "destination_provider":{"type":"string","minLength":1},
+    "kv_identity_preserved":{"type":"boolean"},
+    "continuity_transition":{"enum":["PRESERVED","GOVERNED_ADVANCE"]},
+    "exact_readback_match":{"type":"boolean"},
+    "transport_protocol":{"const":"InTr"},
+    "source_provider_is_kv_authority":{"const":false},
+    "destination_provider_is_kv_authority":{"const":false},
+    "credential_authority":{"const":"TV/TVC"},
+    "authority_effect":{"const":"NONE"},
+    "reason":{"type":"string","minLength":1},
+    "receipt_sha256":{"pattern":"^[a-f0-9]{64}$"}
+  }
+}

--- a/schemas/kv-provider-relocation-request.schema.json
+++ b/schemas/kv-provider-relocation-request.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/kv-provider-relocation-request.schema.json",
+  "title":"KnowledgeVault Provider Relocation Request",
+  "type":"object",
+  "additionalProperties":false,
+  "required":["schema","relocation_id","kv_id","source_provider","destination_provider","source_continuity_root","destination_continuity_root","kv_identity_preserved","continuity_transition","transport","authority"],
+  "properties":{
+    "schema":{"const":"stegverse.kv.provider-relocation-request/v1"},
+    "relocation_id":{"type":"string","minLength":1},
+    "kv_id":{"type":"string","minLength":1},
+    "source_provider":{"type":"string","minLength":1},
+    "destination_provider":{"type":"string","minLength":1},
+    "source_continuity_root":{"pattern":"^[a-f0-9]{64}$"},
+    "destination_continuity_root":{"pattern":"^[a-f0-9]{64}$"},
+    "kv_identity_preserved":{"type":"boolean"},
+    "continuity_transition":{"enum":["PRESERVED","GOVERNED_ADVANCE"]},
+    "transport":{"type":"object","additionalProperties":false,"required":["protocol","interlock_verified","intr_bound"],"properties":{
+      "protocol":{"const":"InTr"},
+      "interlock_verified":{"type":"boolean"},
+      "intr_bound":{"type":"boolean"}
+    }},
+    "authority":{"type":"object","additionalProperties":false,"required":["source_provider_is_kv_authority","destination_provider_is_kv_authority","credential_authority"],"properties":{
+      "source_provider_is_kv_authority":{"const":false},
+      "destination_provider_is_kv_authority":{"const":false},
+      "credential_authority":{"const":"TV/TVC"}
+    }}
+  }
+}

--- a/tests/test_provider_relocation.py
+++ b/tests/test_provider_relocation.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+ROOT=Path(__file__).resolve().parents[1]
+sys.path.insert(0,str(ROOT/"runtime"))
+from provider_relocation import evaluate  # noqa: E402
+
+REQUEST={
+ "schema":"stegverse.kv.provider-relocation-request/v1",
+ "relocation_id":"relocate-001",
+ "kv_id":"kv-test",
+ "source_provider":"iCloud",
+ "destination_provider":"Google Drive",
+ "source_continuity_root":"a"*64,
+ "destination_continuity_root":"a"*64,
+ "kv_identity_preserved":True,
+ "continuity_transition":"PRESERVED",
+ "transport":{"protocol":"InTr","interlock_verified":True,"intr_bound":True},
+ "authority":{"source_provider_is_kv_authority":False,"destination_provider_is_kv_authority":False,"credential_authority":"TV/TVC"}
+}
+EVIDENCE={
+ "schema":"stegverse.kv.provider-relocation-evidence/v1",
+ "relocation_id":"relocate-001",
+ "request_sha256":"1"*64,
+ "source_readback_sha256":"2"*64,
+ "destination_readback_sha256":"2"*64,
+ "intr_packet_ref":"intr:packet:1",
+ "intr_receipt_ref":"intr:receipt:1",
+ "continuity_receipt_ref":"continuity:receipt:1",
+ "provider_credentials_exported":False,
+ "provider_authority_transferred":False
+}
+
+class ProviderRelocationTests(unittest.TestCase):
+ def test_deterministic_path_requires_signoff(self):
+  r=evaluate(copy.deepcopy(REQUEST))
+  self.assertEqual(r["decision"],"ALLOW_WITH_SIGNOFF")
+  self.assertFalse(r["exact_readback_match"])
+
+ def test_observed_exact_relocation_allows(self):
+  r=evaluate(copy.deepcopy(REQUEST),copy.deepcopy(EVIDENCE))
+  self.assertEqual(r["decision"],"ALLOW")
+  self.assertTrue(r["exact_readback_match"])
+  self.assertEqual(r["authority_effect"],"NONE")
+
+ def test_provider_authority_fails_closed(self):
+  x=copy.deepcopy(REQUEST);x["authority"]["destination_provider_is_kv_authority"]=True
+  self.assertEqual(evaluate(x)["decision"],"FAIL_CLOSED")
+
+ def test_missing_intr_fails_closed(self):
+  x=copy.deepcopy(REQUEST);x["transport"]["intr_bound"]=False
+  self.assertEqual(evaluate(x)["decision"],"FAIL_CLOSED")
+
+ def test_preserved_root_drift_escalates(self):
+  x=copy.deepcopy(REQUEST);x["destination_continuity_root"]="b"*64
+  self.assertEqual(evaluate(x)["decision"],"ESCALATE")
+
+ def test_readback_mismatch_fails_closed(self):
+  e=copy.deepcopy(EVIDENCE);e["destination_readback_sha256"]="3"*64
+  self.assertEqual(evaluate(copy.deepcopy(REQUEST),e)["decision"],"FAIL_CLOSED")
+
+if __name__=="__main__": unittest.main()

--- a/tools/run_provider_relocation_probe.py
+++ b/tools/run_provider_relocation_probe.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import sys
+from pathlib import Path
+
+ROOT=Path(__file__).resolve().parents[1]
+sys.path.insert(0,str(ROOT/"runtime"))
+from provider_relocation import evaluate  # noqa: E402
+
+request={
+ "schema":"stegverse.kv.provider-relocation-request/v1",
+ "relocation_id":"probe-icloud-google-drive",
+ "kv_id":"kv-probe",
+ "source_provider":"iCloud",
+ "destination_provider":"Google Drive",
+ "source_continuity_root":"a"*64,
+ "destination_continuity_root":"a"*64,
+ "kv_identity_preserved":True,
+ "continuity_transition":"PRESERVED",
+ "transport":{"protocol":"InTr","interlock_verified":True,"intr_bound":True},
+ "authority":{"source_provider_is_kv_authority":False,"destination_provider_is_kv_authority":False,"credential_authority":"TV/TVC"}
+}
+print(json.dumps(evaluate(request),indent=2,sort_keys=True))


### PR DESCRIPTION
Current-main completion of provider-relocation issue #177, superseding stale PR #178.

Adds:
- request, evidence, and receipt schemas;
- fail-closed provider relocation evaluator/reconstruction;
- iCloud -> Google Drive deterministic case;
- exact-readback and continuity checks;
- TV/TVC-only credential authority and provider non-authority invariants;
- tests and probe;
- canonical handoff;
- validation folded into the existing KV Cross-Platform Recovery workflow.

No live provider migration, provider credential/session activation, runtime observation, or authority transfer is claimed.