### PR TITLE
Finalize historical corpus import source handoff

### DIFF
--- a/KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md
+++ b/KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md
@@ -1,9 +1,10 @@
 # KV Historical Corpus Import Mirror Handoff
 
-Status: SOURCE_IMPLEMENTED / VALIDATION_PENDING  
+Status: SOURCE_MERGED_VALIDATED / LIVE_OWNER_AUTHORIZED_EXECUTION_PENDING  
 Repository: `StegVerse-Labs/continuity-vault-kit`  
 Issue: `#191`  
-Branch: `feature/kv-historical-corpus-import-191`  
+Implementation PR: `#193`  
+Merge commit: `7b84542d814ff18c132cfc4e6962f5a37d38c830`  
 Updated: 2026-09-05  
 Authority effect: NONE  
 Activation effect: false
@@ -24,7 +25,7 @@ This work consumes rather than replaces:
 - existing Interlock/InTr boundaries for governed ingress/egress;
 - Master Records destination custody semantics, which remain independently validating and non-authorizing.
 
-No parallel provider ingress, historical identity, credential authority, task authority, or Master Records authority is introduced.
+No parallel provider ingress, historical identity, credential authority, task authority, or Master Records authority was introduced.
 
 ## Machine preflight — 2026-09-05
 
@@ -32,35 +33,33 @@ Preflight state: `PASS_FOR_BOUNDED_SOURCE_IMPLEMENTATION`.
 
 Resolved before functional mutation:
 
-1. The repository-wide canonical handoff remains `docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`.
-2. The immediate predecessor handoff is `KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md`; issue #188 is source-complete and names this task as its next integration candidate.
-3. Canonical ecosystem task registry generation 15 preserves the authority split: Task Registry = work intent/coordination; WorkerCoordinator = execution claim/fence authority; Master Records = observed-reality/reconstruction authority; Interlock/InTr = governed task ingress/egress. This issue does not mint execution authority from repository state.
-4. `master-records/core-lite/MASTER_RECORDS_MIRROR_HANDOFF.md` remains the current Master Records repository-wide handoff. Its custody pattern requires independent validation before destination acknowledgement and explicitly separates custody from runtime, execution, publication, and continuity authority.
-5. No existing `KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md` or implementation for `KV-HISTORICAL-CORPUS-IMPORT-001` existed on `main`; creating this handoff was therefore the first required task action.
-6. Existing `CVK-LEGACY-KV-UPGRADE-174` remains a separate migration/reinstall lane. This task does not modify or overwrite either the legacy iCloud KnowledgeVault or the current Google Drive KnowledgeVault.
-7. Open PR #161 owns portable direct-source canonical-raw persistence paths. This task does not modify `runtime/portable_direct_source_ingress.py`, its tests, or its mirror handoffs; it consumes merged/public contracts only.
-8. Open PR #186 changes only governed connector capability documentation and does not overlap the source paths claimed here.
+1. The repository-wide canonical handoff remained `docs/CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`.
+2. The predecessor `KV_HISTORICAL_PROVENANCE_MIRROR_HANDOFF.md` was source-complete and named this task as its next integration candidate.
+3. Canonical ecosystem task registry generation 15 preserved the authority split: Task Registry = work intent/coordination; WorkerCoordinator = execution claim/fence authority; Master Records = observed-reality/reconstruction authority; Interlock/InTr = governed task ingress/egress.
+4. `master-records/core-lite/MASTER_RECORDS_MIRROR_HANDOFF.md` remained the current Master Records repository-wide handoff and required independent destination validation before acknowledgement/custody acceptance.
+5. No duplicate historical-corpus import handoff/implementation existed on `main` before this task.
+6. `CVK-LEGACY-KV-UPGRADE-174` remained a separate migration/reinstall lane and neither physical KV was modified.
+7. Open PR #161 owned portable direct-source canonical-raw persistence paths; this task did not modify those paths.
+8. Open PR #186 changed only governed connector capability documentation and did not overlap this task's source paths.
 
 ## README completeness predicate
 
-README change required: **YES**, and satisfied in this source change set.
+README change required: **YES**, and satisfied in PR #193.
 
-Reason: this task advances capability meaning from passive historical-provenance records to an explicit owner-authorized import receipt, custody-request projection, and bounded downstream status model. The README now states that import/custody proves receipt and lineage only, does not certify truth, and does not grant publication, governance, execution, migration, provider-write, or Master Records destination-acknowledgement authority.
+The README now documents owner-authorized historical import receipts, source-only Master Records custody requests, bounded Site/MyKV status projection, and the non-authority boundaries around truth, publication, governance, execution, migration, provider write, and destination custody acknowledgement.
 
 ## Implemented source behavior
 
-The bounded source implementation:
+The merged implementation:
 
-1. accepts caller-supplied exact bytes plus owner-authorization, InTr admission, and persistence evidence references;
-2. reuses `assert_artifact_record()` for exact-byte historical identity rather than creating a second historical identity implementation;
-3. emits a deterministic historical import receipt whose canonical hash covers artifact identity, relationship/contradiction state, authorization reference, admission/persistence evidence, and time;
-4. emits a Master Records custody-request candidate that explicitly has `destination_acknowledgement_minted=false`, `destination_custody_accepted=false`, and `independent_validation_complete=false`;
+1. requires caller-supplied exact bytes plus owner-authorization, InTr admission, and persistence evidence references;
+2. reuses `assert_artifact_record()` for exact-byte historical identity;
+3. emits a deterministic historical import receipt whose canonical hash binds artifact identity, relationship/contradiction state, authorization reference, admission/persistence evidence, and time;
+4. emits a Master Records custody-request candidate with destination acceptance/acknowledgement and independent validation fixed false;
 5. preserves ORIGINAL/COPY/MIRROR/DERIVED lineage and contradiction state without silent merge;
-6. emits a bounded Site/MyKV status projection containing identifiers/state only with `private_content_included=false`;
+6. emits a bounded Site/MyKV status projection with identifiers/state only and `private_content_included=false`;
 7. fails closed on byte/hash mismatch, missing or secret-bearing authorization references, authority escalation, receipt tamper, invalid destination custody assertions, and custody/import mismatch;
-8. advances the exact repository read-only hosted workflow census from 49 to 50 for the added validation workflow.
-
-The source helper performs no provider login, network access, private-vault discovery, publication, vault migration, or Master Records write.
+8. advances the exact read-only hosted workflow census from 49 to 50 for the added validation workflow.
 
 ## Governing invariants
 
@@ -75,7 +74,7 @@ site_status_projection != private_content
 source_merge != live_provider_observation
 ```
 
-## Implemented / claimed source paths
+## Implemented source surfaces
 
 - `KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md`
 - `schemas/kv-historical-import-receipt.schema.json`
@@ -89,14 +88,55 @@ source_merge != live_provider_observation
 - `data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json`
 - `README.md`
 
-## Validation boundary
+## Validation evidence
 
-Source implementation is installed on the feature branch. Completion still requires exact-head applicable hosted validation and source merge. No validation or activation is inferred from the presence of these files.
+Initial PR head `ff434e4317ca1b17a89911a2aa356035b6685551` exposed one task-local validator packaging defect: direct execution of `tools/check_kv_historical_corpus_import.py` could not resolve the repository `runtime` package. Focused unit tests had already passed. The validator was corrected to place the repository root on `sys.path`; no capability or authority semantics were weakened.
 
-Live corpus activation remains separate. It requires an owner-selected artifact and explicit owner authorization at runtime. A repository merge must not be represented as evidence that iCloud, Google Drive, or any private historical artifact was accessed.
+Final validated head: `ed18b0f0a62669247b38642eb00ce3e4d07f3acf`.
 
-Master Records custody is also a separate destination action. This repository may construct a custody-request candidate, but only Master Records may independently validate and mint its destination acknowledgement/custody record.
+Exact-head validation:
 
-## Next integration after source completion
+- `KV Historical Corpus Import` run `34009779451`: PASS;
+- `Repository validation diagnostics` run `34009779449`: PASS;
+- `Security Baseline` run `34009779452`: PASS;
+- `Release integrity` run `34009779448`: PASS;
+- `KV Historical Provenance` run `34009779465`: PASS;
+- `KV Guardrails` run `34009779487`: PASS.
 
-After source completion, the next admissible integration is an authentic owner-authorized corpus-import execution through the existing provider/SKAP/InTr path, followed by independent Master Records custody validation and a bounded Site/MyKV status projection. No source bytes are to be exposed to Site merely because import/custody metadata exists.
+PR #193 merged as `7b84542d814ff18c132cfc4e6962f5a37d38c830`.
+
+## Source completion
+
+```text
+mirror handoff: COMPLETE
+schemas: 3 / 3 COMPLETE
+runtime helper: COMPLETE
+focused tests: COMPLETE
+source validator: COMPLETE
+read-only workflow: COMPLETE
+README predicate: SATISFIED
+workflow census: 50 / 50
+exact-head applicable validation: PASS
+merge: COMPLETE
+source stubs: 0
+```
+
+## Separate live/destination boundaries
+
+No live iCloud or Google Drive access is claimed from source completion.
+No private historical artifact was accessed by this source build.
+No authentic owner-authorized corpus import has yet executed.
+No Master Records destination custody acknowledgement has yet been minted.
+No Site/MyKV live projection has yet been observed.
+
+Authentic execution requires an owner-selected historical artifact plus explicit owner authorization through the existing provider/SKAP/InTr path. Master Records must then independently validate any source custody request before minting destination custody/acknowledgement.
+
+## Next integration goal
+
+The next machine-executable integration is the destination/runtime preparation for authentic custody and bounded projection:
+
+1. install/verify the Master Records historical-corpus custody validator/contract without minting a live custody record;
+2. verify Site/MyKV can consume only the bounded status projection without private source content;
+3. keep authentic provider/artifact execution blocked until owner authorization and exact source bytes are actually supplied through the admitted runtime path.
+
+The existing propagation-verification task is `StegVerse-Labs/continuity-vault-kit#192`.

--- a/data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json
+++ b/data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json
@@ -10,17 +10,11 @@
       "originating_goal": "Implement the first owner-authorized historical-corpus import/receipt path using merged historical provenance, existing direct-source/SKAP/InTr boundaries, source-only Master Records custody requests, and bounded Site/MyKV status projections.",
       "repository": "StegVerse-Labs/continuity-vault-kit",
       "branch": "feature/kv-historical-corpus-import-191",
-      "role": "ACTIVE_IMPLEMENTATION",
-      "state": "CLAIMED_FOR_IMPLEMENTATION",
+      "role": "SOURCE_IMPLEMENTATION",
+      "state": "RELEASED_AFTER_MERGE",
       "normalized_work_key": "kv-historical-corpus-import-001",
-      "dependency_surface_keys": [
-        "kv:historical-provenance",
-        "kv:direct-source-ingress",
-        "kv:intr-admission",
-        "master-records:custody-request",
-        "site:mykv-status-projection"
-      ],
-      "governing_dependency_keys": ["kv:historical-provenance", "kv:intr-admission"],
+      "dependency_surface_keys": ["kv:historical-provenance","kv:direct-source-ingress","kv:intr-admission","master-records:custody-request","site:mykv-status-projection"],
+      "governing_dependency_keys": ["kv:historical-provenance","kv:intr-admission"],
       "claimed_paths": [
         "KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md",
         "schemas/kv-historical-import-receipt.schema.json",
@@ -35,9 +29,10 @@
         "data/session-work-claims.d/cvk-historical-corpus-import-191-20260905.json"
       ],
       "handoff": "KV_HISTORICAL_CORPUS_IMPORT_MIRROR_HANDOFF.md",
-      "handoff_revision": "SOURCE_IMPLEMENTATION_20260905",
+      "handoff_revision": "SOURCE_MERGED_VALIDATED_20260905",
       "claim_created_at": "2026-09-05T22:41:00-05:00",
-      "claim_expires_when": "Release after source validation and merge; authentic owner-authorized corpus execution and destination Master Records custody remain separate runtime/destination evidence gates.",
+      "claim_released_at": "2026-09-05T22:46:00-05:00",
+      "claim_expires_when": "RELEASED",
       "expected_evidence": [
         "historical artifact exact-byte binding reused",
         "owner authorization evidence reference required",
@@ -49,6 +44,16 @@
         "hosted workflow authority census advanced exactly for added read-only workflow",
         "source PR exact-head validation observed"
       ],
+      "validation_evidence": {
+        "final_head": "ed18b0f0a62669247b38642eb00ce3e4d07f3acf",
+        "kv_historical_corpus_import_run": 34009779451,
+        "repository_diagnostics_run": 34009779449,
+        "security_baseline_run": 34009779452,
+        "release_integrity_run": 34009779448,
+        "historical_provenance_run": 34009779465,
+        "kv_guardrails_run": 34009779487,
+        "merge_commit": "7b84542d814ff18c132cfc4e6962f5a37d38c830"
+      },
       "collision_boundaries": [
         "Do not modify CVK-LEGACY-KV-UPGRADE-174 paths or either physical vault",
         "Do not modify PR #161 portable direct-source canonical-raw persistence paths",
@@ -57,14 +62,14 @@
         "Do not expose historical source bytes/private content to Site/MyKV",
         "Do not claim provider access or live corpus import from source state"
       ],
-      "next_task_after_release": "Execute one authentic owner-selected historical artifact import through existing provider/SKAP/InTr boundaries, then submit the resulting source-bound custody request to Master Records for independent destination validation and project only bounded status to Site/MyKV.",
+      "next_task_after_release": "Prepare independent Master Records historical-corpus custody validation and verify bounded Site/MyKV status consumption; authentic artifact execution remains blocked until owner authorization and exact source bytes are supplied through the admitted runtime path.",
       "credential_authority": "TV/TVC",
       "credential_requirement": "NONE_FOR_SOURCE_IMPLEMENTATION",
       "github_token_runtime_authority": "NONE",
       "non_tv_tvc_secret_or_token_used": false,
       "authority_effect": false,
       "activation_effect": false,
-      "archive_eligible": false
+      "archive_eligible": true
     }
   ]
 }


### PR DESCRIPTION
Finalize #191 source state after PR #193 merged and the corrected exact-head validation passed.

This handoff-only change records:
- source merged/validated state and exact merge commit;
- initial validator import-path defect and its bounded repair;
- final validation run identities;
- release of the source implementation claim;
- explicit separation of live owner-authorized artifact execution, Master Records destination custody, and Site/MyKV live projection;
- next machine-executable destination/projection preparation.

README impact: no additional README mutation is required in this handoff-only change. The capability semantics were already updated in PR #193; this PR records completed evidence/state only.