### PR TITLE
Implement owner-authorized historical corpus import receipts

### DIFF
--- a/.github/workflows/kv-historical-corpus-import.yml
+++ b/.github/workflows/kv-historical-corpus-import.yml
@@ -1,0 +1,35 @@
+name: KV Historical Corpus Import
+
+on:
+  pull_request:
+    paths:
+      - 'KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md'
+      - 'schemas/kv-historical-import-receipt.schema.json'
+      - 'schemas/kv-historical-custody-request.schema.json'
+      - 'schemas/kv-historical-status-projection.schema.json'
+      - 'runtime/historical_corpus_import.py'
+      - 'tests/test_historical_corpus_import.py'
+      - 'tests/test_global_hosted_workflow_authority.py'
+      - 'tools/check_kv_historical_corpus_import.py'
+      - 'README.md'
+      - 'data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json'
+      - '.github/workflows/kv-historical-corpus-import.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compile runtime helpers
+        run: python3 -m py_compile runtime/historical_provenance.py runtime/historical_corpus_import.py tools/check_kv_historical_corpus_import.py
+      - name: Run focused tests
+        run: python3 -m unittest tests.test_historical_corpus_import tests.test_global_hosted_workflow_authority -v
+      - name: Validate source contract
+        run: python3 tools/check_kv_historical_corpus_import.py

--- a/KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md
+++ b/KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md
@@ -1,0 +1,102 @@
+# KV Historical Corpus Import Mirror Handoff
+
+Status: ACTIVE_IMPLEMENTATION / SOURCE_FIRST  
+Repository: `StegVerse-Labs/continuity-vault-kit`  
+Issue: `#191`  
+Branch: `feature/kv-historical-corpus-import-191`  
+Updated: 2026-09-05  
+Authority effect: NONE  
+Activation effect: false
+
+## Purpose
+
+Implement the first owner-authorized historical-corpus import/receipt path using the merged provider-neutral historical provenance contract without modifying historical source bytes, migrating an existing vault, or turning storage location or custody into authority.
+
+## Canonical dependency reuse
+
+This work consumes rather than replaces:
+
+- `docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md` — repository-local continuation source of truth;
+- `KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md` — exact-byte historical artifact identity and lineage;
+- `runtime/historical_provenance.py` — canonical historical artifact record builder/validator;
+- `KV_DIRECT_SOURCE_INGRESS_MIRROR_HANDOFF.md` and `runtime/direct_source_ingress.py` — provider/source provenance and SKAP-bounded direct-source semantics;
+- `KV_PROVIDER_SURFACE_CAPABILITIES_MIRROR_HANDOFF.md` — generic provider/device capability facts;
+- existing Interlock/InTr boundaries for governed ingress/egress;
+- Master Records destination custody semantics, which remain independently validating and non-authorizing.
+
+No parallel provider ingress, historical identity, credential authority, task authority, or Master Records authority is introduced.
+
+## Machine preflight — 2026-09-05
+
+Preflight state: `PASS_FOR_BOUNDED_SOURCE_IMPLEMENTATION`.
+
+Resolved before functional mutation:
+
+1. The repository-wide canonical handoff remains `docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`.
+2. The immediate predecessor handoff is `KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md`; issue #188 is source-complete and names this task as its next integration candidate.
+3. Canonical ecosystem task registry generation 15 preserves the authority split: Task Registry = work intent/coordination; WorkerCoordinator = execution claim/fence authority; Master Records = observed-reality/reconstruction authority; Interlock/InTr = governed task ingress/egress. This issue does not mint execution authority from repository state.
+4. `master-records/core-lite/MASTER_RECORDS_MIRROR_HANDOFF.md` remains the current Master Records repository-wide handoff. Its custody pattern requires independent validation before destination acknowledgement and explicitly separates custody from runtime, execution, publication, and continuity authority.
+5. No existing `KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md` or implementation for `KV-HISTORICAL-CORPUS-IMPORT-001` exists on `main`; creating this handoff is therefore the first required task action.
+6. Existing `CVK-LEGACY-KV-UPGRADE-174` remains a separate migration/reinstall lane. This task may not modify or overwrite either the legacy iCloud KnowledgeVault or the current Google Drive KnowledgeVault.
+7. Open PR #161 owns portable direct-source canonical-raw persistence paths. This task will not modify `runtime/portable_direct_source_ingress.py`, its tests, or its mirror handoffs; it will consume merged/public contracts only.
+8. Open PR #186 changes only governed connector capability documentation and does not overlap the source paths claimed here.
+
+## README completeness predicate
+
+README change required: **YES**.
+
+Reason: this task advances capability meaning from passive historical-provenance records to an explicit owner-authorized import receipt, custody-request projection, and bounded downstream status model. The README must state that import/custody proves receipt and lineage only, does not certify truth, and does not grant publication, governance, execution, migration, provider-write, or Master Records destination-acknowledgement authority.
+
+The README update must be part of the same implementation change set.
+
+## Source implementation boundary
+
+The bounded source implementation will:
+
+1. accept caller-supplied exact bytes plus owner-authorization evidence reference and source metadata;
+2. reuse `build_artifact_record()` / `assert_artifact_record()` for exact-byte identity;
+3. emit a deterministic historical import receipt bound to the artifact record SHA-256 and owner-authorization reference;
+4. emit a Master Records custody-request candidate that explicitly has `destination_acknowledgement_minted=false` and `destination_custody_accepted=false`;
+5. preserve ORIGINAL/COPY/MIRROR/DERIVED lineage and contradiction state without silent merge;
+6. emit a bounded Site/MyKV status projection that contains identifiers/state only and no source bytes or private content;
+7. fail closed on byte/hash mismatch, missing owner authorization, authority escalation, or invalid custody state.
+
+The source helper will perform no provider login, network access, private-vault discovery, publication, vault migration, or Master Records write.
+
+## Governing invariants
+
+```text
+owner_authorization_ref != reusable_secret
+import_receipt != truth_certification
+import_receipt != publication_authority
+custody_request != destination_custody_acceptance
+custody_request != master_records_acknowledgement
+historical_evidence != current_doctrine
+site_status_projection != private_content
+source_merge != live_provider_observation
+```
+
+## Claimed source paths
+
+- `KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md`
+- `schemas/kv-historical-import-receipt.schema.json`
+- `schemas/kv-historical-custody-request.schema.json`
+- `schemas/kv-historical-status-projection.schema.json`
+- `runtime/historical_corpus_import.py`
+- `tests/test_historical_corpus_import.py`
+- `tools/check_kv_historical_corpus_import.py`
+- `.github/workflows/kv-historical-corpus-import.yml`
+- `data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json`
+- `README.md`
+
+## Completion boundary
+
+Source completion requires all claimed schemas/helpers/tests/validator/workflow and README semantics to be installed, exact-head applicable validation to pass, and the source PR to merge.
+
+Live corpus activation remains separate. It requires an owner-selected artifact and explicit owner authorization at runtime. A repository merge must not be represented as evidence that iCloud, Google Drive, or any private historical artifact was accessed.
+
+Master Records custody is also a separate destination action. This repository may construct a custody-request candidate, but only Master Records may independently validate and mint its destination acknowledgement/custody record.
+
+## Next integration after source completion
+
+After source completion, the next admissible integration is an authentic owner-authorized corpus-import execution through the existing provider/SKAP/InTr path, followed by independent Master Records custody validation and a bounded Site/MyKV status projection. No source bytes are to be exposed to Site merely because import/custody metadata exists.

--- a/KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md
+++ b/KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # KV Historical Corpus Import Mirror Handoff
 
-Status: ACTIVE_IMPLEMENTATION / SOURCE_FIRST  
+Status: SOURCE_IMPLEMENTED / VALIDATION_PENDING  
 Repository: `StegVerse-Labs/continuity-vault-kit`  
 Issue: `#191`  
 Branch: `feature/kv-historical-corpus-import-191`  
@@ -36,32 +36,31 @@ Resolved before functional mutation:
 2. The immediate predecessor handoff is `KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md`; issue #188 is source-complete and names this task as its next integration candidate.
 3. Canonical ecosystem task registry generation 15 preserves the authority split: Task Registry = work intent/coordination; WorkerCoordinator = execution claim/fence authority; Master Records = observed-reality/reconstruction authority; Interlock/InTr = governed task ingress/egress. This issue does not mint execution authority from repository state.
 4. `master-records/core-lite/MASTER_RECORDS_MIRROR_HANDOFF.md` remains the current Master Records repository-wide handoff. Its custody pattern requires independent validation before destination acknowledgement and explicitly separates custody from runtime, execution, publication, and continuity authority.
-5. No existing `KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md` or implementation for `KV-HISTORICAL-CORPUS-IMPORT-001` exists on `main`; creating this handoff is therefore the first required task action.
-6. Existing `CVK-LEGACY-KV-UPGRADE-174` remains a separate migration/reinstall lane. This task may not modify or overwrite either the legacy iCloud KnowledgeVault or the current Google Drive KnowledgeVault.
-7. Open PR #161 owns portable direct-source canonical-raw persistence paths. This task will not modify `runtime/portable_direct_source_ingress.py`, its tests, or its mirror handoffs; it will consume merged/public contracts only.
+5. No existing `KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md` or implementation for `KV-HISTORICAL-CORPUS-IMPORT-001` existed on `main`; creating this handoff was therefore the first required task action.
+6. Existing `CVK-LEGACY-KV-UPGRADE-174` remains a separate migration/reinstall lane. This task does not modify or overwrite either the legacy iCloud KnowledgeVault or the current Google Drive KnowledgeVault.
+7. Open PR #161 owns portable direct-source canonical-raw persistence paths. This task does not modify `runtime/portable_direct_source_ingress.py`, its tests, or its mirror handoffs; it consumes merged/public contracts only.
 8. Open PR #186 changes only governed connector capability documentation and does not overlap the source paths claimed here.
 
 ## README completeness predicate
 
-README change required: **YES**.
+README change required: **YES**, and satisfied in this source change set.
 
-Reason: this task advances capability meaning from passive historical-provenance records to an explicit owner-authorized import receipt, custody-request projection, and bounded downstream status model. The README must state that import/custody proves receipt and lineage only, does not certify truth, and does not grant publication, governance, execution, migration, provider-write, or Master Records destination-acknowledgement authority.
+Reason: this task advances capability meaning from passive historical-provenance records to an explicit owner-authorized import receipt, custody-request projection, and bounded downstream status model. The README now states that import/custody proves receipt and lineage only, does not certify truth, and does not grant publication, governance, execution, migration, provider-write, or Master Records destination-acknowledgement authority.
 
-The README update must be part of the same implementation change set.
+## Implemented source behavior
 
-## Source implementation boundary
+The bounded source implementation:
 
-The bounded source implementation will:
+1. accepts caller-supplied exact bytes plus owner-authorization, InTr admission, and persistence evidence references;
+2. reuses `assert_artifact_record()` for exact-byte historical identity rather than creating a second historical identity implementation;
+3. emits a deterministic historical import receipt whose canonical hash covers artifact identity, relationship/contradiction state, authorization reference, admission/persistence evidence, and time;
+4. emits a Master Records custody-request candidate that explicitly has `destination_acknowledgement_minted=false`, `destination_custody_accepted=false`, and `independent_validation_complete=false`;
+5. preserves ORIGINAL/COPY/MIRROR/DERIVED lineage and contradiction state without silent merge;
+6. emits a bounded Site/MyKV status projection containing identifiers/state only with `private_content_included=false`;
+7. fails closed on byte/hash mismatch, missing or secret-bearing authorization references, authority escalation, receipt tamper, invalid destination custody assertions, and custody/import mismatch;
+8. advances the exact repository read-only hosted workflow census from 49 to 50 for the added validation workflow.
 
-1. accept caller-supplied exact bytes plus owner-authorization evidence reference and source metadata;
-2. reuse `build_artifact_record()` / `assert_artifact_record()` for exact-byte identity;
-3. emit a deterministic historical import receipt bound to the artifact record SHA-256 and owner-authorization reference;
-4. emit a Master Records custody-request candidate that explicitly has `destination_acknowledgement_minted=false` and `destination_custody_accepted=false`;
-5. preserve ORIGINAL/COPY/MIRROR/DERIVED lineage and contradiction state without silent merge;
-6. emit a bounded Site/MyKV status projection that contains identifiers/state only and no source bytes or private content;
-7. fail closed on byte/hash mismatch, missing owner authorization, authority escalation, or invalid custody state.
-
-The source helper will perform no provider login, network access, private-vault discovery, publication, vault migration, or Master Records write.
+The source helper performs no provider login, network access, private-vault discovery, publication, vault migration, or Master Records write.
 
 ## Governing invariants
 
@@ -76,7 +75,7 @@ site_status_projection != private_content
 source_merge != live_provider_observation
 ```
 
-## Claimed source paths
+## Implemented / claimed source paths
 
 - `KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md`
 - `schemas/kv-historical-import-receipt.schema.json`
@@ -84,14 +83,15 @@ source_merge != live_provider_observation
 - `schemas/kv-historical-status-projection.schema.json`
 - `runtime/historical_corpus_import.py`
 - `tests/test_historical_corpus_import.py`
+- `tests/test_global_hosted_workflow_authority.py`
 - `tools/check_kv_historical_corpus_import.py`
 - `.github/workflows/kv-historical-corpus-import.yml`
 - `data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json`
 - `README.md`
 
-## Completion boundary
+## Validation boundary
 
-Source completion requires all claimed schemas/helpers/tests/validator/workflow and README semantics to be installed, exact-head applicable validation to pass, and the source PR to merge.
+Source implementation is installed on the feature branch. Completion still requires exact-head applicable hosted validation and source merge. No validation or activation is inferred from the presence of these files.
 
 Live corpus activation remains separate. It requires an owner-selected artifact and explicit owner authorization at runtime. A repository merge must not be represented as evidence that iCloud, Google Drive, or any private historical artifact was accessed.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,23 @@ A historical record must keep the exact source artifact separate from later copi
 
 See [`KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md`](./KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md) for the bounded source contract.
 
+## Owner-authorized historical imports and custody
+
+A historical artifact may enter the governed KV import path only when the runtime has an explicit owner-authorization evidence reference, exact bytes matching the historical artifact record, an admitted InTr receipt, and a persistence receipt. The resulting historical import receipt proves that those evidence references and exact-byte identity were bound together; it does **not** certify the historical artifact as true, current doctrine, publishable, or authoritative.
+
+A KV historical import may also produce a **Master Records custody-request candidate**. That candidate is only a request from the source repository. It must state that destination custody has not yet been accepted, destination acknowledgement has not been minted, and independent destination validation has not yet completed. Only the Master Records destination may independently validate and create its own custody acknowledgement.
+
+Site/MyKV may receive a bounded status projection containing artifact and receipt identifiers, import state, lineage/contradiction state, and custody-request state. The status projection does not contain historical source bytes or private content and grants no publication authority.
+
+```text
+owner authorization != reusable credential
+import receipt != truth certification
+custody request != destination custody acceptance
+bounded status != private historical content
+```
+
+See [`KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md`](./KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md) for the source and activation boundaries.
+
 ## Technical review
 
 Developers and reviewers should start with [`docs/TECHNICAL_REVIEW_PATH.md`](./docs/TECHNICAL_REVIEW_PATH.md), [`SECURITY.md`](./SECURITY.md), and [`stegverse.architecture.json`](./stegverse.architecture.json).

--- a/data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json
+++ b/data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "1.0.0",
+  "registry_fragment_type": "stegverse_session_work_claim_registry_fragment",
+  "repository": "StegVerse-Labs/continuity-vault-kit",
+  "claims": [
+    {
+      "claim_id": "CVK-HISTORICAL-CORPUS-IMPORT-191-20260905",
+      "session_worker_id": "chatgpt:cvk-historical-corpus-import-191-20260905",
+      "task_id": "KV-HISTORICAL-CORPUS-IMPORT-001",
+      "originating_goal": "Implement the first owner-authorized historical-corpus import/receipt path using merged historical provenance, existing direct-source/SKAP/InTr boundaries, source-only Master Records custody requests, and bounded Site/MyKV status projections.",
+      "repository": "StegVerse-Labs/continuity-vault-kit",
+      "branch": "feature/kv-historical-corpus-import-191",
+      "role": "ACTIVE_IMPLEMENTATION",
+      "state": "CLAIMED_FOR_IMPLEMENTATION",
+      "normalized_work_key": "kv-historical-corpus-import-001",
+      "dependency_surface_keys": [
+        "kv:historical-provenance",
+        "kv:direct-source-ingress",
+        "kv:intr-admission",
+        "master-records:custody-request",
+        "site:mykv-status-projection"
+      ],
+      "governing_dependency_keys": ["kv:historical-provenance", "kv:intr-admission"],
+      "claimed_paths": [
+        "KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md",
+        "schemas/kv-historical-import-receipt.schema.json",
+        "schemas/kv-historical-custody-request.schema.json",
+        "schemas/kv-historical-status-projection.schema.json",
+        "runtime/historical_corpus_import.py",
+        "tests/test_historical_corpus_import.py",
+        "tests/test_global_hosted_workflow_authority.py",
+        "tools/check_kv_historical_corpus_import.py",
+        ".github/workflows/kv-historical-corpus-import.yml",
+        "README.md",
+        "data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json"
+      ],
+      "handoff": "KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md",
+      "handoff_revision": "SOURCE_IMPLEMENTATION_20260905",
+      "claim_created_at": "2026-09-05T22:41:00-05:00",
+      "claim_expires_when": "Release after source validation and merge; authentic owner-authorized corpus execution and destination Master Records custody remain separate runtime/destination evidence gates.",
+      "expected_evidence": [
+        "historical artifact exact-byte binding reused",
+        "owner authorization evidence reference required",
+        "InTr admission and persistence receipt references required",
+        "import receipt canonical hash validated",
+        "Master Records request cannot mint destination acceptance or acknowledgement",
+        "bounded Site/MyKV projection excludes private content",
+        "README capability semantics updated in same change set",
+        "hosted workflow authority census advanced exactly for added read-only workflow",
+        "source PR exact-head validation observed"
+      ],
+      "collision_boundaries": [
+        "Do not modify CVK-LEGACY-KV-UPGRADE-174 paths or either physical vault",
+        "Do not modify PR #161 portable direct-source canonical-raw persistence paths",
+        "Do not duplicate provider capability registry or direct-source authority",
+        "Do not mint Master Records destination custody or acknowledgement from CVK",
+        "Do not expose historical source bytes/private content to Site/MyKV",
+        "Do not claim provider access or live corpus import from source state"
+      ],
+      "next_task_after_release": "Execute one authentic owner-selected historical artifact import through existing provider/SKAP/InTr boundaries, then submit the resulting source-bound custody request to Master Records for independent destination validation and project only bounded status to Site/MyKV.",
+      "credential_authority": "TV/TVC",
+      "credential_requirement": "NONE_FOR_SOURCE_IMPLEMENTATION",
+      "github_token_runtime_authority": "NONE",
+      "non_tv_tvc_secret_or_token_used": false,
+      "authority_effect": false,
+      "activation_effect": false,
+      "archive_eligible": false
+    }
+  ]
+}

--- a/runtime/historical_corpus_import.py
+++ b/runtime/historical_corpus_import.py
@@ -1,0 +1,257 @@
+"""Deterministic historical-corpus import, custody-request, and bounded status helpers.
+
+This module performs no provider access, network access, Master Records write, Site
+publication, or vault migration. It validates caller-supplied evidence references
+and exact bytes against the canonical historical provenance record.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict
+
+from runtime.historical_provenance import assert_artifact_record
+
+IMPORT_SCHEMA = "stegverse.kv.historical-import-receipt/v1"
+CUSTODY_SCHEMA = "stegverse.kv.historical-custody-request/v1"
+STATUS_SCHEMA = "stegverse.kv.historical-status-projection/v1"
+
+FORBIDDEN_REF_FRAGMENTS = (
+    "access_token=",
+    "refresh_token=",
+    "password=",
+    "api_key=",
+    "secret=",
+    "private_key=",
+    "bearer ",
+)
+
+
+class HistoricalCorpusImportError(ValueError):
+    pass
+
+
+def _required_text(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise HistoricalCorpusImportError(f"{name} is required")
+    text = value.strip()
+    lowered = text.lower()
+    if any(fragment in lowered for fragment in FORBIDDEN_REF_FRAGMENTS):
+        raise HistoricalCorpusImportError(f"{name} may not contain reusable credential material")
+    return text
+
+
+def _canonical_sha256(value: Dict[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_import_receipt(
+    *,
+    artifact_record: Dict[str, Any],
+    exact_bytes: bytes,
+    owner_authorization_ref: str,
+    intr_admission_receipt_ref: str,
+    persistence_receipt_ref: str,
+    imported_at: str,
+    direct_source_receipt_ref: str | None = None,
+) -> Dict[str, Any]:
+    """Build a receipt for an already-admitted/persisted historical import event.
+
+    The caller must supply the real authorization/admission/persistence evidence at
+    runtime. Source validation uses synthetic references only and does not establish
+    a live import.
+    """
+    if not isinstance(exact_bytes, (bytes, bytearray)):
+        raise HistoricalCorpusImportError("exact_bytes must be bytes")
+    try:
+        assert_artifact_record(artifact_record, exact_bytes=bytes(exact_bytes))
+    except Exception as exc:  # preserve the provenance validator as canonical
+        raise HistoricalCorpusImportError(str(exc)) from exc
+
+    auth_ref = _required_text(owner_authorization_ref, "owner_authorization_ref")
+    intr_ref = _required_text(intr_admission_receipt_ref, "intr_admission_receipt_ref")
+    persist_ref = _required_text(persistence_receipt_ref, "persistence_receipt_ref")
+    imported_at = _required_text(imported_at, "imported_at")
+    source_ref = None if direct_source_receipt_ref is None else _required_text(
+        direct_source_receipt_ref, "direct_source_receipt_ref"
+    )
+
+    core = {
+        "schema_version": IMPORT_SCHEMA,
+        "artifact_id": artifact_record["artifact_id"],
+        "artifact_sha256": artifact_record["exact_sha256"],
+        "artifact_receipt_id": artifact_record["receipt_id"],
+        "relationship_kind": artifact_record["relationship"]["kind"],
+        "contradiction_state": artifact_record["contradiction_state"],
+        "owner_authorization_ref": auth_ref,
+        "direct_source_receipt_ref": source_ref,
+        "intr_admission_receipt_ref": intr_ref,
+        "persistence_receipt_ref": persist_ref,
+        "imported_at": imported_at,
+        "state": "ADMITTED_PERSISTED",
+        "truth_certified": False,
+        "private_content_included": False,
+        "authority_posture": {
+            "execution": False,
+            "governance": False,
+            "publication": False,
+            "doctrine": False,
+            "provider_write": False,
+            "migration": False,
+            "master_records_destination": False,
+        },
+    }
+    digest = _canonical_sha256(core)
+    return {**core, "receipt_sha256": digest, "receipt_id": f"kvhistimport:{artifact_record['artifact_id']}:{digest}"}
+
+
+def assert_import_receipt(
+    receipt: Dict[str, Any], *, artifact_record: Dict[str, Any] | None = None
+) -> None:
+    if not isinstance(receipt, dict) or receipt.get("schema_version") != IMPORT_SCHEMA:
+        raise HistoricalCorpusImportError("import receipt schema mismatch")
+    if receipt.get("state") != "ADMITTED_PERSISTED":
+        raise HistoricalCorpusImportError("historical import receipt must be admitted and persisted")
+    for key in (
+        "artifact_id",
+        "artifact_sha256",
+        "artifact_receipt_id",
+        "owner_authorization_ref",
+        "intr_admission_receipt_ref",
+        "persistence_receipt_ref",
+        "imported_at",
+    ):
+        _required_text(receipt.get(key), key)
+    if receipt.get("direct_source_receipt_ref") is not None:
+        _required_text(receipt.get("direct_source_receipt_ref"), "direct_source_receipt_ref")
+    if receipt.get("truth_certified") is not False or receipt.get("private_content_included") is not False:
+        raise HistoricalCorpusImportError("import receipt may not certify truth or contain private content")
+    posture = receipt.get("authority_posture")
+    required_false = {
+        "execution",
+        "governance",
+        "publication",
+        "doctrine",
+        "provider_write",
+        "migration",
+        "master_records_destination",
+    }
+    if not isinstance(posture, dict) or any(posture.get(key) is not False for key in required_false):
+        raise HistoricalCorpusImportError("import receipt may not grant authority")
+
+    core = dict(receipt)
+    receipt_id = core.pop("receipt_id", None)
+    digest = core.pop("receipt_sha256", None)
+    expected = _canonical_sha256(core)
+    if digest != expected or receipt_id != f"kvhistimport:{receipt['artifact_id']}:{expected}":
+        raise HistoricalCorpusImportError("import receipt canonical hash mismatch")
+
+    if artifact_record is not None:
+        try:
+            assert_artifact_record(artifact_record)
+        except Exception as exc:
+            raise HistoricalCorpusImportError(str(exc)) from exc
+        if receipt["artifact_id"] != artifact_record["artifact_id"]:
+            raise HistoricalCorpusImportError("artifact id mismatch")
+        if receipt["artifact_sha256"] != artifact_record["exact_sha256"]:
+            raise HistoricalCorpusImportError("artifact hash mismatch")
+        if receipt["artifact_receipt_id"] != artifact_record["receipt_id"]:
+            raise HistoricalCorpusImportError("artifact receipt mismatch")
+        if receipt.get("relationship_kind") != artifact_record["relationship"]["kind"]:
+            raise HistoricalCorpusImportError("relationship kind mismatch")
+        if receipt.get("contradiction_state") != artifact_record["contradiction_state"]:
+            raise HistoricalCorpusImportError("contradiction state mismatch")
+
+
+def build_master_records_custody_request(*, import_receipt: Dict[str, Any], requested_at: str) -> Dict[str, Any]:
+    assert_import_receipt(import_receipt)
+    requested_at = _required_text(requested_at, "requested_at")
+    return {
+        "schema_version": CUSTODY_SCHEMA,
+        "source_repository": "StegVerse-Labs/continuity-vault-kit",
+        "artifact_id": import_receipt["artifact_id"],
+        "artifact_sha256": import_receipt["artifact_sha256"],
+        "import_receipt_id": import_receipt["receipt_id"],
+        "import_receipt_sha256": import_receipt["receipt_sha256"],
+        "requested_at": requested_at,
+        "custody_requested": True,
+        "destination_repository": "master-records/core-lite",
+        "destination_custody_accepted": False,
+        "destination_acknowledgement_minted": False,
+        "independent_validation_complete": False,
+        "runtime_activation": False,
+        "execution_authority_granted": False,
+        "continuity_receipt_minted": False,
+        "publication_authority_granted": False,
+        "authority_effect": "NONE_CUSTODY_REQUEST_ONLY",
+    }
+
+
+def assert_master_records_custody_request(request: Dict[str, Any]) -> None:
+    if not isinstance(request, dict) or request.get("schema_version") != CUSTODY_SCHEMA:
+        raise HistoricalCorpusImportError("custody request schema mismatch")
+    if request.get("source_repository") != "StegVerse-Labs/continuity-vault-kit":
+        raise HistoricalCorpusImportError("custody source repository mismatch")
+    if request.get("destination_repository") != "master-records/core-lite":
+        raise HistoricalCorpusImportError("custody destination repository mismatch")
+    if request.get("custody_requested") is not True:
+        raise HistoricalCorpusImportError("custody request must declare custody_requested=true")
+    for key in (
+        "destination_custody_accepted",
+        "destination_acknowledgement_minted",
+        "independent_validation_complete",
+        "runtime_activation",
+        "execution_authority_granted",
+        "continuity_receipt_minted",
+        "publication_authority_granted",
+    ):
+        if request.get(key) is not False:
+            raise HistoricalCorpusImportError(f"custody request may not assert {key}")
+    if request.get("authority_effect") != "NONE_CUSTODY_REQUEST_ONLY":
+        raise HistoricalCorpusImportError("custody request authority effect mismatch")
+    for key in ("artifact_id", "artifact_sha256", "import_receipt_id", "import_receipt_sha256", "requested_at"):
+        _required_text(request.get(key), key)
+
+
+def build_site_status_projection(
+    *, import_receipt: Dict[str, Any], custody_request: Dict[str, Any] | None = None
+) -> Dict[str, Any]:
+    assert_import_receipt(import_receipt)
+    if custody_request is not None:
+        assert_master_records_custody_request(custody_request)
+        if custody_request["import_receipt_id"] != import_receipt["receipt_id"]:
+            raise HistoricalCorpusImportError("custody request/import receipt mismatch")
+    return {
+        "schema_version": STATUS_SCHEMA,
+        "artifact_id": import_receipt["artifact_id"],
+        "artifact_sha256": import_receipt["artifact_sha256"],
+        "import_receipt_id": import_receipt["receipt_id"],
+        "import_state": import_receipt["state"],
+        "relationship_kind": import_receipt["relationship_kind"],
+        "contradiction_state": import_receipt["contradiction_state"],
+        "custody_requested": bool(custody_request and custody_request["custody_requested"]),
+        "destination_custody_accepted": False,
+        "destination_acknowledgement_minted": False,
+        "private_content_included": False,
+        "publication_authority_granted": False,
+        "authority_effect": "NONE_STATUS_ONLY",
+    }
+
+
+def assert_site_status_projection(projection: Dict[str, Any]) -> None:
+    if not isinstance(projection, dict) or projection.get("schema_version") != STATUS_SCHEMA:
+        raise HistoricalCorpusImportError("status projection schema mismatch")
+    for key in ("artifact_id", "artifact_sha256", "import_receipt_id", "import_state"):
+        _required_text(projection.get(key), key)
+    if projection.get("private_content_included") is not False:
+        raise HistoricalCorpusImportError("status projection may not include private content")
+    if projection.get("publication_authority_granted") is not False:
+        raise HistoricalCorpusImportError("status projection may not grant publication authority")
+    if projection.get("destination_custody_accepted") is not False:
+        raise HistoricalCorpusImportError("source status may not assert Master Records acceptance")
+    if projection.get("destination_acknowledgement_minted") is not False:
+        raise HistoricalCorpusImportError("source status may not assert Master Records acknowledgement")
+    if projection.get("authority_effect") != "NONE_STATUS_ONLY":
+        raise HistoricalCorpusImportError("status projection authority effect mismatch")

--- a/schemas/kv-historical-custody-request.schema.json
+++ b/schemas/kv-historical-custody-request.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-historical-custody-request.schema.json",
+  "title": "KnowledgeVault Historical Master Records Custody Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version","source_repository","artifact_id","artifact_sha256","import_receipt_id","import_receipt_sha256","requested_at","custody_requested","destination_repository","destination_custody_accepted","destination_acknowledgement_minted","independent_validation_complete","runtime_activation","execution_authority_granted","continuity_receipt_minted","publication_authority_granted","authority_effect"],
+  "properties": {
+    "schema_version": {"const": "stegverse.kv.historical-custody-request/v1"},
+    "source_repository": {"const": "StegVerse-Labs/continuity-vault-kit"},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "artifact_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "import_receipt_id": {"type": "string", "minLength": 1},
+    "import_receipt_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "requested_at": {"type": "string", "minLength": 1},
+    "custody_requested": {"const": true},
+    "destination_repository": {"const": "master-records/core-lite"},
+    "destination_custody_accepted": {"const": false},
+    "destination_acknowledgement_minted": {"const": false},
+    "independent_validation_complete": {"const": false},
+    "runtime_activation": {"const": false},
+    "execution_authority_granted": {"const": false},
+    "continuity_receipt_minted": {"const": false},
+    "publication_authority_granted": {"const": false},
+    "authority_effect": {"const": "NONE_CUSTODY_REQUEST_ONLY"}
+  }
+}

--- a/schemas/kv-historical-import-receipt.schema.json
+++ b/schemas/kv-historical-import-receipt.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-historical-import-receipt.schema.json",
+  "title": "KnowledgeVault Historical Import Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version","artifact_id","artifact_sha256","artifact_receipt_id","relationship_kind","contradiction_state","owner_authorization_ref","direct_source_receipt_ref","intr_admission_receipt_ref","persistence_receipt_ref","imported_at","state","truth_certified","private_content_included","authority_posture","receipt_sha256","receipt_id"],
+  "properties": {
+    "schema_version": {"const": "stegverse.kv.historical-import-receipt/v1"},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "artifact_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "artifact_receipt_id": {"type": "string", "minLength": 1},
+    "relationship_kind": {"enum": ["ORIGINAL","COPY","MIRROR","DERIVED","UNKNOWN"]},
+    "contradiction_state": {"enum": ["NONE","UNRESOLVED","CONFLICTING_SOURCE","UNKNOWN"]},
+    "owner_authorization_ref": {"type": "string", "minLength": 1},
+    "direct_source_receipt_ref": {"type": ["string","null"]},
+    "intr_admission_receipt_ref": {"type": "string", "minLength": 1},
+    "persistence_receipt_ref": {"type": "string", "minLength": 1},
+    "imported_at": {"type": "string", "minLength": 1},
+    "state": {"const": "ADMITTED_PERSISTED"},
+    "truth_certified": {"const": false},
+    "private_content_included": {"const": false},
+    "authority_posture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["execution","governance","publication","doctrine","provider_write","migration","master_records_destination"],
+      "properties": {
+        "execution": {"const": false}, "governance": {"const": false}, "publication": {"const": false},
+        "doctrine": {"const": false}, "provider_write": {"const": false}, "migration": {"const": false},
+        "master_records_destination": {"const": false}
+      }
+    },
+    "receipt_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "receipt_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/schemas/kv-historical-status-projection.schema.json
+++ b/schemas/kv-historical-status-projection.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-historical-status-projection.schema.json",
+  "title": "KnowledgeVault Historical Import Status Projection",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version","artifact_id","artifact_sha256","import_receipt_id","import_state","relationship_kind","contradiction_state","custody_requested","destination_custody_accepted","destination_acknowledgement_minted","private_content_included","publication_authority_granted","authority_effect"],
+  "properties": {
+    "schema_version": {"const": "stegverse.kv.historical-status-projection/v1"},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "artifact_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "import_receipt_id": {"type": "string", "minLength": 1},
+    "import_state": {"const": "ADMITTED_PERSISTED"},
+    "relationship_kind": {"enum": ["ORIGINAL","COPY","MIRROR","DERIVED","UNKNOWN"]},
+    "contradiction_state": {"enum": ["NONE","UNRESOLVED","CONFLICTING_SOURCE","UNKNOWN"]},
+    "custody_requested": {"type": "boolean"},
+    "destination_custody_accepted": {"const": false},
+    "destination_acknowledgement_minted": {"const": false},
+    "private_content_included": {"const": false},
+    "publication_authority_granted": {"const": false},
+    "authority_effect": {"const": "NONE_STATUS_ONLY"}
+  }
+}

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -16,7 +16,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),49)
+        self.assertEqual(len(workflows),50)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tests/test_historical_corpus_import.py
+++ b/tests/test_historical_corpus_import.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import copy
+import unittest
+
+from runtime.historical_provenance import build_artifact_record
+from runtime.historical_corpus_import import (
+    HistoricalCorpusImportError,
+    assert_import_receipt,
+    assert_master_records_custody_request,
+    assert_site_status_projection,
+    build_import_receipt,
+    build_master_records_custody_request,
+    build_site_status_projection,
+)
+
+
+class HistoricalCorpusImportTests(unittest.TestCase):
+    def setUp(self):
+        self.payload = b"exact historical artifact bytes\n"
+        self.artifact = build_artifact_record(
+            artifact_id="artifact-001",
+            exact_bytes=self.payload,
+            original_filename="artifact.txt",
+            source_provider="owner-controlled-storage",
+            source_storage_class="historical-evidence",
+            source_locator_ref="provider:history/artifact.txt",
+            first_observed_at="2026-05-20T12:00:00-05:00",
+            ingested_at="2026-09-05T22:00:00-05:00",
+            relationship_kind="ORIGINAL",
+            contradiction_state="UNRESOLVED",
+        )
+        self.receipt = build_import_receipt(
+            artifact_record=self.artifact,
+            exact_bytes=self.payload,
+            owner_authorization_ref="owner-auth:receipt-001",
+            direct_source_receipt_ref="kv-direct-source:receipt-001",
+            intr_admission_receipt_ref="intr:admission-001",
+            persistence_receipt_ref="kv:persistence-001",
+            imported_at="2026-09-05T22:01:00-05:00",
+        )
+
+    def test_import_receipt_binds_artifact_and_preserves_non_authority(self):
+        assert_import_receipt(self.receipt, artifact_record=self.artifact)
+        self.assertEqual(self.receipt["contradiction_state"], "UNRESOLVED")
+        self.assertFalse(self.receipt["truth_certified"])
+        self.assertTrue(all(value is False for value in self.receipt["authority_posture"].values()))
+
+    def test_byte_drift_fails_closed(self):
+        with self.assertRaises(HistoricalCorpusImportError):
+            build_import_receipt(
+                artifact_record=self.artifact,
+                exact_bytes=b"changed bytes",
+                owner_authorization_ref="owner-auth:receipt-001",
+                intr_admission_receipt_ref="intr:admission-001",
+                persistence_receipt_ref="kv:persistence-001",
+                imported_at="2026-09-05T22:01:00-05:00",
+            )
+
+    def test_missing_or_secret_bearing_owner_authorization_fails_closed(self):
+        for ref in ("", "owner-auth:?access_token=abc"):
+            with self.assertRaises(HistoricalCorpusImportError):
+                build_import_receipt(
+                    artifact_record=self.artifact,
+                    exact_bytes=self.payload,
+                    owner_authorization_ref=ref,
+                    intr_admission_receipt_ref="intr:admission-001",
+                    persistence_receipt_ref="kv:persistence-001",
+                    imported_at="2026-09-05T22:01:00-05:00",
+                )
+
+    def test_import_receipt_hash_and_authority_tamper_fail(self):
+        tampered = copy.deepcopy(self.receipt)
+        tampered["authority_posture"]["publication"] = True
+        with self.assertRaises(HistoricalCorpusImportError):
+            assert_import_receipt(tampered)
+
+        tampered = copy.deepcopy(self.receipt)
+        tampered["contradiction_state"] = "NONE"
+        with self.assertRaises(HistoricalCorpusImportError):
+            assert_import_receipt(tampered)
+
+    def test_custody_request_cannot_mint_destination_acceptance(self):
+        request = build_master_records_custody_request(
+            import_receipt=self.receipt,
+            requested_at="2026-09-05T22:02:00-05:00",
+        )
+        assert_master_records_custody_request(request)
+        self.assertTrue(request["custody_requested"])
+        self.assertFalse(request["destination_custody_accepted"])
+        self.assertFalse(request["destination_acknowledgement_minted"])
+
+        tampered = copy.deepcopy(request)
+        tampered["destination_custody_accepted"] = True
+        with self.assertRaises(HistoricalCorpusImportError):
+            assert_master_records_custody_request(tampered)
+
+    def test_site_projection_is_bounded_and_non_authorizing(self):
+        request = build_master_records_custody_request(
+            import_receipt=self.receipt,
+            requested_at="2026-09-05T22:02:00-05:00",
+        )
+        projection = build_site_status_projection(import_receipt=self.receipt, custody_request=request)
+        assert_site_status_projection(projection)
+        self.assertTrue(projection["custody_requested"])
+        self.assertFalse(projection["private_content_included"])
+        self.assertFalse(projection["publication_authority_granted"])
+        self.assertNotIn("source", projection)
+        self.assertNotIn("bytes", projection)
+
+    def test_site_projection_rejects_mismatched_custody_request(self):
+        request = build_master_records_custody_request(
+            import_receipt=self.receipt,
+            requested_at="2026-09-05T22:02:00-05:00",
+        )
+        request["import_receipt_id"] = "other"
+        with self.assertRaises(HistoricalCorpusImportError):
+            build_site_status_projection(import_receipt=self.receipt, custody_request=request)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_kv_historical_corpus_import.py
+++ b/tools/check_kv_historical_corpus_import.py
@@ -4,7 +4,12 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from runtime.historical_provenance import build_artifact_record
 from runtime.historical_corpus_import import (
@@ -17,7 +22,6 @@ from runtime.historical_corpus_import import (
     build_site_status_projection,
 )
 
-ROOT = Path(__file__).resolve().parents[1]
 HANDOFF = ROOT / "KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md"
 README = ROOT / "README.md"
 SCHEMAS = {

--- a/tools/check_kv_historical_corpus_import.py
+++ b/tools/check_kv_historical_corpus_import.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Dependency-light source validator for historical-corpus import semantics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from runtime.historical_provenance import build_artifact_record
+from runtime.historical_corpus_import import (
+    HistoricalCorpusImportError,
+    assert_import_receipt,
+    assert_master_records_custody_request,
+    assert_site_status_projection,
+    build_import_receipt,
+    build_master_records_custody_request,
+    build_site_status_projection,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+HANDOFF = ROOT / "KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md"
+README = ROOT / "README.md"
+SCHEMAS = {
+    "https://stegverse.org/schemas/kv-historical-import-receipt.schema.json": ROOT / "schemas/kv-historical-import-receipt.schema.json",
+    "https://stegverse.org/schemas/kv-historical-custody-request.schema.json": ROOT / "schemas/kv-historical-custody-request.schema.json",
+    "https://stegverse.org/schemas/kv-historical-status-projection.schema.json": ROOT / "schemas/kv-historical-status-projection.schema.json",
+}
+
+
+def main() -> int:
+    for expected_id, path in SCHEMAS.items():
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        if schema.get("$id") != expected_id:
+            raise SystemExit(f"schema id mismatch: {path.name}")
+
+    handoff = HANDOFF.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    for invariant in (
+        "import_receipt != truth_certification",
+        "custody_request != destination_custody_acceptance",
+        "site_status_projection != private_content",
+        "source_merge != live_provider_observation",
+    ):
+        if invariant not in handoff:
+            raise SystemExit(f"handoff invariant missing: {invariant}")
+    if "Owner-authorized historical imports and custody" not in readme:
+        raise SystemExit("README historical import/custody section missing")
+
+    payload = b"historical-corpus-import-validation-vector"
+    artifact = build_artifact_record(
+        artifact_id="validation-artifact-001",
+        exact_bytes=payload,
+        original_filename="validation.bin",
+        source_provider="owner-controlled-storage",
+        source_storage_class="historical-evidence",
+        source_locator_ref="provider:validation/historical.bin",
+        first_observed_at="2026-09-05T22:00:00-05:00",
+        ingested_at="2026-09-05T22:01:00-05:00",
+        relationship_kind="ORIGINAL",
+        contradiction_state="UNRESOLVED",
+    )
+    receipt = build_import_receipt(
+        artifact_record=artifact,
+        exact_bytes=payload,
+        owner_authorization_ref="owner-auth:synthetic-validation-only",
+        direct_source_receipt_ref="direct-source:synthetic-validation-only",
+        intr_admission_receipt_ref="intr:synthetic-validation-only",
+        persistence_receipt_ref="kv:synthetic-validation-only",
+        imported_at="2026-09-05T22:02:00-05:00",
+    )
+    assert_import_receipt(receipt, artifact_record=artifact)
+
+    custody = build_master_records_custody_request(
+        import_receipt=receipt,
+        requested_at="2026-09-05T22:03:00-05:00",
+    )
+    assert_master_records_custody_request(custody)
+    if custody["destination_custody_accepted"] or custody["destination_acknowledgement_minted"]:
+        raise SystemExit("source validator may not mint Master Records destination state")
+
+    projection = build_site_status_projection(import_receipt=receipt, custody_request=custody)
+    assert_site_status_projection(projection)
+    if projection["private_content_included"]:
+        raise SystemExit("bounded Site projection contains private content")
+
+    try:
+        build_import_receipt(
+            artifact_record=artifact,
+            exact_bytes=b"tampered",
+            owner_authorization_ref="owner-auth:synthetic-validation-only",
+            intr_admission_receipt_ref="intr:synthetic-validation-only",
+            persistence_receipt_ref="kv:synthetic-validation-only",
+            imported_at="2026-09-05T22:02:00-05:00",
+        )
+    except HistoricalCorpusImportError:
+        pass
+    else:
+        raise SystemExit("exact-byte drift negative control failed")
+
+    print("KV historical corpus import source validation: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements #191.

Machine preflight completed before functional mutation. It resolved the repository handoff, predecessor historical-provenance handoff, canonical task-registry authority split, Master Records handoff, active legacy-KV migration claim, and open PR collision surfaces.

This PR adds:
- canonical `KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md`;
- exact-byte import receipt schema and deterministic builder/validator;
- source-only Master Records custody-request candidate that cannot mint destination acceptance or acknowledgement;
- bounded Site/MyKV status projection with no private content;
- regression tests for byte drift, missing/secret-bearing authorization, receipt tamper, authority escalation, custody escalation, and custody/import mismatch;
- read-only validation workflow and exact workflow-census advance from 49 to 50;
- README capability semantics in the same change set;
- bounded session-work claim.

The implementation reuses `runtime/historical_provenance.py` and existing direct-source/SKAP/InTr semantics. It does not modify PR #161 portable raw-persistence paths, the legacy iCloud upgrade lane, either physical KV, or PR #186 connector documentation.

Runtime/authority boundary: source-only. No provider login, private-content discovery, live historical import, Master Records write, Site publication, migration, execution authority, governance authority, or publication authority is claimed from source state.