### PR TITLE
Add provider-neutral KV historical provenance records

### DIFF
--- a/.github/workflows/kv-historical-provenance.yml
+++ b/.github/workflows/kv-historical-provenance.yml
@@ -7,6 +7,7 @@ on:
       - 'schemas/kv-historical-artifact-record.schema.json'
       - 'runtime/historical_provenance.py'
       - 'tests/test_historical_provenance.py'
+      - 'tests/test_global_hosted_workflow_authority.py'
       - 'tools/check_kv_historical_provenance.py'
       - 'README.md'
       - 'data/session-work-claims.d/cvk-historical-provenance-188-20260905.json'
@@ -27,6 +28,6 @@ jobs:
       - name: Compile runtime helper
         run: python3 -m py_compile runtime/historical_provenance.py tools/check_kv_historical_provenance.py
       - name: Run focused tests
-        run: python3 -m unittest tests.test_historical_provenance -v
+        run: python3 -m unittest tests.test_historical_provenance tests.test_global_hosted_workflow_authority -v
       - name: Validate source contract
         run: python3 tools/check_kv_historical_provenance.py

--- a/.github/workflows/kv-historical-provenance.yml
+++ b/.github/workflows/kv-historical-provenance.yml
@@ -1,0 +1,32 @@
+name: KV Historical Provenance
+
+on:
+  pull_request:
+    paths:
+      - 'KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md'
+      - 'schemas/kv-historical-artifact-record.schema.json'
+      - 'runtime/historical_provenance.py'
+      - 'tests/test_historical_provenance.py'
+      - 'tools/check_kv_historical_provenance.py'
+      - 'README.md'
+      - 'data/session-work-claims.d/cvk-historical-provenance-188-20260905.json'
+      - '.github/workflows/kv-historical-provenance.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compile runtime helper
+        run: python3 -m py_compile runtime/historical_provenance.py tools/check_kv_historical_provenance.py
+      - name: Run focused tests
+        run: python3 -m unittest tests.test_historical_provenance -v
+      - name: Validate source contract
+        run: python3 tools/check_kv_historical_provenance.py

--- a/KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md
+++ b/KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Historical Provenance Mirror Handoff
 
-Status: ACTIVE_IMPLEMENTATION / SOURCE_ONLY  
+Status: SOURCE_IMPLEMENTED / VALIDATION_IN_PROGRESS  
 Repository: `StegVerse-Labs/continuity-vault-kit`  
 Issue: `#188`  
 Branch: `feature/kv-historical-provenance-188`  
@@ -44,9 +44,9 @@ Resolved state before functional mutation:
 
 README change required: **YES**.
 
-Reason: issue #188 materially expands documented KnowledgeVault capability meaning by defining multi-provider historical evidence references, exact-byte historical identity, and lineage semantics. The repository README must explain that KV may index evidence across owner-controlled providers without treating storage location, copies, or imported historical artifacts as current authority.
+Reason: issue #188 materially expands documented KnowledgeVault capability meaning by defining multi-provider historical evidence references, exact-byte historical identity, and lineage semantics. The repository README now explains that KV may index evidence across owner-controlled providers without treating storage location, copies, or imported historical artifacts as current authority.
 
-The README update must be part of the same source change set as the capability implementation.
+The README update is part of the same source change set as the capability implementation.
 
 ## Governing invariants
 
@@ -95,17 +95,32 @@ Historical provenance ingestion grants none of the following:
 
 Provider credentials remain behind SKAP.
 
-## Initial source implementation
-
-Planned bounded files:
+## Implemented source surfaces
 
 - `schemas/kv-historical-artifact-record.schema.json`
 - `runtime/historical_provenance.py`
 - `tests/test_historical_provenance.py`
+- `tools/check_kv_historical_provenance.py`
+- `.github/workflows/kv-historical-provenance.yml`
+- `tests/test_global_hosted_workflow_authority.py` — intentional workflow census advanced from 48 to 49 for the added read-only validation workflow
 - `README.md`
+- `data/session-work-claims.d/cvk-historical-provenance-188-20260905.json`
 - this handoff
 
 The runtime helper is pure/local and accepts caller-supplied metadata plus exact bytes. It does not connect to iCloud, Google Drive, or any network provider.
+
+## Validation evidence to date
+
+On PR #189 head `4c8e59576214bdf9b9e9711a21ead50707151672`:
+
+- `KV Historical Provenance` run `34002318687`: PASS;
+- `Repository validation diagnostics` run `34002318663`: PASS;
+- `Security Baseline` run `34002318632`: PASS;
+- `Release integrity` run `34002318676`: FAIL because the repository-wide hosted-workflow census expected 48 workflows while this task intentionally added the 49th workflow.
+
+The failure was inspected to the exact assertion `len(workflows) == 48`. The census is now advanced to 49 and included in the focused validation set. This is a task-caused completeness correction, not unrelated debt and not an authority exception.
+
+Current head after the correction must pass the applicable checks before merge. No validation is inferred from the earlier head.
 
 ## Completion boundary
 
@@ -115,6 +130,8 @@ Source completion requires:
 2. deterministic artifact-record builder installed;
 3. validation covering exact-byte hashing, source/copy relationships, authority posture, and fail-closed invalid lineage;
 4. README updated in the same change set;
-5. source review/validation and merge.
+5. repository-wide hosted-workflow census remains exact after adding the validation workflow;
+6. applicable current-head validation passes;
+7. source merge.
 
 Live activation remains separate and requires owner-authorized provider access plus authentic observation of source artifacts. No live iCloud/Google Drive access may be inferred from source completion.

--- a/KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md
+++ b/KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md
@@ -1,0 +1,120 @@
+# KV Historical Provenance Mirror Handoff
+
+Status: ACTIVE_IMPLEMENTATION / SOURCE_ONLY  
+Repository: `StegVerse-Labs/continuity-vault-kit`  
+Issue: `#188`  
+Branch: `feature/kv-historical-provenance-188`  
+Updated: 2026-09-05  
+Authority effect: NONE  
+Activation effect: false
+
+## Purpose
+
+Define a provider-neutral historical-evidence ingestion capability for KnowledgeVault/MyKV so legacy StegVerse artifacts can remain in their original owner-controlled storage while KV preserves exact-byte identity, source provenance, chronology, copy/mirror lineage, interpretation lineage, contradiction state, and import receipts.
+
+This task does not migrate, upgrade, or mutate the owner's existing iCloud or Google Drive vaults.
+
+## Canonical dependency reuse
+
+This work consumes rather than replaces:
+
+- `docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`;
+- `KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md`;
+- `KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md`;
+- `LEGACY_KV_UPGRADE_MIRROR_HANDOFF.md` only as a collision boundary;
+- SKAP credential-custody semantics;
+- existing KV receipt/provenance conventions.
+
+No parallel provider-ingress authority is introduced.
+
+## Machine preflight — 2026-09-05
+
+Preflight state: `PASS_FOR_BOUNDED_SOURCE_IMPLEMENTATION`.
+
+Resolved state before functional mutation:
+
+1. Repository-local canonical handoff is `docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`.
+2. Canonical ecosystem task coordination separates work intent from WorkerCoordinator execution authority and Master Records observed-reality authority.
+3. `master-records/core-lite/MASTER_RECORDS_MIRROR_HANDOFF.md` remains the current Master Records repository-wide handoff; this task does not mint Master Records custody.
+4. Existing claim `CVK-LEGACY-KV-UPGRADE-174` owns migration/upgrade paths for the older iCloud KV. Issue #188 uses distinct historical-provenance paths and must not modify either existing vault.
+5. `KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md` already defines direct-source provenance and SKAP-bounded provider access. Historical provenance must reuse that ingress model.
+6. `KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md` already owns generic provider/device capability facts. This task must not duplicate that registry.
+
+### README completeness predicate
+
+README change required: **YES**.
+
+Reason: issue #188 materially expands documented KnowledgeVault capability meaning by defining multi-provider historical evidence references, exact-byte historical identity, and lineage semantics. The repository README must explain that KV may index evidence across owner-controlled providers without treating storage location, copies, or imported historical artifacts as current authority.
+
+The README update must be part of the same source change set as the capability implementation.
+
+## Governing invariants
+
+```text
+storage_location != authority
+copy != original
+historical_evidence != current_doctrine
+import_receipt != truth_certification
+semantic_interpretation != source_bytes
+source_merge != live_provider_observation
+```
+
+A historical artifact record must preserve the original artifact identity separately from every later copy, normalized projection, interpretation, derived claim, or canonical present-day doctrine.
+
+## Required artifact identity
+
+Every admitted historical artifact record must include at minimum:
+
+- stable artifact record ID;
+- exact-byte SHA-256;
+- original file name when available;
+- MIME/media type when known;
+- byte size;
+- source provider/storage class;
+- source locator represented without reusable credential material;
+- first-observed timestamp;
+- source-observed timestamp when available and separately labeled;
+- ingest/receipt timestamp;
+- source relationship (`ORIGINAL`, `COPY`, `MIRROR`, `DERIVED`, or `UNKNOWN`);
+- parent/source artifact references for non-original material;
+- current authority posture;
+- contradiction/uncertainty state;
+- receipt identity.
+
+## Authority boundaries
+
+Historical provenance ingestion grants none of the following:
+
+- present execution authority;
+- governance authority;
+- publication authority;
+- doctrinal authority;
+- provider write authority;
+- migration authority;
+- permission to inspect private content without owner authorization.
+
+Provider credentials remain behind SKAP.
+
+## Initial source implementation
+
+Planned bounded files:
+
+- `schemas/kv-historical-artifact-record.schema.json`
+- `runtime/historical_provenance.py`
+- `tests/test_historical_provenance.py`
+- `README.md`
+- this handoff
+
+The runtime helper is pure/local and accepts caller-supplied metadata plus exact bytes. It does not connect to iCloud, Google Drive, or any network provider.
+
+## Completion boundary
+
+Source completion requires:
+
+1. schema installed;
+2. deterministic artifact-record builder installed;
+3. validation covering exact-byte hashing, source/copy relationships, authority posture, and fail-closed invalid lineage;
+4. README updated in the same change set;
+5. source review/validation and merge.
+
+Live activation remains separate and requires owner-authorized provider access plus authentic observation of source artifacts. No live iCloud/Google Drive access may be inferred from source completion.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ See:
 - [`docs/EXAMPLES.md`](./docs/EXAMPLES.md)
 - [`docs/AI_COMPATIBLE.md`](./docs/AI_COMPATIBLE.md)
 
+## Historical provenance across storage providers
+
+KnowledgeVault can represent historical evidence that remains in more than one owner-controlled storage provider. A legacy artifact may remain in iCloud, Google Drive, local storage, or another admitted source while KV records its exact-byte identity, source/provider provenance, chronology, and explicit copy/mirror/derived relationships.
+
+The governing distinction is:
+
+```text
+storage location != authority
+copy != original
+historical evidence != current doctrine
+import receipt != truth certification
+```
+
+A historical record must keep the exact source artifact separate from later copies, normalized projections, interpretations, derived claims, and present-day canonical StegVerse doctrine. Provider credentials remain behind SKAP, and source implementation does not itself authorize provider access, migration, publication, governance, or execution.
+
+See [`KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md`](./KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md) for the bounded source contract.
+
 ## Technical review
 
 Developers and reviewers should start with [`docs/TECHNICAL_REVIEW_PATH.md`](./docs/TECHNICAL_REVIEW_PATH.md), [`SECURITY.md`](./SECURITY.md), and [`stegverse.architecture.json`](./stegverse.architecture.json).

--- a/data/session-work-claims.d/cvk-historical-provenance-188-20260905.json
+++ b/data/session-work-claims.d/cvk-historical-provenance-188-20260905.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "1.0.0",
+  "registry_fragment_type": "stegverse_session_work_claim_registry_fragment",
+  "repository": "StegVerse-Labs/continuity-vault-kit",
+  "claims": [
+    {
+      "claim_id": "CVK-HISTORICAL-PROVENANCE-188-20260905",
+      "session_worker_id": "chatgpt:cvk-historical-provenance-188-20260905",
+      "task_id": "CVK-HISTORICAL-PROVENANCE-188",
+      "originating_goal": "Preserve exact-byte historical StegVerse evidence across owner-controlled storage providers without making provider location, copies, interpretations, or imported history current authority.",
+      "repository": "StegVerse-Labs/continuity-vault-kit",
+      "branch": "feature/kv-historical-provenance-188",
+      "role": "ACTIVE_IMPLEMENTATION",
+      "state": "CLAIMED_FOR_IMPLEMENTATION",
+      "normalized_work_key": "cvk-historical-provenance-188",
+      "dependency_surface_keys": [
+        "kv:historical-provenance",
+        "kv:direct-source-ingress",
+        "kv:provider-surface-capabilities"
+      ],
+      "governing_dependency_keys": ["kv:historical-provenance"],
+      "claimed_paths": [
+        "KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md",
+        "schemas/kv-historical-artifact-record.schema.json",
+        "runtime/historical_provenance.py",
+        "tests/test_historical_provenance.py",
+        "README.md",
+        "data/session-work-claims.d/cvk-historical-provenance-188-20260905.json"
+      ],
+      "handoff": "KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md",
+      "handoff_revision": "SOURCE_IMPLEMENTATION_20260905",
+      "claim_created_at": "2026-09-05T19:47:00-05:00",
+      "claim_expires_when": "Release after source validation/merge; live provider observation remains separate owner/runtime work.",
+      "expected_evidence": [
+        "exact-byte SHA-256 binding validated",
+        "copy/mirror/derived lineage constraints validated",
+        "authority escalation rejected",
+        "reusable credential material rejected from locator refs",
+        "README capability semantics updated in same change set",
+        "source PR validation observed"
+      ],
+      "collision_boundaries": [
+        "Do not modify CVK-LEGACY-KV-UPGRADE-174 claimed paths",
+        "Do not mutate the older iCloud KnowledgeVault",
+        "Do not mutate the current Google Drive production candidate",
+        "Do not duplicate provider capability registry",
+        "Do not create a parallel direct-source ingress authority",
+        "Do not claim live provider observation from source state"
+      ],
+      "next_task_after_release": "Add an owner-authorized historical-corpus import/receipt projection through the existing direct-source and InTr boundaries, then anchor accepted custody evidence into Master Records without changing historical bytes.",
+      "credential_authority": "TV/TVC",
+      "credential_requirement": "NONE_FOR_SOURCE_IMPLEMENTATION",
+      "github_token_runtime_authority": "NONE",
+      "non_tv_tvc_secret_or_token_used": false,
+      "authority_effect": false,
+      "activation_effect": false,
+      "archive_eligible": false
+    }
+  ]
+}

--- a/data/session-work-claims.d/cvk-historical-provenance-188-20260905.json
+++ b/data/session-work-claims.d/cvk-historical-provenance-188-20260905.json
@@ -24,6 +24,9 @@
         "schemas/kv-historical-artifact-record.schema.json",
         "runtime/historical_provenance.py",
         "tests/test_historical_provenance.py",
+        "tests/test_global_hosted_workflow_authority.py",
+        "tools/check_kv_historical_provenance.py",
+        ".github/workflows/kv-historical-provenance.yml",
         "README.md",
         "data/session-work-claims.d/cvk-historical-provenance-188-20260905.json"
       ],
@@ -37,6 +40,7 @@
         "authority escalation rejected",
         "reusable credential material rejected from locator refs",
         "README capability semantics updated in same change set",
+        "hosted workflow authority census updated for intentional new validation workflow",
         "source PR validation observed"
       ],
       "collision_boundaries": [

--- a/runtime/historical_provenance.py
+++ b/runtime/historical_provenance.py
@@ -1,0 +1,162 @@
+"""Deterministic, provider-neutral historical provenance helpers for KnowledgeVault."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, Iterable
+
+SCHEMA_VERSION = "stegverse.kv.historical-artifact-record/v1"
+RELATIONSHIP_KINDS = {"ORIGINAL", "COPY", "MIRROR", "DERIVED", "UNKNOWN"}
+CONTRADICTION_STATES = {"NONE", "UNRESOLVED", "CONFLICTING_SOURCE", "UNKNOWN"}
+FORBIDDEN_LOCATOR_FRAGMENTS = (
+    "access_token=",
+    "refresh_token=",
+    "password=",
+    "api_key=",
+    "secret=",
+    "private_key=",
+)
+
+
+class HistoricalProvenanceError(ValueError):
+    pass
+
+
+def _required_text(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise HistoricalProvenanceError(f"{name} is required")
+    return value.strip()
+
+
+def _clean_refs(values: Iterable[str] | None, name: str) -> list[str]:
+    result: list[str] = []
+    for value in values or []:
+        ref = _required_text(value, name)
+        if ref not in result:
+            result.append(ref)
+    return result
+
+
+def _validate_locator(locator_ref: str) -> str:
+    locator = _required_text(locator_ref, "source_locator_ref")
+    lowered = locator.lower()
+    if any(fragment in lowered for fragment in FORBIDDEN_LOCATOR_FRAGMENTS):
+        raise HistoricalProvenanceError("source locator may not contain reusable credential material")
+    return locator
+
+
+def build_artifact_record(
+    *,
+    artifact_id: str,
+    exact_bytes: bytes,
+    original_filename: str,
+    source_provider: str,
+    source_storage_class: str,
+    source_locator_ref: str,
+    first_observed_at: str,
+    ingested_at: str,
+    relationship_kind: str = "UNKNOWN",
+    parent_artifact_refs: Iterable[str] | None = None,
+    media_type: str | None = None,
+    source_observed_at: str | None = None,
+    interpretation_refs: Iterable[str] | None = None,
+    contradiction_state: str = "UNKNOWN",
+) -> Dict[str, Any]:
+    """Build a source-only historical record from exact caller-supplied bytes.
+
+    This function performs no provider access, network access, migration, or publication.
+    """
+    if not isinstance(exact_bytes, (bytes, bytearray)):
+        raise HistoricalProvenanceError("exact_bytes must be bytes")
+
+    relationship_kind = _required_text(relationship_kind, "relationship_kind").upper()
+    if relationship_kind not in RELATIONSHIP_KINDS:
+        raise HistoricalProvenanceError("unsupported relationship kind")
+
+    parents = _clean_refs(parent_artifact_refs, "parent_artifact_ref")
+    if relationship_kind == "ORIGINAL" and parents:
+        raise HistoricalProvenanceError("ORIGINAL artifacts may not claim parent artifact refs")
+    if relationship_kind in {"COPY", "MIRROR", "DERIVED"} and not parents:
+        raise HistoricalProvenanceError(f"{relationship_kind} requires at least one parent artifact ref")
+
+    contradiction_state = _required_text(contradiction_state, "contradiction_state").upper()
+    if contradiction_state not in CONTRADICTION_STATES:
+        raise HistoricalProvenanceError("unsupported contradiction state")
+
+    artifact_id = _required_text(artifact_id, "artifact_id")
+    digest = hashlib.sha256(bytes(exact_bytes)).hexdigest()
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_id": artifact_id,
+        "exact_sha256": digest,
+        "byte_size": len(exact_bytes),
+        "original_filename": _required_text(original_filename, "original_filename"),
+        "media_type": media_type.strip() if isinstance(media_type, str) and media_type.strip() else None,
+        "source": {
+            "provider": _required_text(source_provider, "source_provider"),
+            "storage_class": _required_text(source_storage_class, "source_storage_class"),
+            "locator_ref": _validate_locator(source_locator_ref),
+            "first_observed_at": _required_text(first_observed_at, "first_observed_at"),
+            "source_observed_at": source_observed_at.strip() if isinstance(source_observed_at, str) and source_observed_at.strip() else None,
+        },
+        "relationship": {
+            "kind": relationship_kind,
+            "parent_artifact_refs": parents,
+        },
+        "ingested_at": _required_text(ingested_at, "ingested_at"),
+        "interpretation_refs": _clean_refs(interpretation_refs, "interpretation_ref"),
+        "contradiction_state": contradiction_state,
+        "authority_posture": {
+            "execution": False,
+            "governance": False,
+            "publication": False,
+            "doctrine": False,
+            "provider_write": False,
+            "migration": False,
+        },
+        "receipt_id": f"kvhist:{artifact_id}:{digest}",
+    }
+
+
+def assert_artifact_record(record: Dict[str, Any], *, exact_bytes: bytes | None = None) -> None:
+    if not isinstance(record, dict):
+        raise HistoricalProvenanceError("record must be an object")
+    if record.get("schema_version") != SCHEMA_VERSION:
+        raise HistoricalProvenanceError("record schema mismatch")
+
+    _required_text(record.get("artifact_id"), "artifact_id")
+    digest = record.get("exact_sha256")
+    if not isinstance(digest, str) or len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+        raise HistoricalProvenanceError("exact_sha256 must be lowercase SHA-256 hex")
+    if exact_bytes is not None and hashlib.sha256(bytes(exact_bytes)).hexdigest() != digest:
+        raise HistoricalProvenanceError("exact bytes do not match recorded SHA-256")
+
+    source = record.get("source")
+    if not isinstance(source, dict):
+        raise HistoricalProvenanceError("source object required")
+    _required_text(source.get("provider"), "source.provider")
+    _required_text(source.get("storage_class"), "source.storage_class")
+    _validate_locator(source.get("locator_ref"))
+    _required_text(source.get("first_observed_at"), "source.first_observed_at")
+
+    relationship = record.get("relationship")
+    if not isinstance(relationship, dict):
+        raise HistoricalProvenanceError("relationship object required")
+    kind = _required_text(relationship.get("kind"), "relationship.kind").upper()
+    if kind not in RELATIONSHIP_KINDS:
+        raise HistoricalProvenanceError("unsupported relationship kind")
+    parents = _clean_refs(relationship.get("parent_artifact_refs"), "parent_artifact_ref")
+    if kind == "ORIGINAL" and parents:
+        raise HistoricalProvenanceError("ORIGINAL artifacts may not claim parents")
+    if kind in {"COPY", "MIRROR", "DERIVED"} and not parents:
+        raise HistoricalProvenanceError(f"{kind} requires a parent artifact ref")
+
+    posture = record.get("authority_posture")
+    required_false = {"execution", "governance", "publication", "doctrine", "provider_write", "migration"}
+    if not isinstance(posture, dict) or any(posture.get(key) is not False for key in required_false):
+        raise HistoricalProvenanceError("historical artifact record may not grant authority")
+
+    expected_receipt = f"kvhist:{record['artifact_id']}:{digest}"
+    if record.get("receipt_id") != expected_receipt:
+        raise HistoricalProvenanceError("receipt identity mismatch")

--- a/schemas/kv-historical-artifact-record.schema.json
+++ b/schemas/kv-historical-artifact-record.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-historical-artifact-record.schema.json",
+  "title": "KnowledgeVault Historical Artifact Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_id",
+    "exact_sha256",
+    "byte_size",
+    "original_filename",
+    "media_type",
+    "source",
+    "relationship",
+    "ingested_at",
+    "interpretation_refs",
+    "contradiction_state",
+    "authority_posture",
+    "receipt_id"
+  ],
+  "properties": {
+    "schema_version": { "const": "stegverse.kv.historical-artifact-record/v1" },
+    "artifact_id": { "type": "string", "minLength": 1, "maxLength": 160 },
+    "exact_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "byte_size": { "type": "integer", "minimum": 0 },
+    "original_filename": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "media_type": { "type": ["string", "null"], "maxLength": 160 },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "storage_class", "locator_ref", "first_observed_at", "source_observed_at"],
+      "properties": {
+        "provider": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "storage_class": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "locator_ref": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "first_observed_at": { "type": "string", "format": "date-time" },
+        "source_observed_at": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "parent_artifact_refs"],
+      "properties": {
+        "kind": { "enum": ["ORIGINAL", "COPY", "MIRROR", "DERIVED", "UNKNOWN"] },
+        "parent_artifact_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 200 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "ingested_at": { "type": "string", "format": "date-time" },
+    "interpretation_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1, "maxLength": 256 },
+      "uniqueItems": true
+    },
+    "contradiction_state": { "enum": ["NONE", "UNRESOLVED", "CONFLICTING_SOURCE", "UNKNOWN"] },
+    "authority_posture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["execution", "governance", "publication", "doctrine", "provider_write", "migration"],
+      "properties": {
+        "execution": { "const": false },
+        "governance": { "const": false },
+        "publication": { "const": false },
+        "doctrine": { "const": false },
+        "provider_write": { "const": false },
+        "migration": { "const": false }
+      }
+    },
+    "receipt_id": { "type": "string", "minLength": 1, "maxLength": 256 }
+  }
+}

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),48)
+        self.assertEqual(len(workflows),49)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tests/test_historical_provenance.py
+++ b/tests/test_historical_provenance.py
@@ -1,0 +1,78 @@
+import copy
+import unittest
+
+from runtime.historical_provenance import (
+    HistoricalProvenanceError,
+    assert_artifact_record,
+    build_artifact_record,
+)
+
+
+class HistoricalProvenanceTests(unittest.TestCase):
+    def _record(self, **overrides):
+        args = {
+            "artifact_id": "stegverse-early-governance-001",
+            "exact_bytes": b"historical source bytes",
+            "original_filename": "early-governance-notes.md",
+            "source_provider": "iCloud",
+            "source_storage_class": "owner-controlled-cloud-file",
+            "source_locator_ref": "icloud:KnowledgeVault/02_Research/early-governance-notes.md",
+            "first_observed_at": "2026-09-05T19:50:00-05:00",
+            "source_observed_at": "2024-11-15T10:00:00-06:00",
+            "ingested_at": "2026-09-05T19:51:00-05:00",
+            "relationship_kind": "ORIGINAL",
+            "contradiction_state": "UNKNOWN",
+        }
+        args.update(overrides)
+        return build_artifact_record(**args)
+
+    def test_exact_bytes_are_bound_and_authority_is_false(self):
+        record = self._record()
+        assert_artifact_record(record, exact_bytes=b"historical source bytes")
+        self.assertEqual(record["byte_size"], len(b"historical source bytes"))
+        self.assertTrue(record["receipt_id"].endswith(record["exact_sha256"]))
+        self.assertTrue(all(value is False for value in record["authority_posture"].values()))
+
+    def test_byte_drift_is_rejected(self):
+        record = self._record()
+        with self.assertRaises(HistoricalProvenanceError):
+            assert_artifact_record(record, exact_bytes=b"modified historical source bytes")
+
+    def test_copy_requires_parent(self):
+        with self.assertRaises(HistoricalProvenanceError):
+            self._record(relationship_kind="COPY")
+
+    def test_original_rejects_parent(self):
+        with self.assertRaises(HistoricalProvenanceError):
+            self._record(relationship_kind="ORIGINAL", parent_artifact_refs=["artifact:older"])
+
+    def test_copy_preserves_parent_and_independent_byte_identity(self):
+        record = self._record(
+            artifact_id="stegverse-early-governance-copy-001",
+            relationship_kind="COPY",
+            parent_artifact_refs=["stegverse-early-governance-001"],
+            source_provider="Google Drive",
+            source_locator_ref="gdrive:StegVerse-History/early-governance-notes.md",
+        )
+        assert_artifact_record(record, exact_bytes=b"historical source bytes")
+        self.assertEqual(record["relationship"]["parent_artifact_refs"], ["stegverse-early-governance-001"])
+
+    def test_locator_rejects_reusable_secret_material(self):
+        with self.assertRaises(HistoricalProvenanceError):
+            self._record(source_locator_ref="https://example.invalid/file?access_token=secret")
+
+    def test_authority_escalation_is_rejected(self):
+        record = self._record()
+        tampered = copy.deepcopy(record)
+        tampered["authority_posture"]["doctrine"] = True
+        with self.assertRaises(HistoricalProvenanceError):
+            assert_artifact_record(tampered)
+
+    def test_contradiction_state_is_preserved_not_resolved(self):
+        record = self._record(contradiction_state="UNRESOLVED", interpretation_refs=["analysis:2026-09-05"])
+        self.assertEqual(record["contradiction_state"], "UNRESOLVED")
+        self.assertEqual(record["interpretation_refs"], ["analysis:2026-09-05"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_kv_historical_provenance.py
+++ b/tools/check_kv_historical_provenance.py
@@ -4,11 +4,15 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from runtime.historical_provenance import HistoricalProvenanceError, assert_artifact_record, build_artifact_record
 
-ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "schemas" / "kv-historical-artifact-record.schema.json"
 HANDOFF = ROOT / "KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md"
 README = ROOT / "README.md"

--- a/tools/check_kv_historical_provenance.py
+++ b/tools/check_kv_historical_provenance.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Dependency-light source validator for KV historical provenance."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from runtime.historical_provenance import HistoricalProvenanceError, assert_artifact_record, build_artifact_record
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "kv-historical-artifact-record.schema.json"
+HANDOFF = ROOT / "KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md"
+README = ROOT / "README.md"
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    if schema.get("$id") != "https://stegverse.org/schemas/kv-historical-artifact-record.schema.json":
+        raise SystemExit("historical provenance schema id mismatch")
+
+    handoff = HANDOFF.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    for required in (
+        "storage_location != authority",
+        "copy != original",
+        "historical_evidence != current_doctrine",
+        "import_receipt != truth_certification",
+    ):
+        if required not in handoff:
+            raise SystemExit(f"handoff invariant missing: {required}")
+    if "Historical provenance across storage providers" not in readme:
+        raise SystemExit("README historical provenance section missing")
+
+    payload = b"historical-source-validation-vector"
+    record = build_artifact_record(
+        artifact_id="validation-vector-001",
+        exact_bytes=payload,
+        original_filename="validation-vector.bin",
+        source_provider="owner-controlled-storage",
+        source_storage_class="historical-evidence",
+        source_locator_ref="provider:historical/validation-vector.bin",
+        first_observed_at="2026-09-05T19:55:00-05:00",
+        ingested_at="2026-09-05T19:55:01-05:00",
+        relationship_kind="ORIGINAL",
+        contradiction_state="UNKNOWN",
+    )
+    assert_artifact_record(record, exact_bytes=payload)
+
+    try:
+        assert_artifact_record(record, exact_bytes=b"tampered")
+    except HistoricalProvenanceError:
+        pass
+    else:
+        raise SystemExit("byte-drift negative control failed")
+
+    if any(record["authority_posture"].values()):
+        raise SystemExit("authority posture must remain false")
+
+    print("KV historical provenance source validation: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements #188.

Preflight resolved the repository handoff, canonical task-registry authority split, Master Records handoff, and active CVK-LEGACY-KV-UPGRADE-174 collision boundary before functional mutation.

This PR adds:
- `KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md`;
- exact-byte historical artifact schema;
- deterministic local record builder/validator;
- regression tests for byte drift, parent lineage, credential-bearing locators, authority escalation, and unresolved contradiction preservation;
- README capability semantics in the same change set;
- a bounded session-work claim fragment.

Authority/runtime boundary: source-only. No iCloud/Google Drive login, private-content inspection, migration, publication, governance authority, execution authority, or live provider observation is claimed.

The implementation reuses direct-source ingress/provider capability semantics and does not modify the active legacy-upgrade task paths.