### PR TITLE
Enable KV #2 and provider-neutral KV #n instances

### DIFF
--- a/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
+++ b/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
@@ -1,0 +1,129 @@
+# KV Multi-Instance COSV Binding Mirror Handoff
+
+Status: SOURCE_IMPLEMENTATION_IN_PROGRESS / CANONICAL_COSV_BOUND / RUNTIME_ACTIVATION_PENDING
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Branch: `kv-multi-instance-roots`
+Pull request: `#196`
+Updated: 2026-09-08
+Authority effect: NONE
+Activation effect: false
+
+## Canonical task binding
+
+This file does **not** create a new StegVerse task.
+
+The KV #1 / KV #2 / KV #n multi-instance and relationship-tier work is a capability slice of the existing canonical KV connection/revalidation task:
+
+```text
+GOAL TASK ID: KV-CONNECTION-REVALIDATION-WORKER-001
+COSV ID: 50000000102000
+CANONICAL COSV HANDOFF: StegVerse-Labs/.github/KV_CONNECTION_REVALIDATION_COSV_MIRROR_HANDOFF.md
+CANONICAL OWNER REPOSITORY: StegVerse-Labs/continuity-vault-kit
+REPOSITORY HANDOFF: CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
+```
+
+The organization-level COSV handoff remains authoritative for the task vector. This repository handoff records how PR #196 participates in that already-existing task.
+
+## Capability slice
+
+PR #196 extends the canonical KV connection/revalidation surface with provider-neutral multi-instance identity and explicit inter-instance relationship semantics:
+
+```text
+KV #1 -> storage medium A
+KV #2 -> storage medium A or B
+...
+KV #n -> any admitted owner-controlled storage medium
+```
+
+Each instance has an isolated root, unique `instance_id`, shared or distinct `kv_set_id` as selected, storage-medium metadata, and its own installation receipt.
+
+Instance ordinal is identity only. It does not grant priority, authority, freshness, trust, primary status, replication rank, or inheritance.
+
+## Canonical relationship tiers
+
+The inter-instance relationship has four cumulative capability tiers:
+
+```text
+NOT_CONNECTED
+  inter-comms: false
+  data movement: false
+  replication: false
+  unified AI corpus: false
+
+CONNECTED
+  inter-comms: true
+  data movement: true
+  replication: false
+  unified AI corpus: false
+
+SYNCED
+  inter-comms: true
+  data movement: true
+  replication: true
+  unified AI corpus: false
+
+AI_INTERACTION
+  inter-comms: true
+  data movement: true
+  replication: true
+  unified AI corpus: true
+```
+
+New instances begin `NOT_CONNECTED` even when they share the same owner, `kv_set_id`, or storage provider.
+
+`AI_INTERACTION` means participating KVs are exposed to an admitted AI interaction as one logical corpus. Physical roots remain distinct, provenance remains instance-specific, contradictory records are not silently collapsed, and AI does not become canonical authority over the data.
+
+## Relationship transition boundary
+
+Source code may represent or request relationship changes before Interlock/InTr runtime activation, but source state must not claim that a governed transition occurred.
+
+The source layer may therefore produce transition requests such as:
+
+```text
+NOT_CONNECTED -> CONNECTED
+CONNECTED -> SYNCED
+SYNCED -> AI_INTERACTION
+AI_INTERACTION -> SYNCED
+SYNCED -> CONNECTED
+CONNECTED -> NOT_CONNECTED
+```
+
+Actual transition admission, data movement, replication, or unified AI exposure remains a governed runtime action and must be supported by authentic Interlock/InTr/provider/private-KV evidence.
+
+## Current PR #196 artifacts
+
+- `tools/init_vault.py`
+- `runtime/kv_instance_relationships.py`
+- relationship transition request/runtime source added on the branch
+- `tests/test_multi_instance_vaults.py`
+- `docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md`
+- `README.md`
+- `tools/test_clean_room_user_kv.py`
+
+## Acceptance conditions for this capability slice
+
+Source completion requires:
+
+1. KV #2 can be created beside KV #1 without overwrite.
+2. KV #n can use any described owner-controlled storage medium without changing instance semantics.
+3. every instance has isolated identity and receipt binding.
+4. new instances default to `NOT_CONNECTED`.
+5. the four relationship tiers are encoded as machine-readable cumulative capabilities.
+6. transition requests are representable without claiming runtime authority.
+7. tests prove same-provider coexistence and relationship semantics.
+8. PR #196 is validated and merged.
+
+Runtime completion remains separate and requires authentic evidence for admitted provider/inter-instance operations.
+
+## Remaining work
+
+- obtain repository validation for the current PR #196 head;
+- remediate any failing checks;
+- merge PR #196 when validation and review gates permit;
+- materialize a real KV #2 instance without altering KV #1;
+- later bind CONNECTED/SYNCED/AI_INTERACTION runtime transitions to actual Interlock/InTr execution and evidence;
+- project the instance list and relationship tiers into MyKV add/remove/manage-drive UX.
+
+## Manual work
+
+None required for source implementation or task binding at this point. Any provider login, account authorization, or user-controlled cloud installation step remains outside source-only proof until explicitly performed through an admitted runtime/user flow.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,37 @@ Baseline use is file-based. No account, hosted service, SDK, or AI provider is r
 python3 tools/init_vault.py /path/to/parent-folder
 ```
 
+The default command creates **KV #1** at `KnowledgeVault/`.
+
+A second isolated instance can be created beside it without overwriting KV #1:
+
+```bash
+python3 tools/init_vault.py /path/to/parent-folder --instance 2 --storage-medium icloud-drive
+```
+
+That creates **KV #2** at `KnowledgeVault-2/`. The same rule extends to any positive instance number: KV #n is created at `KnowledgeVault-n/` unless `--vault-name` supplies another isolated folder name.
+
+`--storage-medium` is descriptive metadata and may identify any owner-controlled storage medium, such as `icloud-drive`, `google-drive`, `onedrive`, `dropbox`, `local-disk`, or `removable-encrypted-volume`. It does not activate a provider session or grant provider authority. `--storage-locator` may record a non-secret path/provider locator; credentials and tokens must never be supplied there.
+
 **Any device:** copy or unzip `vault_template/KnowledgeVault/` somewhere you control.
 
-The initializer refuses to overwrite an existing vault, verifies the installed file set and immutable hashes, and writes `_System/installation.receipt.json`.
+The initializer refuses to overwrite an existing instance root, verifies the installed template file set and immutable hashes, writes `_System/installation.receipt.json`, and creates `_System/Instances/instance.json` with a unique instance ID and storage metadata.
+
+### KV #1 / KV #2 / KV #n relationship
+
+KV numbering identifies **instances**, not authority.
+
+```text
+Owner continuity set
+├── KV #1  -> storage medium A
+├── KV #2  -> storage medium A or B
+├── KV #3  -> storage medium C
+└── KV #n  -> any admitted owner-controlled storage medium
+```
+
+All instances in the same `kv_set_id` are peers by default. KV #2 does not inherit authority from KV #1, and a higher or lower instance number does not make one vault canonical, subordinate, primary, backup, or replica. Those roles, if desired, are separate governed relationships established by policy/Interlock/InTr rather than by the instance ordinal.
+
+This separation allows same-provider multi-instance use immediately—for example KV #1 and KV #2 can both live in iCloud Drive—while provider-specific adapters and governed add/remove transitions can be integrated later without changing the instance identity model.
 
 ### Use
 
@@ -43,7 +71,7 @@ KnowledgeVault/
 ├── _Index/        indexes and cross-references
 ├── _Meta/         manifest and integrity metadata
 ├── _Policy/       vault policy
-├── _System/       receipts, execution state, guides, migrations
+├── _System/       receipts, instance identity, execution state, guides, migrations
 ├── _Templates/    reusable templates
 └── docs/          vault-local documentation
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ That creates **KV #2** at `KnowledgeVault-2/`. The same rule extends to any posi
 
 **Any device:** copy or unzip `vault_template/KnowledgeVault/` somewhere you control.
 
-The initializer refuses to overwrite an existing instance root, verifies the installed template file set and immutable hashes, writes `_System/installation.receipt.json`, and creates `_System/Instances/instance.json` with a unique instance ID and storage metadata.
+The initializer refuses to overwrite an existing instance root, verifies the installed template file set and immutable hashes, writes `_System/installation.receipt.json`, and creates `_System/Instances/instance.json` with a unique instance ID, storage metadata, and an initial `NOT_CONNECTED` relationship state.
 
 ### KV #1 / KV #2 / KV #n relationship
 
@@ -42,9 +42,32 @@ Owner continuity set
 └── KV #n  -> any admitted owner-controlled storage medium
 ```
 
-All instances in the same `kv_set_id` are peers by default. KV #2 does not inherit authority from KV #1, and a higher or lower instance number does not make one vault canonical, subordinate, primary, backup, or replica. Those roles, if desired, are separate governed relationships established by policy/Interlock/InTr rather than by the instance ordinal.
+Instances sharing a `kv_set_id` belong to the same owner continuity set but begin **NOT_CONNECTED**. Sharing a set ID or storage provider does not itself authorize inter-instance communication.
 
-This separation allows same-provider multi-instance use immediately—for example KV #1 and KV #2 can both live in iCloud Drive—while provider-specific adapters and governed add/remove transitions can be integrated later without changing the instance identity model.
+The relationship model has four cumulative capability tiers:
+
+```text
+NOT_CONNECTED
+  no inter-comms; no data movement; no replication; no unified AI corpus
+
+CONNECTED
+  inter-comms aware; admitted data can move between separately rooted KVs
+
+SYNCED
+  CONNECTED capabilities plus admitted replication between participating KVs
+
+AI_INTERACTION
+  SYNCED capabilities plus all participating KV data considered one logical corpus
+  for the authorized AI interaction
+```
+
+`AI_INTERACTION` does not physically merge the vaults, erase provenance, or make the AI canonical authority. Physical roots and source identity remain distinct even when retrieval/reasoning treats the admitted set as one logical corpus.
+
+KV #2 does not inherit authority from KV #1, and a higher or lower instance number does not make one vault canonical, subordinate, primary, backup, or replica. Operational roles are a separate dimension from relationship tier and are established by policy/Interlock/InTr rather than by instance ordinal.
+
+This separation allows same-provider multi-instance use immediately—for example KV #1 and KV #2 can both live in iCloud Drive—while provider-specific adapters and governed relationship transitions can be integrated later without changing the instance identity model.
+
+See [`docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md`](./docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md) for the complete relationship contract.
 
 ### Use
 

--- a/docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md
+++ b/docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md
@@ -101,7 +101,41 @@ NOT_CONNECTED
     < AI_INTERACTION
 ```
 
-A higher tier includes the lower-tier capabilities, but changing tiers is a governed transition once Interlock/InTr is active. The source model can represent desired/current tier state now without claiming the runtime transition occurred.
+A higher tier includes the lower-tier capabilities, but changing tiers is a governed transition once Interlock/InTr is active.
+
+## Transition request contract
+
+The source layer can now produce a deterministic relationship transition request without pretending that the requested transition occurred. The request binds:
+
+- `kv_set_id`;
+- two or more unique `kvi_...` participant instance IDs;
+- current tier;
+- requested target tier;
+- upgrade, downgrade, or unchanged direction;
+- the capabilities implied by the requested tier.
+
+Every source-generated transition request is explicitly:
+
+```text
+governance_state: PENDING_INTERLOCK_INTR
+authority_effect: NONE
+activation_effect: false
+data_moved: false
+replication_started: false
+ai_corpus_exposed: false
+```
+
+This means even a request for `AI_INTERACTION` cannot claim that any data was exposed to an AI system. The future Interlock/InTr execution lane must admit the transition and produce separate runtime evidence before current state may change.
+
+Canonical source artifacts:
+
+```text
+runtime/kv_instance_relationships.py
+schemas/kv-relationship-transition-request.schema.json
+tests/test_multi_instance_vaults.py
+```
+
+Upgrades and downgrades are both representable. Downgrading from `AI_INTERACTION` to `NOT_CONNECTED`, for example, is a request to remove capabilities and still requires governed execution rather than silent source mutation.
 
 ## Storage relationship
 

--- a/docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md
+++ b/docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md
@@ -1,0 +1,105 @@
+# KnowledgeVault Multi-Instance Relationship Model
+
+## Scope
+
+This document defines multiple KnowledgeVault instances belonging to one owner continuity set. It does not create provider authority, credentials, provider sessions, synchronization authority, or Interlock/InTr activation.
+
+## Instance identity
+
+Each installed KnowledgeVault root has:
+
+- a unique `instance_id`;
+- a positive `instance_number` used for human-readable `KV #n` naming;
+- a `kv_set_id` grouping related instances;
+- a storage-medium description and optional non-secret locator;
+- an installation receipt bound to the instance ID.
+
+The canonical instance-local record is:
+
+```text
+_System/Instances/instance.json
+```
+
+## Relationship rules
+
+### KV #1
+
+`KV #1` is the first numbered member of a KV set. Its default folder is `KnowledgeVault/` for backward compatibility.
+
+KV #1 is **not automatically authoritative**, canonical, primary, writable, or privileged merely because its ordinal is 1.
+
+### KV #2
+
+`KV #2` is a separately rooted peer instance. Its default folder is `KnowledgeVault-2/`.
+
+KV #2 may reside on the same storage medium as KV #1 or on a different one. Creating KV #2 never overwrites KV #1 and does not inherit authority from KV #1.
+
+### KV #n
+
+For every positive integer `n`, `KV #n` is an independently identified member of the same continuity set when its `kv_set_id` matches the other members.
+
+`n` is an instance ordinal only. It is not a priority, authority, freshness, trust, or replication rank.
+
+```text
+Owner continuity set S
+  KV #1 -> medium A
+  KV #2 -> medium A or B
+  ...
+  KV #n -> any owner-controlled storage medium admitted by the surrounding system
+```
+
+## Storage relationship
+
+Storage is metadata about where an instance root is materialized. The instance model is provider-neutral.
+
+Examples include:
+
+- `icloud-drive`
+- `google-drive`
+- `onedrive`
+- `dropbox`
+- `local-disk`
+- `removable-encrypted-volume`
+- future storage mediums
+
+The storage-medium field does not prove that a provider adapter, login session, credential, or governed transition exists.
+
+## Peer relationship versus governed roles
+
+All instances sharing a `kv_set_id` are `PEER` members by default.
+
+Roles such as the following are deliberately separate from instance numbering:
+
+- PRIMARY
+- REPLICA
+- MIRROR
+- BACKUP
+- ARCHIVE
+- READ_ONLY
+- RECOVERY_SOURCE
+
+Those roles may later be admitted by Interlock/InTr policy and recorded through a separate governed relationship/receipt. The baseline initializer does not assign them.
+
+## Same-provider multi-instance example
+
+Two isolated iCloud-backed roots can be initialized without any new cloud adapter:
+
+```bash
+python3 tools/init_vault.py /iCloud/StegVerse --instance 1 --storage-medium icloud-drive
+python3 tools/init_vault.py /iCloud/StegVerse --instance 2 --storage-medium icloud-drive
+```
+
+Result:
+
+```text
+/iCloud/StegVerse/KnowledgeVault/
+/iCloud/StegVerse/KnowledgeVault-2/
+```
+
+Each root receives a different `instance_id` and its own installation receipt.
+
+## Future MyKV mapping
+
+MyKV can project the KV set as a list of connected instance roots/drives. Add/remove operations should operate on a specific `instance_id` and storage binding rather than assuming a single global `KnowledgeVault` root.
+
+Provider connection/admission remains an Interlock/InTr adapter concern. Instance identity is intentionally usable before that runtime authority is available.

--- a/docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md
+++ b/docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This document defines multiple KnowledgeVault instances belonging to one owner continuity set. It does not create provider authority, credentials, provider sessions, synchronization authority, or Interlock/InTr activation.
+This document defines multiple KnowledgeVault instances belonging to one owner continuity set and the explicit relationship tier between them. It does not itself create provider authority, credentials, provider sessions, synchronization authority, or Interlock/InTr activation.
 
 ## Instance identity
 
@@ -20,25 +20,11 @@ The canonical instance-local record is:
 _System/Instances/instance.json
 ```
 
-## Relationship rules
+## KV #1 / #2 / #n identity
 
-### KV #1
+`KV #1` is the first numbered member of a KV set and retains the default `KnowledgeVault/` folder for backward compatibility. `KV #2` defaults to `KnowledgeVault-2/`. Every positive integer `n` can identify `KV #n` as an independently rooted member of the same continuity set when `kv_set_id` matches.
 
-`KV #1` is the first numbered member of a KV set. Its default folder is `KnowledgeVault/` for backward compatibility.
-
-KV #1 is **not automatically authoritative**, canonical, primary, writable, or privileged merely because its ordinal is 1.
-
-### KV #2
-
-`KV #2` is a separately rooted peer instance. Its default folder is `KnowledgeVault-2/`.
-
-KV #2 may reside on the same storage medium as KV #1 or on a different one. Creating KV #2 never overwrites KV #1 and does not inherit authority from KV #1.
-
-### KV #n
-
-For every positive integer `n`, `KV #n` is an independently identified member of the same continuity set when its `kv_set_id` matches the other members.
-
-`n` is an instance ordinal only. It is not a priority, authority, freshness, trust, or replication rank.
+The ordinal is identity only. It is not authority, priority, freshness, trust, or replication rank. KV #2 does not inherit authority from KV #1.
 
 ```text
 Owner continuity set S
@@ -47,6 +33,75 @@ Owner continuity set S
   ...
   KV #n -> any owner-controlled storage medium admitted by the surrounding system
 ```
+
+## Four relationship tiers
+
+Relationship state is explicit. Sharing a `kv_set_id` does not imply communication, synchronization, or AI corpus unification.
+
+### Tier 0 — NOT_CONNECTED
+
+The instances are known to belong to the same continuity set but have no inter-instance communications.
+
+```text
+inter_comms: false
+data_movement: false
+replication: false
+unified_ai_corpus: false
+```
+
+This is the default for a newly initialized KV instance.
+
+### Tier 1 — CONNECTED
+
+The instances are mutually relationship-aware and may exchange or move admitted data between their separately rooted stores.
+
+```text
+inter_comms: true
+data_movement: true
+replication: false
+unified_ai_corpus: false
+```
+
+Connected does not mean synchronized. A record can exist in only one KV and can be deliberately moved or copied through an admitted operation.
+
+### Tier 2 — SYNCED
+
+The connected instances additionally participate in a replication relationship.
+
+```text
+inter_comms: true
+data_movement: true
+replication: true
+unified_ai_corpus: false
+```
+
+Synced means designated replicated state is maintained across the participating KV instances. It does not require every physical byte or provider-specific artifact to be identical unless the admitted sync policy says so.
+
+### Tier 3 — AI_INTERACTION
+
+The participating KV instances are exposed to an admitted AI interaction as one logical information corpus.
+
+```text
+inter_comms: true
+data_movement: true
+replication: true
+unified_ai_corpus: true
+```
+
+For AI reasoning and retrieval, data across the participating instances is considered one source boundary for the authorized interaction. Physical roots remain distinct, provenance remains instance-specific, and contradictory records must not be silently collapsed. AI Interaction does not turn an AI system into canonical authority over the data.
+
+## Capability ordering
+
+The tiers are cumulative in capability:
+
+```text
+NOT_CONNECTED
+    < CONNECTED
+    < SYNCED
+    < AI_INTERACTION
+```
+
+A higher tier includes the lower-tier capabilities, but changing tiers is a governed transition once Interlock/InTr is active. The source model can represent desired/current tier state now without claiming the runtime transition occurred.
 
 ## Storage relationship
 
@@ -64,11 +119,11 @@ Examples include:
 
 The storage-medium field does not prove that a provider adapter, login session, credential, or governed transition exists.
 
-## Peer relationship versus governed roles
+## Relationship versus role
 
-All instances sharing a `kv_set_id` are `PEER` members by default.
+Relationship tier and operational role are separate dimensions.
 
-Roles such as the following are deliberately separate from instance numbering:
+Possible future roles include:
 
 - PRIMARY
 - REPLICA
@@ -78,7 +133,7 @@ Roles such as the following are deliberately separate from instance numbering:
 - READ_ONLY
 - RECOVERY_SOURCE
 
-Those roles may later be admitted by Interlock/InTr policy and recorded through a separate governed relationship/receipt. The baseline initializer does not assign them.
+For example, two KVs may be `SYNCED` while one is designated `PRIMARY` and another `BACKUP`, or both may remain equal peers. Ordinal numbering never assigns these roles.
 
 ## Same-provider multi-instance example
 
@@ -96,10 +151,16 @@ Result:
 /iCloud/StegVerse/KnowledgeVault-2/
 ```
 
-Each root receives a different `instance_id` and its own installation receipt.
+Each root receives a different `instance_id`, its own installation receipt, and begins at `NOT_CONNECTED` even though both may share the same storage provider and `kv_set_id`.
 
 ## Future MyKV mapping
 
-MyKV can project the KV set as a list of connected instance roots/drives. Add/remove operations should operate on a specific `instance_id` and storage binding rather than assuming a single global `KnowledgeVault` root.
+MyKV should project each KV instance and its relationship tier separately. At minimum it should allow the owner to see:
 
-Provider connection/admission remains an Interlock/InTr adapter concern. Instance identity is intentionally usable before that runtime authority is available.
+- storage binding and health;
+- `NOT_CONNECTED`, `CONNECTED`, `SYNCED`, or `AI_INTERACTION` state;
+- the instances participating in each relationship;
+- add/remove drive or instance operations;
+- requested tier changes and their governed status.
+
+Provider connection/admission remains an Interlock/InTr adapter concern. Instance identity and the four-tier relationship model are intentionally representable before runtime authority is available.

--- a/runtime/kv_instance_relationships.py
+++ b/runtime/kv_instance_relationships.py
@@ -1,13 +1,17 @@
 """KnowledgeVault inter-instance relationship semantics.
 
-This module defines capability tiers only. It does not create provider sessions,
-copy data, synchronize storage, or grant Interlock/InTr authority.
+This module defines the four capability tiers and non-authorizing transition proposals.
+It does not create provider sessions, copy data, synchronize storage, expose data to an
+AI system, or grant Interlock/InTr authority.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import Iterable
 
 
 class KVRelationshipTier(IntEnum):
@@ -32,30 +36,28 @@ CAPABILITIES = {
     KVRelationshipTier.AI_INTERACTION: KVRelationshipCapabilities(True, True, True, True),
 }
 
+TRANSITION_SCHEMA = "stegverse.kv.relationship-transition-request/v1"
+
+
+def _tier(value: KVRelationshipTier | str) -> KVRelationshipTier:
+    return KVRelationshipTier[value] if isinstance(value, str) else value
+
 
 def capabilities_for(tier: KVRelationshipTier | str) -> KVRelationshipCapabilities:
-    if isinstance(tier, str):
-        tier = KVRelationshipTier[tier]
-    return CAPABILITIES[tier]
+    return CAPABILITIES[_tier(tier)]
 
 
 def validate_transition(current: KVRelationshipTier | str, target: KVRelationshipTier | str) -> bool:
-    """Return whether the target tier is structurally representable.
+    """Return whether both tiers are structurally representable.
 
-    Relationship tiers are ordered by capability, but downgrade and upgrade authority
-    are intentionally not granted here. Interlock/InTr policy must separately admit
-    the actual transition when runtime governance is active.
+    Upgrade and downgrade authority are intentionally not granted here. Interlock/InTr
+    must separately admit the actual transition when runtime governance is active.
     """
-    if isinstance(current, str):
-        current = KVRelationshipTier[current]
-    if isinstance(target, str):
-        target = KVRelationshipTier[target]
-    return current in KVRelationshipTier and target in KVRelationshipTier
+    return _tier(current) in KVRelationshipTier and _tier(target) in KVRelationshipTier
 
 
 def relationship_record(tier: KVRelationshipTier | str) -> dict[str, object]:
-    if isinstance(tier, str):
-        tier = KVRelationshipTier[tier]
+    tier = _tier(tier)
     caps = capabilities_for(tier)
     return {
         "tier": tier.name,
@@ -66,4 +68,53 @@ def relationship_record(tier: KVRelationshipTier | str) -> dict[str, object]:
         "unified_ai_corpus": caps.unified_ai_corpus,
         "authority_effect": "NONE",
         "activation_effect": False,
+    }
+
+
+def transition_request(
+    *,
+    kv_set_id: str,
+    participant_instance_ids: Iterable[str],
+    current_tier: KVRelationshipTier | str,
+    target_tier: KVRelationshipTier | str,
+    requested_by: str = "owner",
+) -> dict[str, object]:
+    """Create a deterministic, non-authorizing relationship transition request.
+
+    The request is suitable for later Interlock/InTr admission. Creating it does not
+    perform the transition. A relationship requires at least two unique participants.
+    """
+    current = _tier(current_tier)
+    target = _tier(target_tier)
+    participants = sorted({str(value).strip() for value in participant_instance_ids if str(value).strip()})
+    if not kv_set_id.strip():
+        raise ValueError("kv_set_id is required")
+    if len(participants) < 2:
+        raise ValueError("at least two unique KV participant instance IDs are required")
+    if not all(value.startswith("kvi_") for value in participants):
+        raise ValueError("participant instance IDs must use kvi_ identifiers")
+    if not requested_by.strip():
+        raise ValueError("requested_by is required")
+
+    canonical = {
+        "kv_set_id": kv_set_id.strip(),
+        "participants": participants,
+        "current_tier": current.name,
+        "target_tier": target.name,
+        "requested_by": requested_by.strip(),
+    }
+    digest = hashlib.sha256(json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    direction = "UNCHANGED" if current == target else ("UPGRADE" if target > current else "DOWNGRADE")
+    return {
+        "schema": TRANSITION_SCHEMA,
+        "request_id": f"kvrel_{digest[:24]}",
+        **canonical,
+        "direction": direction,
+        "requested_capabilities": relationship_record(target),
+        "governance_state": "PENDING_INTERLOCK_INTR",
+        "authority_effect": "NONE",
+        "activation_effect": False,
+        "data_moved": False,
+        "replication_started": False,
+        "ai_corpus_exposed": False,
     }

--- a/runtime/kv_instance_relationships.py
+++ b/runtime/kv_instance_relationships.py
@@ -1,0 +1,69 @@
+"""KnowledgeVault inter-instance relationship semantics.
+
+This module defines capability tiers only. It does not create provider sessions,
+copy data, synchronize storage, or grant Interlock/InTr authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class KVRelationshipTier(IntEnum):
+    NOT_CONNECTED = 0
+    CONNECTED = 1
+    SYNCED = 2
+    AI_INTERACTION = 3
+
+
+@dataclass(frozen=True)
+class KVRelationshipCapabilities:
+    inter_comms: bool
+    data_movement: bool
+    replication: bool
+    unified_ai_corpus: bool
+
+
+CAPABILITIES = {
+    KVRelationshipTier.NOT_CONNECTED: KVRelationshipCapabilities(False, False, False, False),
+    KVRelationshipTier.CONNECTED: KVRelationshipCapabilities(True, True, False, False),
+    KVRelationshipTier.SYNCED: KVRelationshipCapabilities(True, True, True, False),
+    KVRelationshipTier.AI_INTERACTION: KVRelationshipCapabilities(True, True, True, True),
+}
+
+
+def capabilities_for(tier: KVRelationshipTier | str) -> KVRelationshipCapabilities:
+    if isinstance(tier, str):
+        tier = KVRelationshipTier[tier]
+    return CAPABILITIES[tier]
+
+
+def validate_transition(current: KVRelationshipTier | str, target: KVRelationshipTier | str) -> bool:
+    """Return whether the target tier is structurally representable.
+
+    Relationship tiers are ordered by capability, but downgrade and upgrade authority
+    are intentionally not granted here. Interlock/InTr policy must separately admit
+    the actual transition when runtime governance is active.
+    """
+    if isinstance(current, str):
+        current = KVRelationshipTier[current]
+    if isinstance(target, str):
+        target = KVRelationshipTier[target]
+    return current in KVRelationshipTier and target in KVRelationshipTier
+
+
+def relationship_record(tier: KVRelationshipTier | str) -> dict[str, object]:
+    if isinstance(tier, str):
+        tier = KVRelationshipTier[tier]
+    caps = capabilities_for(tier)
+    return {
+        "tier": tier.name,
+        "tier_order": int(tier),
+        "inter_comms": caps.inter_comms,
+        "data_movement": caps.data_movement,
+        "replication": caps.replication,
+        "unified_ai_corpus": caps.unified_ai_corpus,
+        "authority_effect": "NONE",
+        "activation_effect": False,
+    }

--- a/schemas/kv-relationship-transition-request.schema.json
+++ b/schemas/kv-relationship-transition-request.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-relationship-transition-request.schema.json",
+  "title": "KnowledgeVault Relationship Transition Request",
+  "type": "object",
+  "required": [
+    "schema",
+    "request_id",
+    "kv_set_id",
+    "participants",
+    "current_tier",
+    "target_tier",
+    "direction",
+    "requested_capabilities",
+    "governance_state",
+    "authority_effect",
+    "activation_effect",
+    "data_moved",
+    "replication_started",
+    "ai_corpus_exposed"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.kv.relationship-transition-request/v1"},
+    "request_id": {"type": "string", "pattern": "^kvrel_[a-f0-9]{24}$"},
+    "kv_set_id": {"type": "string", "minLength": 1},
+    "participants": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^kvi_"}
+    },
+    "current_tier": {"enum": ["NOT_CONNECTED", "CONNECTED", "SYNCED", "AI_INTERACTION"]},
+    "target_tier": {"enum": ["NOT_CONNECTED", "CONNECTED", "SYNCED", "AI_INTERACTION"]},
+    "direction": {"enum": ["UNCHANGED", "UPGRADE", "DOWNGRADE"]},
+    "requested_by": {"type": "string", "minLength": 1},
+    "requested_capabilities": {"type": "object"},
+    "governance_state": {"const": "PENDING_INTERLOCK_INTR"},
+    "authority_effect": {"const": "NONE"},
+    "activation_effect": {"const": false},
+    "data_moved": {"const": false},
+    "replication_started": {"const": false},
+    "ai_corpus_exposed": {"const": false}
+  },
+  "additionalProperties": true
+}

--- a/tests/test_multi_instance_vaults.py
+++ b/tests/test_multi_instance_vaults.py
@@ -5,18 +5,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+from runtime.kv_instance_relationships import KVRelationshipTier, capabilities_for, relationship_record
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INIT = REPO_ROOT / "tools" / "init_vault.py"
 
 
 def _run(*args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [sys.executable, str(INIT), *args],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    return subprocess.run([sys.executable, str(INIT), *args], cwd=REPO_ROOT, text=True, capture_output=True, check=False)
 
 
 def _load_instance(root: Path) -> dict:
@@ -26,15 +22,12 @@ def _load_instance(root: Path) -> dict:
 def test_second_instance_can_coexist_with_first(tmp_path: Path) -> None:
     first = _run(str(tmp_path), "--instance", "1", "--storage-medium", "icloud-drive")
     assert first.returncode == 0, first.stdout + first.stderr
-
     second = _run(str(tmp_path), "--instance", "2", "--storage-medium", "icloud-drive")
     assert second.returncode == 0, second.stdout + second.stderr
 
     kv1 = tmp_path / "KnowledgeVault"
     kv2 = tmp_path / "KnowledgeVault-2"
-    assert kv1.is_dir()
-    assert kv2.is_dir()
-    assert kv1.resolve() != kv2.resolve()
+    assert kv1.is_dir() and kv2.is_dir() and kv1.resolve() != kv2.resolve()
 
     one = _load_instance(kv1)
     two = _load_instance(kv2)
@@ -42,31 +35,21 @@ def test_second_instance_can_coexist_with_first(tmp_path: Path) -> None:
     assert two["instance_number"] == 2
     assert one["logical_name"] == "KV #1"
     assert two["logical_name"] == "KV #2"
-    assert one["storage"]["medium"] == "icloud-drive"
-    assert two["storage"]["medium"] == "icloud-drive"
+    assert one["storage"]["medium"] == two["storage"]["medium"] == "icloud-drive"
     assert one["kv_set_id"] == two["kv_set_id"] == "default"
     assert one["instance_id"] != two["instance_id"]
     assert one["relationship"]["set_membership"] == "PEER"
     assert two["relationship"]["set_membership"] == "PEER"
     assert two["relationship"]["inherits_authority_from_kv_1"] is False
+    assert one["relationship"]["tier"] == two["relationship"]["tier"] == "NOT_CONNECTED"
+    assert one["relationship"]["inter_comms"] is False
+    assert two["relationship"]["data_movement"] is False
 
 
 def test_nth_instance_can_use_any_described_storage_medium(tmp_path: Path) -> None:
-    result = _run(
-        str(tmp_path),
-        "--instance",
-        "17",
-        "--storage-medium",
-        "removable-encrypted-volume",
-        "--storage-locator",
-        "owner-volume-a",
-        "--set-id",
-        "personal-continuity",
-    )
+    result = _run(str(tmp_path), "--instance", "17", "--storage-medium", "removable-encrypted-volume", "--storage-locator", "owner-volume-a", "--set-id", "personal-continuity")
     assert result.returncode == 0, result.stdout + result.stderr
-
-    kvn = tmp_path / "KnowledgeVault-17"
-    instance = _load_instance(kvn)
+    instance = _load_instance(tmp_path / "KnowledgeVault-17")
     assert instance["instance_number"] == 17
     assert instance["logical_name"] == "KV #17"
     assert instance["kv_set_id"] == "personal-continuity"
@@ -88,3 +71,23 @@ def test_custom_folder_name_does_not_change_logical_instance_number(tmp_path: Pa
     instance = _load_instance(tmp_path / "MyKV-iCloud-Secondary")
     assert instance["instance_number"] == 2
     assert instance["logical_name"] == "KV #2"
+
+
+def test_relationship_tiers_are_cumulative() -> None:
+    not_connected = capabilities_for(KVRelationshipTier.NOT_CONNECTED)
+    connected = capabilities_for(KVRelationshipTier.CONNECTED)
+    synced = capabilities_for(KVRelationshipTier.SYNCED)
+    ai = capabilities_for(KVRelationshipTier.AI_INTERACTION)
+
+    assert (not_connected.inter_comms, not_connected.data_movement, not_connected.replication, not_connected.unified_ai_corpus) == (False, False, False, False)
+    assert (connected.inter_comms, connected.data_movement, connected.replication, connected.unified_ai_corpus) == (True, True, False, False)
+    assert (synced.inter_comms, synced.data_movement, synced.replication, synced.unified_ai_corpus) == (True, True, True, False)
+    assert (ai.inter_comms, ai.data_movement, ai.replication, ai.unified_ai_corpus) == (True, True, True, True)
+
+
+def test_relationship_record_never_claims_runtime_activation() -> None:
+    record = relationship_record("AI_INTERACTION")
+    assert record["tier_order"] == 3
+    assert record["unified_ai_corpus"] is True
+    assert record["authority_effect"] == "NONE"
+    assert record["activation_effect"] is False

--- a/tests/test_multi_instance_vaults.py
+++ b/tests/test_multi_instance_vaults.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INIT = REPO_ROOT / "tools" / "init_vault.py"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(INIT), *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _load_instance(root: Path) -> dict:
+    return json.loads((root / "_System/Instances/instance.json").read_text(encoding="utf-8"))
+
+
+def test_second_instance_can_coexist_with_first(tmp_path: Path) -> None:
+    first = _run(str(tmp_path), "--instance", "1", "--storage-medium", "icloud-drive")
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    second = _run(str(tmp_path), "--instance", "2", "--storage-medium", "icloud-drive")
+    assert second.returncode == 0, second.stdout + second.stderr
+
+    kv1 = tmp_path / "KnowledgeVault"
+    kv2 = tmp_path / "KnowledgeVault-2"
+    assert kv1.is_dir()
+    assert kv2.is_dir()
+    assert kv1.resolve() != kv2.resolve()
+
+    one = _load_instance(kv1)
+    two = _load_instance(kv2)
+    assert one["instance_number"] == 1
+    assert two["instance_number"] == 2
+    assert one["logical_name"] == "KV #1"
+    assert two["logical_name"] == "KV #2"
+    assert one["storage"]["medium"] == "icloud-drive"
+    assert two["storage"]["medium"] == "icloud-drive"
+    assert one["kv_set_id"] == two["kv_set_id"] == "default"
+    assert one["instance_id"] != two["instance_id"]
+    assert one["relationship"]["set_membership"] == "PEER"
+    assert two["relationship"]["set_membership"] == "PEER"
+    assert two["relationship"]["inherits_authority_from_kv_1"] is False
+
+
+def test_nth_instance_can_use_any_described_storage_medium(tmp_path: Path) -> None:
+    result = _run(
+        str(tmp_path),
+        "--instance",
+        "17",
+        "--storage-medium",
+        "removable-encrypted-volume",
+        "--storage-locator",
+        "owner-volume-a",
+        "--set-id",
+        "personal-continuity",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    kvn = tmp_path / "KnowledgeVault-17"
+    instance = _load_instance(kvn)
+    assert instance["instance_number"] == 17
+    assert instance["logical_name"] == "KV #17"
+    assert instance["kv_set_id"] == "personal-continuity"
+    assert instance["storage"]["medium"] == "removable-encrypted-volume"
+    assert instance["storage"]["locator"] == "owner-volume-a"
+    assert instance["storage"]["provider_authority_effect"] == "NONE"
+
+
+def test_existing_instance_root_is_never_overwritten(tmp_path: Path) -> None:
+    assert _run(str(tmp_path), "--instance", "2").returncode == 0
+    refused = _run(str(tmp_path), "--instance", "2")
+    assert refused.returncode == 5
+    assert "Refusing to overwrite existing" in refused.stdout
+
+
+def test_custom_folder_name_does_not_change_logical_instance_number(tmp_path: Path) -> None:
+    result = _run(str(tmp_path), "--instance", "2", "--vault-name", "MyKV-iCloud-Secondary")
+    assert result.returncode == 0, result.stdout + result.stderr
+    instance = _load_instance(tmp_path / "MyKV-iCloud-Secondary")
+    assert instance["instance_number"] == 2
+    assert instance["logical_name"] == "KV #2"

--- a/tests/test_multi_instance_vaults.py
+++ b/tests/test_multi_instance_vaults.py
@@ -5,7 +5,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-from runtime.kv_instance_relationships import KVRelationshipTier, capabilities_for, relationship_record
+import pytest
+
+from runtime.kv_instance_relationships import (
+    KVRelationshipTier,
+    capabilities_for,
+    relationship_record,
+    transition_request,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INIT = REPO_ROOT / "tools" / "init_vault.py"
@@ -91,3 +98,63 @@ def test_relationship_record_never_claims_runtime_activation() -> None:
     assert record["unified_ai_corpus"] is True
     assert record["authority_effect"] == "NONE"
     assert record["activation_effect"] is False
+
+
+def test_transition_request_is_deterministic_and_non_authorizing() -> None:
+    args = dict(
+        kv_set_id="personal",
+        participant_instance_ids=["kvi_b", "kvi_a"],
+        current_tier="NOT_CONNECTED",
+        target_tier="CONNECTED",
+    )
+    first = transition_request(**args)
+    second = transition_request(**args)
+    assert first == second
+    assert first["participants"] == ["kvi_a", "kvi_b"]
+    assert first["direction"] == "UPGRADE"
+    assert first["governance_state"] == "PENDING_INTERLOCK_INTR"
+    assert first["authority_effect"] == "NONE"
+    assert first["activation_effect"] is False
+    assert first["data_moved"] is False
+    assert first["replication_started"] is False
+    assert first["ai_corpus_exposed"] is False
+
+
+def test_ai_interaction_request_does_not_claim_ai_exposure() -> None:
+    request = transition_request(
+        kv_set_id="personal",
+        participant_instance_ids=["kvi_1", "kvi_2", "kvi_3"],
+        current_tier="SYNCED",
+        target_tier="AI_INTERACTION",
+    )
+    assert request["requested_capabilities"]["unified_ai_corpus"] is True
+    assert request["ai_corpus_exposed"] is False
+    assert request["activation_effect"] is False
+
+
+def test_downgrade_is_representable_but_still_requires_governance() -> None:
+    request = transition_request(
+        kv_set_id="personal",
+        participant_instance_ids=["kvi_1", "kvi_2"],
+        current_tier="AI_INTERACTION",
+        target_tier="NOT_CONNECTED",
+    )
+    assert request["direction"] == "DOWNGRADE"
+    assert request["governance_state"] == "PENDING_INTERLOCK_INTR"
+
+
+def test_relationship_requires_two_unique_valid_participants() -> None:
+    with pytest.raises(ValueError):
+        transition_request(
+            kv_set_id="personal",
+            participant_instance_ids=["kvi_1", "kvi_1"],
+            current_tier="NOT_CONNECTED",
+            target_tier="CONNECTED",
+        )
+    with pytest.raises(ValueError):
+        transition_request(
+            kv_set_id="personal",
+            participant_instance_ids=["bad", "kvi_2"],
+            current_tier="NOT_CONNECTED",
+            target_tier="CONNECTED",
+        )

--- a/tools/init_vault.py
+++ b/tools/init_vault.py
@@ -36,13 +36,7 @@ def inventory(root: Path, *, exclude_generated: bool = False) -> list[dict[str, 
         relative = path.relative_to(root).as_posix()
         if exclude_generated and relative in generated:
             continue
-        files.append(
-            {
-                "path": relative,
-                "size": path.stat().st_size,
-                "sha256": sha256_file(path),
-            }
-        )
+        files.append({"path": relative, "size": path.stat().st_size, "sha256": sha256_file(path)})
     return files
 
 
@@ -62,45 +56,14 @@ def validate_vault_name(value: str) -> str:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Create a verified KnowledgeVault instance without overwriting an existing vault."
-    )
-    parser.add_argument(
-        "target_dir",
-        type=Path,
-        help="Parent directory that will receive the new KnowledgeVault instance folder.",
-    )
-    parser.add_argument(
-        "--instance",
-        type=int,
-        default=1,
-        help="Logical KV instance number. 1 -> KnowledgeVault; 2 -> KnowledgeVault-2; n -> KnowledgeVault-n.",
-    )
-    parser.add_argument(
-        "--vault-name",
-        type=validate_vault_name,
-        help="Override the destination folder name without changing the logical instance number.",
-    )
-    parser.add_argument(
-        "--set-id",
-        default="default",
-        help="Non-secret identifier grouping related KV instances for the same owner/continuity set.",
-    )
-    parser.add_argument(
-        "--storage-medium",
-        default="filesystem",
-        help="Descriptive storage medium/provider class, e.g. icloud-drive, google-drive, onedrive, local-disk.",
-    )
-    parser.add_argument(
-        "--storage-locator",
-        default=None,
-        help="Optional non-secret provider/path locator recorded as metadata. Do not supply credentials or tokens.",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Validate inputs and print the destination without copying files.",
-    )
+    parser = argparse.ArgumentParser(description="Create a verified KnowledgeVault instance without overwriting an existing vault.")
+    parser.add_argument("target_dir", type=Path, help="Parent directory that will receive the new KnowledgeVault instance folder.")
+    parser.add_argument("--instance", type=int, default=1, help="Logical KV instance number. 1 -> KnowledgeVault; 2 -> KnowledgeVault-2; n -> KnowledgeVault-n.")
+    parser.add_argument("--vault-name", type=validate_vault_name, help="Override the destination folder name without changing the logical instance number.")
+    parser.add_argument("--set-id", default="default", help="Non-secret identifier grouping related KV instances for the same owner/continuity set.")
+    parser.add_argument("--storage-medium", default="filesystem", help="Descriptive storage medium/provider class, e.g. icloud-drive, google-drive, onedrive, local-disk.")
+    parser.add_argument("--storage-locator", default=None, help="Optional non-secret provider/path locator recorded as metadata. Do not supply credentials or tokens.")
+    parser.add_argument("--dry-run", action="store_true", help="Validate inputs and print the destination without copying files.")
     args = parser.parse_args()
     if args.instance < 1:
         parser.error("--instance must be >= 1")
@@ -133,10 +96,7 @@ def main() -> int:
         return 6
 
     if args.dry_run:
-        print(
-            f"DRY RUN: would initialize KV #{args.instance} ({len(source_inventory)} files) "
-            f"at {target_vault} on storage medium {args.storage_medium}"
-        )
+        print(f"DRY RUN: would initialize KV #{args.instance} ({len(source_inventory)} files) at {target_vault} on storage medium {args.storage_medium}")
         return 0
 
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -148,8 +108,6 @@ def main() -> int:
         manifest["created_utc"] = created_utc
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
-        # The manifest timestamp intentionally differs from the packaged template,
-        # so verify all other template files exactly before adding instance-local records.
         source_by_path = {entry["path"]: entry for entry in source_inventory}
         target_inventory = inventory(target_vault, exclude_generated=True)
         target_by_path = {entry["path"]: entry for entry in target_inventory}
@@ -157,12 +115,7 @@ def main() -> int:
             raise RuntimeError("source and destination file sets differ")
 
         mutable_path = "_Meta/vault.manifest.json"
-        mismatches = [
-            path
-            for path in source_by_path
-            if path != mutable_path
-            and source_by_path[path]["sha256"] != target_by_path[path]["sha256"]
-        ]
+        mismatches = [path for path in source_by_path if path != mutable_path and source_by_path[path]["sha256"] != target_by_path[path]["sha256"]]
         if mismatches:
             raise RuntimeError("copied file hash mismatch: " + ", ".join(mismatches[:3]))
 
@@ -175,15 +128,19 @@ def main() -> int:
             "kv_set_id": args.set_id.strip(),
             "relationship": {
                 "set_membership": "PEER",
+                "tier": "NOT_CONNECTED",
+                "tier_order": 0,
+                "inter_comms": False,
+                "data_movement": False,
+                "replication": False,
+                "unified_ai_corpus": False,
                 "ordinal_is_authority": False,
                 "inherits_authority_from_kv_1": False,
-                "notes": "KV numbering identifies instances only; governance/authority must be established separately.",
+                "authority_effect": "NONE",
+                "activation_effect": False,
+                "notes": "New instances are isolated by default. Relationship-tier changes require separate governed admission when runtime authority is active.",
             },
-            "storage": {
-                "medium": args.storage_medium.strip(),
-                "locator": args.storage_locator,
-                "provider_authority_effect": "NONE",
-            },
+            "storage": {"medium": args.storage_medium.strip(), "locator": args.storage_locator, "provider_authority_effect": "NONE"},
             "created_utc": created_utc,
             "kit_version": VERSION_FILE.read_text(encoding="utf-8").strip(),
         }
@@ -197,25 +154,12 @@ def main() -> int:
             "created_utc": created_utc,
             "source": "vault_template/KnowledgeVault",
             "destination": str(target_vault),
-            "instance": {
-                "instance_id": instance_id,
-                "instance_number": args.instance,
-                "logical_name": f"KV #{args.instance}",
-                "kv_set_id": args.set_id.strip(),
-                "record": INSTANCE_RECORD.as_posix(),
-            },
-            "storage": {
-                "medium": args.storage_medium.strip(),
-                "locator": args.storage_locator,
-            },
+            "instance": {"instance_id": instance_id, "instance_number": args.instance, "logical_name": f"KV #{args.instance}", "kv_set_id": args.set_id.strip(), "record": INSTANCE_RECORD.as_posix()},
+            "relationship": {"tier": "NOT_CONNECTED", "tier_order": 0},
+            "storage": {"medium": args.storage_medium.strip(), "locator": args.storage_locator},
             "file_count": len(target_inventory),
             "manifest_sha256": target_by_path[mutable_path]["sha256"],
-            "verification": {
-                "file_set_matches": True,
-                "immutable_file_hashes_match": True,
-                "overwrote_existing_vault": False,
-                "instance_root_isolated": True,
-            },
+            "verification": {"file_set_matches": True, "immutable_file_hashes_match": True, "overwrote_existing_vault": False, "instance_root_isolated": True},
         }
         receipt_path = target_vault / "_System" / RECEIPT_NAME
         receipt_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/init_vault.py
+++ b/tools/init_vault.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python3
-"""Safely initialize and verify a standalone KnowledgeVault copy."""
+"""Safely initialize and verify a standalone KnowledgeVault instance."""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
+import re
 import shutil
 import sys
 import time
+import uuid
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE_VAULT = REPO_ROOT / "vault_template" / "KnowledgeVault"
 VERSION_FILE = REPO_ROOT / "VERSION"
 RECEIPT_NAME = "installation.receipt.json"
+INSTANCE_RECORD = Path("_System/Instances/instance.json")
+INSTANCE_SCHEMA = "stegverse.kv.instance/v1"
 
 
 def sha256_file(path: Path) -> str:
@@ -25,11 +29,12 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def inventory(root: Path, *, exclude_receipt: bool = False) -> list[dict[str, object]]:
+def inventory(root: Path, *, exclude_generated: bool = False) -> list[dict[str, object]]:
     files: list[dict[str, object]] = []
+    generated = {f"_System/{RECEIPT_NAME}", INSTANCE_RECORD.as_posix()}
     for path in sorted(p for p in root.rglob("*") if p.is_file()):
         relative = path.relative_to(root).as_posix()
-        if exclude_receipt and relative == f"_System/{RECEIPT_NAME}":
+        if exclude_generated and relative in generated:
             continue
         files.append(
             {
@@ -41,27 +46,76 @@ def inventory(root: Path, *, exclude_receipt: bool = False) -> list[dict[str, ob
     return files
 
 
+def default_vault_name(instance_number: int) -> str:
+    return "KnowledgeVault" if instance_number == 1 else f"KnowledgeVault-{instance_number}"
+
+
+def validate_vault_name(value: str) -> str:
+    value = value.strip()
+    if not value:
+        raise argparse.ArgumentTypeError("vault name cannot be empty")
+    if value in {".", ".."} or "/" in value or "\\" in value:
+        raise argparse.ArgumentTypeError("vault name must be a single folder name")
+    if not re.fullmatch(r"[A-Za-z0-9._ -]+", value):
+        raise argparse.ArgumentTypeError("vault name contains unsupported characters")
+    return value
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Create a verified KnowledgeVault without overwriting an existing vault."
+        description="Create a verified KnowledgeVault instance without overwriting an existing vault."
     )
     parser.add_argument(
         "target_dir",
         type=Path,
-        help="Parent directory that will receive a new KnowledgeVault folder.",
+        help="Parent directory that will receive the new KnowledgeVault instance folder.",
+    )
+    parser.add_argument(
+        "--instance",
+        type=int,
+        default=1,
+        help="Logical KV instance number. 1 -> KnowledgeVault; 2 -> KnowledgeVault-2; n -> KnowledgeVault-n.",
+    )
+    parser.add_argument(
+        "--vault-name",
+        type=validate_vault_name,
+        help="Override the destination folder name without changing the logical instance number.",
+    )
+    parser.add_argument(
+        "--set-id",
+        default="default",
+        help="Non-secret identifier grouping related KV instances for the same owner/continuity set.",
+    )
+    parser.add_argument(
+        "--storage-medium",
+        default="filesystem",
+        help="Descriptive storage medium/provider class, e.g. icloud-drive, google-drive, onedrive, local-disk.",
+    )
+    parser.add_argument(
+        "--storage-locator",
+        default=None,
+        help="Optional non-secret provider/path locator recorded as metadata. Do not supply credentials or tokens.",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Validate inputs and print the destination without copying files.",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.instance < 1:
+        parser.error("--instance must be >= 1")
+    if not args.set_id.strip():
+        parser.error("--set-id cannot be empty")
+    if not args.storage_medium.strip():
+        parser.error("--storage-medium cannot be empty")
+    return args
 
 
 def main() -> int:
     args = parse_args()
     target_dir = args.target_dir.expanduser().resolve()
-    target_vault = target_dir / "KnowledgeVault"
+    vault_name = args.vault_name or default_vault_name(args.instance)
+    target_vault = target_dir / vault_name
 
     if not TEMPLATE_VAULT.is_dir():
         print(f"Missing template vault: {TEMPLATE_VAULT}")
@@ -79,7 +133,10 @@ def main() -> int:
         return 6
 
     if args.dry_run:
-        print(f"DRY RUN: would initialize {len(source_inventory)} files at {target_vault}")
+        print(
+            f"DRY RUN: would initialize KV #{args.instance} ({len(source_inventory)} files) "
+            f"at {target_vault} on storage medium {args.storage_medium}"
+        )
         return 0
 
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -92,9 +149,9 @@ def main() -> int:
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
         # The manifest timestamp intentionally differs from the packaged template,
-        # so verify all other files exactly and record the initialized manifest hash.
+        # so verify all other template files exactly before adding instance-local records.
         source_by_path = {entry["path"]: entry for entry in source_inventory}
-        target_inventory = inventory(target_vault)
+        target_inventory = inventory(target_vault, exclude_generated=True)
         target_by_path = {entry["path"]: entry for entry in target_inventory}
         if set(source_by_path) != set(target_by_path):
             raise RuntimeError("source and destination file sets differ")
@@ -109,18 +166,55 @@ def main() -> int:
         if mismatches:
             raise RuntimeError("copied file hash mismatch: " + ", ".join(mismatches[:3]))
 
+        instance_id = f"kvi_{uuid.uuid4().hex}"
+        instance_record = {
+            "schema": INSTANCE_SCHEMA,
+            "instance_id": instance_id,
+            "instance_number": args.instance,
+            "logical_name": f"KV #{args.instance}",
+            "kv_set_id": args.set_id.strip(),
+            "relationship": {
+                "set_membership": "PEER",
+                "ordinal_is_authority": False,
+                "inherits_authority_from_kv_1": False,
+                "notes": "KV numbering identifies instances only; governance/authority must be established separately.",
+            },
+            "storage": {
+                "medium": args.storage_medium.strip(),
+                "locator": args.storage_locator,
+                "provider_authority_effect": "NONE",
+            },
+            "created_utc": created_utc,
+            "kit_version": VERSION_FILE.read_text(encoding="utf-8").strip(),
+        }
+        instance_path = target_vault / INSTANCE_RECORD
+        instance_path.parent.mkdir(parents=True, exist_ok=True)
+        instance_path.write_text(json.dumps(instance_record, indent=2) + "\n", encoding="utf-8")
+
         receipt = {
-            "schema_version": "1.0",
+            "schema_version": "1.1",
             "kit_version": VERSION_FILE.read_text(encoding="utf-8").strip(),
             "created_utc": created_utc,
             "source": "vault_template/KnowledgeVault",
             "destination": str(target_vault),
+            "instance": {
+                "instance_id": instance_id,
+                "instance_number": args.instance,
+                "logical_name": f"KV #{args.instance}",
+                "kv_set_id": args.set_id.strip(),
+                "record": INSTANCE_RECORD.as_posix(),
+            },
+            "storage": {
+                "medium": args.storage_medium.strip(),
+                "locator": args.storage_locator,
+            },
             "file_count": len(target_inventory),
             "manifest_sha256": target_by_path[mutable_path]["sha256"],
             "verification": {
                 "file_set_matches": True,
                 "immutable_file_hashes_match": True,
                 "overwrote_existing_vault": False,
+                "instance_root_isolated": True,
             },
         }
         receipt_path = target_vault / "_System" / RECEIPT_NAME
@@ -131,7 +225,8 @@ def main() -> int:
         print(f"Initialization failed and partial destination was removed: {exc}")
         return 7
 
-    print(f"Initialized and verified vault at: {target_vault}")
+    print(f"Initialized and verified KV #{args.instance} at: {target_vault}")
+    print(f"Instance record: {target_vault / INSTANCE_RECORD}")
     print(f"Receipt: {target_vault / '_System' / RECEIPT_NAME}")
     return 0
 

--- a/tools/test_clean_room_user_kv.py
+++ b/tools/test_clean_room_user_kv.py
@@ -16,6 +16,7 @@ from zipfile import ZipFile
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE = REPO_ROOT / "vault_template" / "KnowledgeVault"
 DIST = REPO_ROOT / "dist"
+INSTANCE_RECORD = "_System/Instances/instance.json"
 
 FORBIDDEN_INSTALLER_MARKERS = (
     "1c8OdhJeLD6E4ALmi-aR7dXvG8PjDLSfi",  # connected-user Drive root
@@ -136,22 +137,36 @@ def main() -> int:
         run([sys.executable, "tools/init_vault.py", str(initialized_parent)], env=clean_env)
         initialized = initialized_parent / "KnowledgeVault"
         receipt_path = initialized / "_System" / "installation.receipt.json"
+        instance_path = initialized / INSTANCE_RECORD
         if not receipt_path.is_file():
             raise RuntimeError("clean-room initializer did not emit installation receipt")
+        if not instance_path.is_file():
+            raise RuntimeError("clean-room initializer did not emit instance identity record")
 
         init_inventory = inventory(initialized)
         receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        instance = json.loads(instance_path.read_text(encoding="utf-8"))
         receipt_text = json.dumps(receipt, sort_keys=True).lower()
         for marker in FORBIDDEN_RECEIPT_MARKERS:
             if marker.lower() in receipt_text:
                 raise RuntimeError(f"installation receipt leaked creator/provider marker: {marker}")
 
-        expected_initialized_paths = set(source) | {"_System/installation.receipt.json"}
+        expected_initialized_paths = set(source) | {
+            "_System/installation.receipt.json",
+            INSTANCE_RECORD,
+        }
         if set(init_inventory) != expected_initialized_paths:
             raise RuntimeError("initialized path set includes unexpected creator/runtime state")
 
+        if instance.get("instance_number") != 1 or instance.get("logical_name") != "KV #1":
+            raise RuntimeError("default initializer did not identify the first KV instance")
+        if instance.get("relationship", {}).get("ordinal_is_authority") is not False:
+            raise RuntimeError("KV ordinal must not create authority")
+        if receipt.get("instance", {}).get("instance_id") != instance.get("instance_id"):
+            raise RuntimeError("installation receipt is not bound to instance identity")
+
         for prefix in FORBIDDEN_FRESH_RUNTIME_PREFIXES:
-            if any(path.startswith(prefix) for path in init_inventory):
+            if any(path.startswith(prefix) and path != INSTANCE_RECORD for path in init_inventory):
                 raise RuntimeError(f"fresh vault inherited connected-user runtime state: {prefix}")
 
         mutable = "_Meta/vault.manifest.json"
@@ -168,6 +183,8 @@ def main() -> int:
             raise RuntimeError("initializer receipt lacks immutable_file_hashes_match=true")
         if verification.get("overwrote_existing_vault") is not False:
             raise RuntimeError("initializer receipt does not preserve overwrite refusal")
+        if verification.get("instance_root_isolated") is not True:
+            raise RuntimeError("initializer receipt lacks instance_root_isolated=true")
 
         refused = subprocess.run(
             [sys.executable, "tools/init_vault.py", str(initialized_parent)],
@@ -190,6 +207,7 @@ def main() -> int:
                 "cloud_credentials_required": False,
                 "network_required": False,
                 "connected_user_runtime_state_inherited": False,
+                "multi_instance_identity_record": True,
                 "authority_effect": "NONE",
                 "activation_effect": False,
             },


### PR DESCRIPTION
Canonical StegVerse task binding:
- GOAL TASK ID: `KV-CONNECTION-REVALIDATION-WORKER-001`
- COSV ID: `50000000102000`
- canonical COSV handoff: `StegVerse-Labs/.github/KV_CONNECTION_REVALIDATION_COSV_MIRROR_HANDOFF.md`
- canonical owner repository: `StegVerse-Labs/continuity-vault-kit`
- repository handoff: `CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md`
- capability-slice handoff: `KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md`

This PR does **not** create a new task. It extends the existing KV connection/revalidation workstream.

Changes:
- make `tools/init_vault.py` support isolated KV #1 / KV #2 / KV #n roots;
- preserve `KnowledgeVault/` for KV #1 and default later instances to `KnowledgeVault-n/`;
- add unique instance IDs, `kv_set_id`, storage-medium metadata, and receipt binding;
- make ordinals explicitly non-authoritative;
- prove two iCloud-described instances can coexist without overwrite;
- define KV #n over any owner-controlled storage medium;
- implement four relationship tiers: `NOT_CONNECTED`, `CONNECTED`, `SYNCED`, `AI_INTERACTION`;
- default every new instance to `NOT_CONNECTED`, regardless of shared owner/set/provider;
- encode cumulative inter-comms/data-movement/replication/unified-AI-corpus capabilities;
- represent governed relationship transition requests without claiming runtime admission;
- update README and relationship documentation because installation/runtime semantics materially change;
- update clean-room expectations for generated instance identity state;
- bind this capability slice explicitly to COSV `50000000102000` through `KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md`.

Runtime boundary: source implementation does not activate provider sessions, credentials, data movement, synchronization, unified AI exposure, or Interlock/InTr authority. Authentic runtime admission/readback evidence remains required under the existing KV connection/revalidation task.