### PR TITLE
Retire Personal-KV bearer-token handling for TVC broker materialization

### DIFF
--- a/PERSONAL_KV_PROVIDER_BINDING_MIRROR_HANDOFF.md
+++ b/PERSONAL_KV_PROVIDER_BINDING_MIRROR_HANDOFF.md
@@ -208,3 +208,47 @@ provider session observed: false
 ```
 
 Therefore no Personal-KV consumer/runtime source change is authorized yet. The next lawful change must originate from the explicit TVC #293 admit/reuse/deny/defer decision.
+
+
+## TVC broker materialization boundary — 2026-09-03
+
+The previously inactive bearer-token consumer path is retired.
+
+Upstream canonical source now exists:
+
+```text
+TVC exact-class admission:
+  28f9beb222c84dda3dd411fed6fc4ae64a19bebe
+
+TVC lease/broker contract:
+  2c0a758852b5c28190e507bdc8a8b5e2ac0141c5
+
+existing non-exportable broker Google Drive extension:
+  StegVerse-Labs/stegfin-governance 17930b3b22584248992f5f53d35199bef043b1d4
+
+TVC owner-session lifecycle core:
+  4c42636b346a9ea0fafbdf8f6696239ba339b819
+```
+
+CVK now owns only secret-free materialization verification:
+
+```text
+TVC exact lease
+-> existing non-exportable vault broker
+-> bounded Google Drive read
+-> secret-free broker result
+-> CVK verifies binding/scope/path/hash/size
+-> exact-byte temporary KV root write/readback
+```
+
+Retired from CVK:
+- bearer-token/session-file reads;
+- Authorization header construction;
+- direct Google Drive HTTP execution;
+- token-permission tests.
+
+The binding credential reference class is now
+`TVC_NONSECRET_PROVIDER_MATERIALIZATION_BROKER`.
+
+No source/validation/merge proves a live TVC session, provider read, DEVICE_KV consumption,
+HB-derived return, Site readback, reconstruction, or physical recovery.

--- a/runtime/personal_provider_binding.py
+++ b/runtime/personal_provider_binding.py
@@ -1,31 +1,28 @@
-"""Provider-neutral Personal KnowledgeVault binding and minimal Google Drive materialization.
+"""Provider-neutral Personal KnowledgeVault binding and secret-free TVC broker materialization.
 
-This module never owns credentials. A Google Drive bearer token may only be supplied by
-a TV/TVC-owned ephemeral session file at runtime. The token is read for request use and
-is never copied into the KnowledgeVault, receipts, logs, or materialized files.
+Credential-bearing Google Drive processing occurs only inside the TV/TVC-owned
+non-exportable provider broker. This module accepts no bearer token, refresh
+token, provider credential file, or Authorization header.
 """
 from __future__ import annotations
 
+import base64
 import hashlib
-import json
 import os
 import re
-import stat
 import tempfile
-import urllib.parse
-import urllib.request
 from pathlib import Path
 from typing import Any, Iterable
 
 BINDING_SCHEMA="stegverse.kv.personal-provider-binding/v1"
+BROKER_RESULT_SCHEMA="stegverse.tvc.google-drive-personal-kv-materialization/v1"
 ALLOWED_SCOPES={
     "_System/installation.receipt.json",
     "_System/Workspace/**",
     "_Entities/Self/Personal_Contact_Profile.json",
     "_Entities/Self/Personal_Form_Profile.json",
 }
-GOOGLE_DRIVE_API="https://www.googleapis.com/drive/v3/files"
-GOOGLE_FOLDER_MIME="application/vnd.google-apps.folder"
+CREDENTIAL_REFERENCE_CLASS="TVC_NONSECRET_PROVIDER_MATERIALIZATION_BROKER"
 
 class PersonalProviderBindingError(ValueError): pass
 
@@ -53,7 +50,7 @@ def validate_binding(value:dict[str,Any])->dict[str,Any]:
     _require(isinstance(scope,list) and scope and len(scope)==len(set(scope)),"binding_scope_invalid")
     _require(set(scope).issubset(ALLOWED_SCOPES),"binding_scope_expansion")
     _require(value["credential_authority"]=="TV/TVC","binding_credential_authority_invalid")
-    _require(value["credential_reference_class"]=="TVC_EPHEMERAL_PROVIDER_SESSION","binding_credential_reference_invalid")
+    _require(value["credential_reference_class"]==CREDENTIAL_REFERENCE_CLASS,"binding_credential_reference_invalid")
     _require(value["compatibility_state"] in {"ASSEMBLED_UNVERIFIED","VERIFIED","BLOCKED_SESSION","BLOCKED_RUNTIME","REVALIDATION_REQUIRED"},"binding_compatibility_state_invalid")
     _require(value["credential_material_present"] is False,"binding_credential_material_prohibited")
     _require(value["provider_operation_authorized"] is False,"binding_provider_authority_prohibited")
@@ -76,7 +73,7 @@ def build_binding(*,root_folder_id:str,compatibility_state:str="ASSEMBLED_UNVERI
         "canonical_root_name":"KnowledgeVault",
         "materialization_scope":scope,
         "credential_authority":"TV/TVC",
-        "credential_reference_class":"TVC_EPHEMERAL_PROVIDER_SESSION",
+        "credential_reference_class":CREDENTIAL_REFERENCE_CLASS,
         "compatibility_state":compatibility_state,
         "last_connection_proof_ref":None,
         "last_readback_proof_ref":None,
@@ -86,58 +83,6 @@ def build_binding(*,root_folder_id:str,compatibility_state:str="ASSEMBLED_UNVERI
         "activation_effect":False,
     }
     return validate_binding(value)
-
-def _read_tvc_bearer(token_file:Path)->str:
-    path=token_file.expanduser().resolve()
-    _require(path.is_file(),"tvc_provider_session_file_missing")
-    mode=stat.S_IMODE(path.stat().st_mode)
-    _require(mode & 0o077 == 0,"tvc_provider_session_file_permissions_too_broad")
-    token=path.read_text(encoding="utf-8").strip()
-    _require(bool(token) and len(token)<=8192,"tvc_provider_session_token_invalid")
-    return token
-
-def _drive_json(url:str,token:str)->dict[str,Any]:
-    request=urllib.request.Request(url,headers={"Authorization":"Bearer "+token,"Accept":"application/json"})
-    with urllib.request.urlopen(request,timeout=20) as response:
-        payload=response.read()
-    result=json.loads(payload.decode("utf-8"))
-    _require(isinstance(result,dict),"google_drive_response_invalid")
-    return result
-
-def _drive_bytes(file_id:str,token:str)->bytes:
-    url=GOOGLE_DRIVE_API+"/"+urllib.parse.quote(file_id,safe="")+"?alt=media"
-    request=urllib.request.Request(url,headers={"Authorization":"Bearer "+token})
-    with urllib.request.urlopen(request,timeout=30) as response:
-        return response.read()
-
-def _children(parent_id:str,token:str)->list[dict[str,Any]]:
-    items=[];page_token=None
-    while True:
-        params={
-            "q":f"'{parent_id}' in parents and trashed = false",
-            "fields":"nextPageToken,files(id,name,mimeType,size,modifiedTime)",
-            "pageSize":"1000",
-            "spaces":"drive",
-        }
-        if page_token: params["pageToken"]=page_token
-        result=_drive_json(GOOGLE_DRIVE_API+"?"+urllib.parse.urlencode(params),token)
-        files=result.get("files",[])
-        _require(isinstance(files,list),"google_drive_children_invalid")
-        items.extend(files)
-        page_token=result.get("nextPageToken")
-        if not page_token: return items
-
-def _child_named(parent_id:str,name:str,token:str)->dict[str,Any]:
-    matches=[item for item in _children(parent_id,token) if item.get("name")==name]
-    _require(len(matches)==1,"google_drive_path_component_not_unique:"+name)
-    return matches[0]
-
-def _resolve_path(root_id:str,path:str,token:str)->dict[str,Any]:
-    current={"id":root_id,"name":"KnowledgeVault","mimeType":GOOGLE_FOLDER_MIME}
-    for part in [p for p in path.split("/") if p]:
-        _require(current.get("mimeType")==GOOGLE_FOLDER_MIME,"google_drive_nonfolder_in_path:"+part)
-        current=_child_named(current["id"],part,token)
-    return current
 
 def _safe_destination(root:Path,relative:str)->Path:
     _require(".." not in Path(relative).parts and not Path(relative).is_absolute(),"materialization_path_escape")
@@ -154,48 +99,76 @@ def _write_exact(root:Path,relative:str,data:bytes)->dict[str,Any]:
     _require(readback==data,"materialization_exact_readback_failed")
     return {"path":relative,"sha256":"sha256:"+hashlib.sha256(data).hexdigest(),"size_bytes":len(data)}
 
-def materialize_google_drive_scope(*,binding:dict[str,Any],token_file:Path,destination_root:Path)->dict[str,Any]:
+def _path_admitted(path:str,scope:list[str])->bool:
+    if path in scope:
+        return True
+    if "_System/Workspace/**" in scope and re.fullmatch(r"_System/Workspace/[A-Za-z0-9._-]+",path):
+        return True
+    return False
+
+def validate_broker_materialization(*,binding:dict[str,Any],broker_response:dict[str,Any])->dict[str,Any]:
     b=validate_binding(binding)
-    token=_read_tvc_bearer(token_file)
-    root_id=b["root_locator"]["value"]
+    _require(isinstance(broker_response,dict),"broker_response_object_required")
+    _require(broker_response.get("decision")=="ALLOW_OPERATION_RESULT","broker_result_not_allowed")
+    result=broker_response.get("result");receipt=broker_response.get("use_receipt")
+    _require(isinstance(result,dict) and isinstance(receipt,dict),"broker_result_receipt_required")
+    _require(result.get("schema")==BROKER_RESULT_SCHEMA,"broker_result_schema_invalid")
+    _require(result.get("provider")=="GOOGLE_DRIVE","broker_result_provider_invalid")
+    _require(result.get("binding_id")==b["binding_id"],"broker_result_binding_mismatch")
+    _require(result.get("read_only") is True and result.get("provider_mutation_performed") is False,"broker_result_not_read_only")
+    _require(result.get("credential_material_returned") is False,"broker_result_credential_material_prohibited")
+    _require(result.get("credential_authority")=="TV/TVC","broker_result_credential_authority_invalid")
+    _require(result.get("authority_effect")=="NONE","broker_result_authority_invalid")
+    _require(receipt.get("provider")=="google_drive" and receipt.get("operation")=="personal_kv_materialize","broker_use_receipt_operation_invalid")
+    for key in ("secret_material_returned","secret_material_logged","secret_material_retained","wallet_contacted","signed","broadcast"):
+        _require(receipt.get(key) is False,"broker_use_receipt_boundary_invalid:"+key)
+    _require(receipt.get("single_use_consumed") is True,"broker_use_receipt_single_use_missing")
+    records=result.get("records")
+    _require(isinstance(records,list),"broker_result_records_invalid")
+    seen=set();validated=[]
+    for row in records:
+        _require(isinstance(row,dict),"broker_record_object_required")
+        path=row.get("canonical_path")
+        _require(isinstance(path,str) and _path_admitted(path,b["materialization_scope"]),"broker_record_path_not_admitted")
+        _require(path not in seen,"broker_record_duplicate_path");seen.add(path)
+        file_id=row.get("provider_file_id");encoded=row.get("content_base64");claimed_hash=row.get("sha256");size=row.get("size_bytes")
+        _require(isinstance(file_id,str) and bool(file_id),"broker_record_provider_file_id_invalid")
+        _require(isinstance(encoded,str),"broker_record_content_invalid")
+        try:data=base64.b64decode(encoded.encode("ascii"),validate=True)
+        except Exception as exc: raise PersonalProviderBindingError("broker_record_content_base64_invalid") from exc
+        _require(isinstance(size,int) and size==len(data),"broker_record_size_mismatch")
+        actual="sha256:"+hashlib.sha256(data).hexdigest()
+        _require(claimed_hash==actual,"broker_record_hash_mismatch")
+        validated.append({"path":path,"data":data,"sha256":actual,"size_bytes":len(data)})
+    for exact in (set(b["materialization_scope"])-{"_System/Workspace/**"}):
+        _require(exact in seen,"broker_result_required_path_missing:"+exact)
+    return {"binding":b,"records":validated,"broker_use_receipt":dict(receipt)}
+
+def materialize_broker_result(*,binding:dict[str,Any],broker_response:dict[str,Any],destination_root:Path)->dict[str,Any]:
+    validated=validate_broker_materialization(binding=binding,broker_response=broker_response)
+    b=validated["binding"]
     destination=destination_root.expanduser().resolve();destination.mkdir(parents=True,exist_ok=True)
-    records=[]
-    try:
-        if "_System/installation.receipt.json" in b["materialization_scope"]:
-            item=_resolve_path(root_id,"_System/installation.receipt.json",token)
-            _require(item.get("mimeType")!=GOOGLE_FOLDER_MIME,"installation_receipt_not_file")
-            records.append(_write_exact(destination,"_System/installation.receipt.json",_drive_bytes(item["id"],token)))
-        if "_Entities/Self/Personal_Contact_Profile.json" in b["materialization_scope"]:
-            item=_resolve_path(root_id,"_Entities/Self/Personal_Contact_Profile.json",token)
-            _require(item.get("mimeType")!=GOOGLE_FOLDER_MIME,"personal_profile_not_file")
-            records.append(_write_exact(destination,"_Entities/Self/Personal_Contact_Profile.json",_drive_bytes(item["id"],token)))
-        if "_Entities/Self/Personal_Form_Profile.json" in b["materialization_scope"]:
-            item=_resolve_path(root_id,"_Entities/Self/Personal_Form_Profile.json",token)
-            _require(item.get("mimeType")!=GOOGLE_FOLDER_MIME,"personal_form_profile_not_file")
-            records.append(_write_exact(destination,"_Entities/Self/Personal_Form_Profile.json",_drive_bytes(item["id"],token)))
-        if "_System/Workspace/**" in b["materialization_scope"]:
-            folder=_resolve_path(root_id,"_System/Workspace",token)
-            _require(folder.get("mimeType")==GOOGLE_FOLDER_MIME,"workspace_not_folder")
-            for item in _children(folder["id"],token):
-                _require(item.get("mimeType")!=GOOGLE_FOLDER_MIME,"workspace_nested_folder_not_supported")
-                name=str(item.get("name") or "")
-                _require(bool(re.fullmatch(r"[A-Za-z0-9._-]+",name)),"workspace_filename_invalid")
-                records.append(_write_exact(destination,"_System/Workspace/"+name,_drive_bytes(item["id"],token)))
-    finally:
-        token=""
-    receipt={
-        "schema":"stegverse.kv.provider-materialization-receipt/v1",
+    written=[]
+    for row in validated["records"]:
+        receipt=_write_exact(destination,row["path"],row["data"])
+        _require(receipt["sha256"]==row["sha256"] and receipt["size_bytes"]==row["size_bytes"],"materialization_broker_readback_binding_failed")
+        written.append(receipt)
+    return {
+        "schema":"stegverse.kv.provider-materialization-receipt/v2",
         "binding_id":b["binding_id"],
         "provider":"GOOGLE_DRIVE",
         "materialized_root":str(destination),
-        "records":records,
+        "records":written,
         "exact_readback_verified":True,
         "credential_authority":"TV/TVC",
         "credential_material_persisted":False,
-        "provider_operation":"READ_ONLY_MATERIALIZATION",
-        "provider_operation_authorized_by_session":True,
+        "consumer_received_provider_credential":False,
+        "provider_operation":"READ_ONLY_MATERIALIZATION_VIA_TVC_BROKER",
         "provider_operation_authority_transferred":False,
+        "broker_use_receipt_sha256":"sha256:"+hashlib.sha256(repr(sorted(validated["broker_use_receipt"].items())).encode("utf-8")).hexdigest(),
         "authority_effect":"NONE",
         "activation_effect":False,
     }
-    return receipt
+
+def materialize_google_drive_scope(**_:Any)->dict[str,Any]:
+    raise PersonalProviderBindingError("consumer_bearer_token_path_retired_use_tvc_broker_materialization")

--- a/schemas/kv-personal-provider-binding.schema.json
+++ b/schemas/kv-personal-provider-binding.schema.json
@@ -63,7 +63,8 @@
         "enum": [
           "_System/installation.receipt.json",
           "_System/Workspace/**",
-          "_Entities/Self/Personal_Contact_Profile.json"
+          "_Entities/Self/Personal_Contact_Profile.json",
+          "_Entities/Self/Personal_Form_Profile.json"
         ]
       }
     },
@@ -71,7 +72,7 @@
       "const": "TV/TVC"
     },
     "credential_reference_class": {
-      "const": "TVC_EPHEMERAL_PROVIDER_SESSION"
+      "const": "TVC_NONSECRET_PROVIDER_MATERIALIZATION_BROKER"
     },
     "compatibility_state": {
       "enum": [

--- a/tests/test_personal_provider_binding.py
+++ b/tests/test_personal_provider_binding.py
@@ -1,58 +1,72 @@
-import importlib.util, json, os, stat, tempfile
+import base64, hashlib, importlib.util, tempfile
 from pathlib import Path
 
 ROOT=Path(__file__).resolve().parents[1]
 spec=importlib.util.spec_from_file_location("binding",ROOT/"runtime/personal_provider_binding.py")
 m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
 
+def binding():
+    return m.build_binding(root_folder_id="folder-1234567890",materialization_scope=[
+        "_System/installation.receipt.json",
+        "_Entities/Self/Personal_Form_Profile.json",
+    ])
+
+def broker_response():
+    rows=[]
+    for path,data,file_id in [
+        ("_System/installation.receipt.json",b'{"ok":true}\n',"f1"),
+        ("_Entities/Self/Personal_Form_Profile.json",b'{"profile":true}\n',"f2"),
+    ]:
+        rows.append({"canonical_path":path,"provider_file_id":file_id,"sha256":"sha256:"+hashlib.sha256(data).hexdigest(),"size_bytes":len(data),"content_base64":base64.b64encode(data).decode("ascii")})
+    return {
+      "decision":"ALLOW_OPERATION_RESULT",
+      "result":{"schema":m.BROKER_RESULT_SCHEMA,"provider":"GOOGLE_DRIVE","binding_id":binding()["binding_id"],"records":rows,"total_size_bytes":sum(r["size_bytes"] for r in rows),"read_only":True,"provider_mutation_performed":False,"credential_material_returned":False,"credential_authority":"TV/TVC","authority_effect":"NONE"},
+      "use_receipt":{"provider":"google_drive","operation":"personal_kv_materialize","secret_material_returned":False,"secret_material_logged":False,"secret_material_retained":False,"wallet_contacted":False,"signed":False,"broadcast":False,"single_use_consumed":True},
+    }
+
 def test_binding_is_deterministic_and_non_authorizing():
-    b=m.build_binding(root_folder_id="folder-1234567890")
+    b=binding()
     assert b["binding_id"]==m.deterministic_binding_id("GOOGLE_DRIVE","folder-1234567890")
     assert b["credential_authority"]=="TV/TVC"
+    assert b["credential_reference_class"]==m.CREDENTIAL_REFERENCE_CLASS
     assert b["credential_material_present"] is False
     assert b["provider_operation_authorized"] is False
-    assert b["authority_effect"]=="NONE"
-    assert b["activation_effect"] is False
-    assert "_Entities/Self/Personal_Form_Profile.json" in b["materialization_scope"]
 
 def test_scope_cannot_expand():
-    try:
-        m.build_binding(root_folder_id="folder-1234567890",materialization_scope=["_Vault/**"])
-        assert False
-    except m.PersonalProviderBindingError:
-        pass
+    try:m.build_binding(root_folder_id="folder-1234567890",materialization_scope=["_Vault/**"])
+    except m.PersonalProviderBindingError:pass
+    else:raise AssertionError("scope expansion must fail")
 
-def test_token_file_requires_private_permissions():
-    with tempfile.TemporaryDirectory() as d:
-        p=Path(d)/"token";p.write_text("example-token")
-        os.chmod(p,0o644)
-        try:
-            m._read_tvc_bearer(p)
-            assert False
-        except m.PersonalProviderBindingError:
-            pass
-        os.chmod(p,0o600)
-        assert m._read_tvc_bearer(p)=="example-token"
+def test_legacy_token_materializer_is_retired():
+    try:m.materialize_google_drive_scope(token_file=Path("/tmp/token"))
+    except m.PersonalProviderBindingError as exc:assert "retired" in str(exc)
+    else:raise AssertionError("legacy token path must fail closed")
+    assert not hasattr(m,"_read_tvc_bearer")
 
 def test_safe_destination_rejects_escape():
     with tempfile.TemporaryDirectory() as d:
         root=Path(d)/"kv";root.mkdir()
-        try:
-            m._safe_destination(root,"../escape")
-            assert False
-        except m.PersonalProviderBindingError:
-            pass
+        try:m._safe_destination(root,"../escape")
+        except m.PersonalProviderBindingError:pass
+        else:raise AssertionError("escape must fail")
 
-def test_exact_write_round_trip():
+def test_broker_materialization_exact_round_trip():
     with tempfile.TemporaryDirectory() as d:
-        root=Path(d)/"kv";root.mkdir()
-        receipt=m._write_exact(root,"_System/installation.receipt.json",b'{"ok":true}\n')
-        assert receipt["path"]=="_System/installation.receipt.json"
-        assert receipt["size_bytes"]==12
-        assert (root/"_System/installation.receipt.json").read_bytes()==b'{"ok":true}\n'
+        receipt=m.materialize_broker_result(binding=binding(),broker_response=broker_response(),destination_root=Path(d)/"kv")
+        assert receipt["schema"]=="stegverse.kv.provider-materialization-receipt/v2"
+        assert receipt["consumer_received_provider_credential"] is False
+        assert receipt["provider_operation_authority_transferred"] is False
+        assert (Path(d)/"kv/_System/installation.receipt.json").read_bytes()==b'{"ok":true}\n'
 
+def test_broker_hash_tamper_fails_closed():
+    response=broker_response();response["result"]["records"][0]["sha256"]="sha256:"+"0"*64
+    try:m.validate_broker_materialization(binding=binding(),broker_response=response)
+    except m.PersonalProviderBindingError as exc:assert "hash" in str(exc)
+    else:raise AssertionError("tampered broker record must fail")
 
-def test_personal_form_profile_scope_is_bounded():
-    b=m.build_binding(root_folder_id="folder-1234567890")
-    assert set(b["materialization_scope"]).issubset(m.ALLOWED_SCOPES)
-    assert "_Entities/Self/Personal_Form_Profile.json" in m.ALLOWED_SCOPES
+def test_broker_scope_expansion_fails_closed():
+    response=broker_response();data=b"x"
+    response["result"]["records"].append({"canonical_path":"_Vault/secret","provider_file_id":"x","sha256":"sha256:"+hashlib.sha256(data).hexdigest(),"size_bytes":1,"content_base64":base64.b64encode(data).decode("ascii")})
+    try:m.validate_broker_materialization(binding=binding(),broker_response=response)
+    except m.PersonalProviderBindingError as exc:assert "path_not_admitted" in str(exc)
+    else:raise AssertionError("scope expansion must fail")


### PR DESCRIPTION
Implements #182.

Removes consumer bearer-token/Authorization/provider HTTP handling from CVK and replaces it with strict validation/materialization of the secret-free TVC broker result.

Also reconciles the binding schema to include Personal_Form_Profile and the new non-secret broker reference class.

No provider credentials, runtime activation, or new authority are introduced.