### PR TITLE
Persist governed KV relationship state

### DIFF
--- a/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
+++ b/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
@@ -1,9 +1,10 @@
 # KV Multi-Instance COSV Binding Mirror Handoff
 
-Status: SOURCE_IMPLEMENTATION_IN_PROGRESS / CANONICAL_COSV_BOUND / RUNTIME_ACTIVATION_PENDING
+Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MATERIALIZATION_IN_PROGRESS / CANONICAL_COSV_BOUND / RUNTIME_ACTIVATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
-Branch: `kv-multi-instance-roots`
-Pull request: `#196`
+Current branch: `kv-relationship-state-materialization`
+Merged source PR: `#196`
+Merged source commit: `2a2a5273a684fedfaf10f6c4ea93d195d9d9ae6f`
 Updated: 2026-09-08
 Authority effect: NONE
 Activation effect: false
@@ -11,8 +12,6 @@ Activation effect: false
 ## Canonical task binding
 
 This file does **not** create a new StegVerse task.
-
-The KV #1 / KV #2 / KV #n multi-instance and relationship-tier work is a capability slice of the existing canonical KV connection/revalidation task:
 
 ```text
 GOAL TASK ID: KV-CONNECTION-REVALIDATION-WORKER-001
@@ -22,26 +21,51 @@ CANONICAL OWNER REPOSITORY: StegVerse-Labs/continuity-vault-kit
 REPOSITORY HANDOFF: CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
 ```
 
-The organization-level COSV handoff remains authoritative for the task vector. This repository handoff records how PR #196 participates in that already-existing task.
+The organization-level COSV handoff remains authoritative for the task vector. This repository handoff records the multi-instance capability slice and its source/runtime boundary.
 
-## Capability slice
+## Merged capability baseline
 
-PR #196 extends the canonical KV connection/revalidation surface with provider-neutral multi-instance identity and explicit inter-instance relationship semantics:
+PR #196 is validated and merged. The repository now defines:
+
+- isolated `KV #1`, `KV #2`, and `KV #n` roots;
+- unique per-instance identity and installation receipt binding;
+- provider-neutral storage metadata;
+- ordinal identity with no implied authority hierarchy;
+- four cumulative relationship tiers: `NOT_CONNECTED`, `CONNECTED`, `SYNCED`, `AI_INTERACTION`;
+- default `NOT_CONNECTED` state for every new instance;
+- non-authorizing governed transition requests.
+
+## Relationship-state materialization slice
+
+The current machine-executable source slice adds durable private-KV relationship state:
 
 ```text
-KV #1 -> storage medium A
-KV #2 -> storage medium A or B
-...
-KV #n -> any admitted owner-controlled storage medium
+_System/Instances/Relationships/
+  relationship-state.json
+  Requests/<request_id>.json
+  Receipts/<request_id>.json
 ```
 
-Each instance has an isolated root, unique `instance_id`, shared or distinct `kv_set_id` as selected, storage-medium metadata, and its own installation receipt.
+Source invariants:
 
-Instance ordinal is identity only. It does not grant priority, authority, freshness, trust, primary status, replication rank, or inheritance.
+1. initialization is fail-closed at `NOT_CONNECTED`;
+2. persisting a transition request does not change current relationship state;
+3. pending requests must remain `PENDING_INTERLOCK_INTR` with no claimed data movement, replication, AI exposure, authority, or activation;
+4. a relationship state change may be materialized only from `ADMITTED` runtime evidence bound to the same request;
+5. both Interlock and InTr receipt references are required before state materialization;
+6. current-tier and `kv_set_id` bindings must match persisted state;
+7. source materialization never creates credential/provider authority and retains `authority_effect: NONE` / `activation_effect: false`.
+
+Current source artifacts include:
+
+- `runtime/kv_relationship_state_store.py`
+- `schemas/kv-relationship-state.schema.json`
+- `tests/test_kv_relationship_state_store.py`
+- existing `runtime/kv_instance_relationships.py`
+- existing `schemas/kv-relationship-transition-request.schema.json`
+- `README.md` relationship-state documentation
 
 ## Canonical relationship tiers
-
-The inter-instance relationship has four cumulative capability tiers:
 
 ```text
 NOT_CONNECTED
@@ -69,61 +93,15 @@ AI_INTERACTION
   unified AI corpus: true
 ```
 
-New instances begin `NOT_CONNECTED` even when they share the same owner, `kv_set_id`, or storage provider.
-
-`AI_INTERACTION` means participating KVs are exposed to an admitted AI interaction as one logical corpus. Physical roots remain distinct, provenance remains instance-specific, contradictory records are not silently collapsed, and AI does not become canonical authority over the data.
-
-## Relationship transition boundary
-
-Source code may represent or request relationship changes before Interlock/InTr runtime activation, but source state must not claim that a governed transition occurred.
-
-The source layer may therefore produce transition requests such as:
-
-```text
-NOT_CONNECTED -> CONNECTED
-CONNECTED -> SYNCED
-SYNCED -> AI_INTERACTION
-AI_INTERACTION -> SYNCED
-SYNCED -> CONNECTED
-CONNECTED -> NOT_CONNECTED
-```
-
-Actual transition admission, data movement, replication, or unified AI exposure remains a governed runtime action and must be supported by authentic Interlock/InTr/provider/private-KV evidence.
-
-## Current PR #196 artifacts
-
-- `tools/init_vault.py`
-- `runtime/kv_instance_relationships.py`
-- relationship transition request/runtime source added on the branch
-- `tests/test_multi_instance_vaults.py`
-- `docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md`
-- `README.md`
-- `tools/test_clean_room_user_kv.py`
-
-## Acceptance conditions for this capability slice
-
-Source completion requires:
-
-1. KV #2 can be created beside KV #1 without overwrite.
-2. KV #n can use any described owner-controlled storage medium without changing instance semantics.
-3. every instance has isolated identity and receipt binding.
-4. new instances default to `NOT_CONNECTED`.
-5. the four relationship tiers are encoded as machine-readable cumulative capabilities.
-6. transition requests are representable without claiming runtime authority.
-7. tests prove same-provider coexistence and relationship semantics.
-8. PR #196 is validated and merged.
-
-Runtime completion remains separate and requires authentic evidence for admitted provider/inter-instance operations.
+`AI_INTERACTION` is a unified logical corpus for an admitted AI interaction; it does not physically merge roots, erase provenance, collapse contradictions, or make AI canonical authority.
 
 ## Remaining work
 
-- obtain repository validation for the current PR #196 head;
-- remediate any failing checks;
-- merge PR #196 when validation and review gates permit;
-- materialize a real KV #2 instance without altering KV #1;
-- later bind CONNECTED/SYNCED/AI_INTERACTION runtime transitions to actual Interlock/InTr execution and evidence;
-- project the instance list and relationship tiers into MyKV add/remove/manage-drive UX.
+- validate and merge the relationship-state materialization source slice;
+- materialize a real KV #2 instance without altering KV #1 when an admissible storage/user flow is available;
+- bind actual CONNECTED/SYNCED/AI_INTERACTION transitions to authentic Interlock/InTr runtime evidence;
+- project instance list, storage bindings, health, and four-tier relationship state into MyKV add/remove/manage-drive UX.
 
 ## Manual work
 
-None required for source implementation or task binding at this point. Any provider login, account authorization, or user-controlled cloud installation step remains outside source-only proof until explicitly performed through an admitted runtime/user flow.
+None required for this source slice. Provider login/account authorization or installation into user-controlled cloud storage remains a separate admitted user/runtime action.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ KV #2 does not inherit authority from KV #1, and a higher or lower instance numb
 
 This separation allows same-provider multi-instance use immediately—for example KV #1 and KV #2 can both live in iCloud Drive—while provider-specific adapters and governed relationship transitions can be integrated later without changing the instance identity model.
 
+Relationship state is durably represented inside each KV at `_System/Instances/Relationships/relationship-state.json`. Transition requests are stored separately under `_System/Instances/Relationships/Requests/`. Persisting a request never changes the current tier. A state transition can be materialized only from an already-admitted request carrying both Interlock and InTr receipt references; source code does not decide admission and does not claim runtime activation, provider authority, data movement, replication, or AI exposure by itself.
+
 See [`docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md`](./docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md) for the complete relationship contract.
 
 ### Use

--- a/runtime/kv_relationship_state_store.py
+++ b/runtime/kv_relationship_state_store.py
@@ -1,0 +1,160 @@
+"""Private-KV persistence for inter-instance relationship requests and state.
+
+This module materializes relationship records inside an admitted local/private KV root.
+It does not perform provider login, data movement, replication, AI exposure, or grant
+Interlock/InTr authority.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from runtime.kv_instance_relationships import (
+    TRANSITION_SCHEMA,
+    KVRelationshipTier,
+    relationship_record,
+)
+
+STATE_SCHEMA = "stegverse.kv.relationship-state/v1"
+
+
+class KVRelationshipStateError(ValueError):
+    pass
+
+
+def canonical_paths(kv_root: Path) -> dict[str, Path]:
+    root = kv_root.expanduser().resolve()
+    base = root / "_System" / "Instances" / "Relationships"
+    return {
+        "root": base,
+        "requests": base / "Requests",
+        "state": base / "relationship-state.json",
+        "receipts": base / "Receipts",
+    }
+
+
+def initialize_store(kv_root: Path, *, kv_set_id: str, instance_id: str) -> Dict[str, Any]:
+    if not kv_set_id.strip():
+        raise KVRelationshipStateError("kv_set_id is required")
+    if not instance_id.startswith("kvi_"):
+        raise KVRelationshipStateError("instance_id must use kvi_ identifier")
+    paths = canonical_paths(kv_root)
+    paths["root"].mkdir(parents=True, exist_ok=True)
+    paths["requests"].mkdir(parents=True, exist_ok=True)
+    paths["receipts"].mkdir(parents=True, exist_ok=True)
+    if not paths["state"].exists():
+        state = {
+            "schema": STATE_SCHEMA,
+            "kv_set_id": kv_set_id.strip(),
+            "instance_id": instance_id,
+            "relationship": relationship_record(KVRelationshipTier.NOT_CONNECTED),
+            "governance_state": "NOT_CONNECTED",
+            "last_admitted_request_id": None,
+            "last_interlock_receipt_ref": None,
+            "last_intr_receipt_ref": None,
+            "authority_effect": "NONE",
+            "activation_effect": False,
+        }
+        paths["state"].write_text(json.dumps(state, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return load_state(kv_root)
+
+
+def load_state(kv_root: Path) -> Dict[str, Any]:
+    path = canonical_paths(kv_root)["state"]
+    if not path.is_file():
+        raise KVRelationshipStateError("relationship state store is not initialized")
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise KVRelationshipStateError("relationship state is unreadable") from exc
+    if state.get("schema") != STATE_SCHEMA:
+        raise KVRelationshipStateError("unexpected relationship state schema")
+    if state.get("authority_effect") != "NONE" or state.get("activation_effect") is not False:
+        raise KVRelationshipStateError("source relationship state cannot claim authority or activation")
+    return state
+
+
+def persist_transition_request(kv_root: Path, request: Dict[str, Any]) -> Path:
+    if request.get("schema") != TRANSITION_SCHEMA:
+        raise KVRelationshipStateError("unexpected transition request schema")
+    if request.get("governance_state") != "PENDING_INTERLOCK_INTR":
+        raise KVRelationshipStateError("only pending governed requests may be source-persisted")
+    if request.get("authority_effect") != "NONE" or request.get("activation_effect") is not False:
+        raise KVRelationshipStateError("transition request cannot claim authority or activation")
+    if request.get("data_moved") is not False or request.get("replication_started") is not False or request.get("ai_corpus_exposed") is not False:
+        raise KVRelationshipStateError("pending request cannot claim runtime effects")
+    request_id = str(request.get("request_id") or "")
+    if not request_id.startswith("kvrel_"):
+        raise KVRelationshipStateError("request_id invalid")
+    path = canonical_paths(kv_root)["requests"] / f"{request_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = copy.deepcopy(request)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def apply_admitted_transition(
+    kv_root: Path,
+    *,
+    request: Dict[str, Any],
+    admission: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Materialize an already-admitted relationship transition.
+
+    This function is intentionally evidence-gated. It does not decide admission.
+    The caller must supply authentic runtime admission evidence references.
+    """
+    if request.get("schema") != TRANSITION_SCHEMA:
+        raise KVRelationshipStateError("unexpected transition request schema")
+    if admission.get("governance_state") != "ADMITTED":
+        raise KVRelationshipStateError("transition requires ADMITTED governance evidence")
+    if admission.get("request_id") != request.get("request_id"):
+        raise KVRelationshipStateError("admission request binding mismatch")
+    interlock_ref = str(admission.get("interlock_receipt_ref") or "").strip()
+    intr_ref = str(admission.get("intr_receipt_ref") or "").strip()
+    if not interlock_ref or not intr_ref:
+        raise KVRelationshipStateError("Interlock and InTr receipt references are required")
+    if admission.get("authority_effect") not in {None, "NONE"}:
+        raise KVRelationshipStateError("admission evidence cannot create source authority")
+
+    current = load_state(kv_root)
+    if current.get("kv_set_id") != request.get("kv_set_id"):
+        raise KVRelationshipStateError("kv_set_id mismatch")
+    if current.get("relationship", {}).get("tier") != request.get("current_tier"):
+        raise KVRelationshipStateError("current tier does not match persisted state")
+
+    target = str(request.get("target_tier") or "")
+    try:
+        relationship = relationship_record(KVRelationshipTier[target])
+    except Exception as exc:
+        raise KVRelationshipStateError("target tier invalid") from exc
+
+    next_state = {
+        **current,
+        "relationship": relationship,
+        "governance_state": "ADMITTED",
+        "last_admitted_request_id": request["request_id"],
+        "last_interlock_receipt_ref": interlock_ref,
+        "last_intr_receipt_ref": intr_ref,
+        "authority_effect": "NONE",
+        "activation_effect": False,
+    }
+    canonical_paths(kv_root)["state"].write_text(json.dumps(next_state, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    receipt = {
+        "schema": "stegverse.kv.relationship-transition-receipt/v1",
+        "request_id": request["request_id"],
+        "kv_set_id": request["kv_set_id"],
+        "from_tier": request["current_tier"],
+        "to_tier": target,
+        "interlock_receipt_ref": interlock_ref,
+        "intr_receipt_ref": intr_ref,
+        "authority_effect": "NONE",
+        "activation_effect": False,
+    }
+    receipt_path = canonical_paths(kv_root)["receipts"] / f"{request['request_id']}.json"
+    receipt_path.write_text(json.dumps(receipt, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return copy.deepcopy(next_state)

--- a/schemas/kv-relationship-state.schema.json
+++ b/schemas/kv-relationship-state.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-relationship-state.schema.json",
+  "title": "KnowledgeVault Relationship State",
+  "type": "object",
+  "required": [
+    "schema",
+    "kv_set_id",
+    "instance_id",
+    "relationship",
+    "governance_state",
+    "authority_effect",
+    "activation_effect"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.kv.relationship-state/v1"},
+    "kv_set_id": {"type": "string", "minLength": 1},
+    "instance_id": {"type": "string", "pattern": "^kvi_[A-Za-z0-9]+$"},
+    "relationship": {
+      "type": "object",
+      "required": ["tier", "tier_order", "inter_comms", "data_movement", "replication", "unified_ai_corpus", "authority_effect", "activation_effect"],
+      "properties": {
+        "tier": {"enum": ["NOT_CONNECTED", "CONNECTED", "SYNCED", "AI_INTERACTION"]},
+        "tier_order": {"type": "integer", "minimum": 0, "maximum": 3},
+        "inter_comms": {"type": "boolean"},
+        "data_movement": {"type": "boolean"},
+        "replication": {"type": "boolean"},
+        "unified_ai_corpus": {"type": "boolean"},
+        "authority_effect": {"const": "NONE"},
+        "activation_effect": {"const": false}
+      },
+      "additionalProperties": false
+    },
+    "governance_state": {"enum": ["NOT_CONNECTED", "ADMITTED"]},
+    "last_admitted_request_id": {"type": ["string", "null"]},
+    "last_interlock_receipt_ref": {"type": ["string", "null"]},
+    "last_intr_receipt_ref": {"type": ["string", "null"]},
+    "authority_effect": {"const": "NONE"},
+    "activation_effect": {"const": false}
+  },
+  "additionalProperties": false
+}

--- a/tests/test_kv_relationship_state_store.py
+++ b/tests/test_kv_relationship_state_store.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from runtime.kv_instance_relationships import transition_request
+from runtime.kv_relationship_state_store import (
+    KVRelationshipStateError,
+    apply_admitted_transition,
+    initialize_store,
+    load_state,
+    persist_transition_request,
+)
+
+
+def test_store_initializes_fail_closed(tmp_path: Path) -> None:
+    state = initialize_store(tmp_path, kv_set_id="personal", instance_id="kvi_one")
+    assert state["relationship"]["tier"] == "NOT_CONNECTED"
+    assert state["governance_state"] == "NOT_CONNECTED"
+    assert state["authority_effect"] == "NONE"
+    assert state["activation_effect"] is False
+
+
+def test_pending_request_can_be_persisted_without_runtime_effect(tmp_path: Path) -> None:
+    initialize_store(tmp_path, kv_set_id="personal", instance_id="kvi_one")
+    request = transition_request(
+        kv_set_id="personal",
+        participant_instance_ids=["kvi_one", "kvi_two"],
+        current_tier="NOT_CONNECTED",
+        target_tier="CONNECTED",
+    )
+    path = persist_transition_request(tmp_path, request)
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved["governance_state"] == "PENDING_INTERLOCK_INTR"
+    assert saved["data_moved"] is False
+    assert saved["replication_started"] is False
+    assert saved["ai_corpus_exposed"] is False
+    assert load_state(tmp_path)["relationship"]["tier"] == "NOT_CONNECTED"
+
+
+def test_apply_rejects_unadmitted_transition(tmp_path: Path) -> None:
+    initialize_store(tmp_path, kv_set_id="personal", instance_id="kvi_one")
+    request = transition_request(
+        kv_set_id="personal",
+        participant_instance_ids=["kvi_one", "kvi_two"],
+        current_tier="NOT_CONNECTED",
+        target_tier="CONNECTED",
+    )
+    with pytest.raises(KVRelationshipStateError, match="ADMITTED"):
+        apply_admitted_transition(
+            tmp_path,
+            request=request,
+            admission={"governance_state": "PENDING_INTERLOCK_INTR", "request_id": request["request_id"]},
+        )
+
+
+def test_apply_requires_both_interlock_and_intr_receipts(tmp_path: Path) -> None:
+    initialize_store(tmp_path, kv_set_id="personal", instance_id="kvi_one")
+    request = transition_request(
+        kv_set_id="personal",
+        participant_instance_ids=["kvi_one", "kvi_two"],
+        current_tier="NOT_CONNECTED",
+        target_tier="CONNECTED",
+    )
+    with pytest.raises(KVRelationshipStateError, match="Interlock and InTr"):
+        apply_admitted_transition(
+            tmp_path,
+            request=request,
+            admission={
+                "governance_state": "ADMITTED",
+                "request_id": request["request_id"],
+                "interlock_receipt_ref": "receipt://interlock/1",
+            },
+        )
+
+
+def test_admitted_transition_materializes_state_and_receipt(tmp_path: Path) -> None:
+    initialize_store(tmp_path, kv_set_id="personal", instance_id="kvi_one")
+    request = transition_request(
+        kv_set_id="personal",
+        participant_instance_ids=["kvi_one", "kvi_two"],
+        current_tier="NOT_CONNECTED",
+        target_tier="CONNECTED",
+    )
+    next_state = apply_admitted_transition(
+        tmp_path,
+        request=request,
+        admission={
+            "governance_state": "ADMITTED",
+            "request_id": request["request_id"],
+            "interlock_receipt_ref": "receipt://interlock/1",
+            "intr_receipt_ref": "receipt://intr/1",
+            "authority_effect": "NONE",
+        },
+    )
+    assert next_state["relationship"]["tier"] == "CONNECTED"
+    assert next_state["governance_state"] == "ADMITTED"
+    assert next_state["activation_effect"] is False
+    receipt = tmp_path / "_System/Instances/Relationships/Receipts" / f"{request['request_id']}.json"
+    assert receipt.is_file()
+
+
+def test_state_cannot_skip_current_tier_binding(tmp_path: Path) -> None:
+    initialize_store(tmp_path, kv_set_id="personal", instance_id="kvi_one")
+    request = transition_request(
+        kv_set_id="personal",
+        participant_instance_ids=["kvi_one", "kvi_two"],
+        current_tier="CONNECTED",
+        target_tier="SYNCED",
+    )
+    with pytest.raises(KVRelationshipStateError, match="current tier"):
+        apply_admitted_transition(
+            tmp_path,
+            request=request,
+            admission={
+                "governance_state": "ADMITTED",
+                "request_id": request["request_id"],
+                "interlock_receipt_ref": "receipt://interlock/2",
+                "intr_receipt_ref": "receipt://intr/2",
+            },
+        )


### PR DESCRIPTION
Canonical StegVerse task binding:
- GOAL TASK ID: `KV-CONNECTION-REVALIDATION-WORKER-001`
- COSV ID: `50000000102000`
- canonical COSV handoff: `StegVerse-Labs/.github/KV_CONNECTION_REVALIDATION_COSV_MIRROR_HANDOFF.md`
- capability handoff: `KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md`

Continues the existing KV multi-instance workstream after merged PR #196; no new task is created.

Changes:
- persist relationship state under `_System/Instances/Relationships/relationship-state.json`;
- persist pending governed requests separately under `Requests/`;
- keep initialization fail-closed at `NOT_CONNECTED`;
- prohibit pending requests from claiming data movement, replication, AI exposure, authority, or activation;
- require matching `kv_set_id` and current tier before state transition materialization;
- require both Interlock and InTr receipt references and `ADMITTED` evidence before a state change can be written;
- emit a relationship transition receipt after admitted materialization;
- add machine-readable relationship-state schema and tests;
- update README and the COSV capability handoff because relationship-state semantics changed.

Runtime boundary: this source does not decide admission, activate providers, move or replicate data, expose data to AI, or create authority. Authentic Interlock/InTr evidence remains required for any non-`NOT_CONNECTED` materialized runtime state.