### PR TITLE
Project KV #n state to MyKV

### DIFF
--- a/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
+++ b/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
@@ -1,10 +1,10 @@
 # KV Multi-Instance COSV Binding Mirror Handoff
 
-Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MATERIALIZATION_IN_PROGRESS / CANONICAL_COSV_BOUND / RUNTIME_ACTIVATION_PENDING
+Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MERGED / MYKV_PROJECTION_IN_PROGRESS / CANONICAL_COSV_BOUND / RUNTIME_ACTIVATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
-Current branch: `kv-relationship-state-materialization`
-Merged source PR: `#196`
-Merged source commit: `2a2a5273a684fedfaf10f6c4ea93d195d9d9ae6f`
+Current branch: `kv-my-kv-instance-projection`
+Merged source PRs: `#196`, `#197`
+Merged commits: `2a2a5273a684fedfaf10f6c4ea93d195d9d9ae6f`, `ea4da1e58e74c7f2690d26e82cb9c6a6e30aca03`
 Updated: 2026-09-08
 Authority effect: NONE
 Activation effect: false
@@ -25,19 +25,9 @@ The organization-level COSV handoff remains authoritative for the task vector. T
 
 ## Merged capability baseline
 
-PR #196 is validated and merged. The repository now defines:
+PR #196 is validated and merged. The repository defines isolated `KV #1`, `KV #2`, and `KV #n` roots; unique per-instance identity and receipt binding; provider-neutral storage metadata; four cumulative relationship tiers (`NOT_CONNECTED`, `CONNECTED`, `SYNCED`, `AI_INTERACTION`); default `NOT_CONNECTED`; and non-authorizing governed transition requests.
 
-- isolated `KV #1`, `KV #2`, and `KV #n` roots;
-- unique per-instance identity and installation receipt binding;
-- provider-neutral storage metadata;
-- ordinal identity with no implied authority hierarchy;
-- four cumulative relationship tiers: `NOT_CONNECTED`, `CONNECTED`, `SYNCED`, `AI_INTERACTION`;
-- default `NOT_CONNECTED` state for every new instance;
-- non-authorizing governed transition requests.
-
-## Relationship-state materialization slice
-
-The current machine-executable source slice adds durable private-KV relationship state:
+PR #197 is validated and merged. Relationship state is durably represented under:
 
 ```text
 _System/Instances/Relationships/
@@ -46,24 +36,39 @@ _System/Instances/Relationships/
   Receipts/<request_id>.json
 ```
 
-Source invariants:
+State transitions remain fail-closed and require matching `kv_set_id`, current-tier binding, `ADMITTED` evidence, and both Interlock and InTr receipt references before source materialization.
 
-1. initialization is fail-closed at `NOT_CONNECTED`;
-2. persisting a transition request does not change current relationship state;
-3. pending requests must remain `PENDING_INTERLOCK_INTR` with no claimed data movement, replication, AI exposure, authority, or activation;
-4. a relationship state change may be materialized only from `ADMITTED` runtime evidence bound to the same request;
-5. both Interlock and InTr receipt references are required before state materialization;
-6. current-tier and `kv_set_id` bindings must match persisted state;
-7. source materialization never creates credential/provider authority and retains `authority_effect: NONE` / `activation_effect: false`.
+## Current MyKV projection slice
 
-Current source artifacts include:
+The current source slice gives MyKV a bounded multi-instance status surface without exposing private KV content or granting provider/runtime authority.
 
-- `runtime/kv_relationship_state_store.py`
-- `schemas/kv-relationship-state.schema.json`
-- `tests/test_kv_relationship_state_store.py`
-- existing `runtime/kv_instance_relationships.py`
-- existing `schemas/kv-relationship-transition-request.schema.json`
-- `README.md` relationship-state documentation
+Current artifacts:
+
+- `runtime/kv_my_kv_projection.py`
+- `schemas/kv-my-kv-instance-projection.schema.json`
+- `tests/test_kv_my_kv_projection.py`
+- `README.md`
+
+The projection exposes only:
+
+- `instance_id`, `instance_number`, logical KV name, and `kv_set_id`;
+- storage medium and explicitly non-secret locator metadata already present in the instance record;
+- current relationship tier and relationship governance state;
+- last admitted relationship request ID and pending relationship request IDs;
+- request-surface capability flags for connect, disconnect, and relationship-tier-change requests.
+
+The projection fixes these boundaries:
+
+```text
+private_content_included: false
+credential_material_included: false
+provider_mutation_authorized: false
+relationship_mutation_authorized: false
+authority_effect: NONE_STATUS_ONLY
+activation_effect: false
+```
+
+MyKV may render these fields and initiate governed requests. The projection itself cannot connect/disconnect storage, change tiers, move data, replicate content, expose a unified AI corpus, authenticate a provider, or create execution/governance authority.
 
 ## Canonical relationship tiers
 
@@ -97,10 +102,11 @@ AI_INTERACTION
 
 ## Remaining work
 
-- validate and merge the relationship-state materialization source slice;
+- validate and merge the MyKV projection source slice;
+- coordinate the Site/MyKV consumer against this bounded projection contract without inventing a parallel provider/relationship authority;
 - materialize a real KV #2 instance without altering KV #1 when an admissible storage/user flow is available;
 - bind actual CONNECTED/SYNCED/AI_INTERACTION transitions to authentic Interlock/InTr runtime evidence;
-- project instance list, storage bindings, health, and four-tier relationship state into MyKV add/remove/manage-drive UX.
+- add real provider adapters and MyKV add/remove-drive request execution only when the corresponding admitted runtime paths exist.
 
 ## Manual work
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ This separation allows same-provider multi-instance use immediately—for exampl
 
 Relationship state is durably represented inside each KV at `_System/Instances/Relationships/relationship-state.json`. Transition requests are stored separately under `_System/Instances/Relationships/Requests/`. Persisting a request never changes the current tier. A state transition can be materialized only from an already-admitted request carrying both Interlock and InTr receipt references; source code does not decide admission and does not claim runtime activation, provider authority, data movement, replication, or AI exposure by itself.
 
+MyKV-facing source may consume a bounded multi-instance projection rather than private KV content. `runtime/kv_my_kv_projection.py` projects instance identity, storage metadata, current relationship tier, governance state, and pending relationship request IDs while fixing `private_content_included=false`, `credential_material_included=false`, provider/relationship mutation authority to false, and `authority_effect=NONE_STATUS_ONLY`. The projection supports rendering and request initiation; it does not itself connect/disconnect storage, change tiers, move data, replicate content, or expose a unified AI corpus.
+
 See [`docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md`](./docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md) for the complete relationship contract.
 
 ### Use

--- a/docs/KV_MYKV_INSTANCE_PROJECTION.md
+++ b/docs/KV_MYKV_INSTANCE_PROJECTION.md
@@ -1,0 +1,55 @@
+# KV MyKV Instance Projection
+
+This document defines the bounded status contract by which MyKV can display multiple KnowledgeVault instances without receiving private vault content or provider credentials.
+
+## Source
+
+`runtime/kv_my_kv_projection.py`
+
+## Projection purpose
+
+MyKV may display, per KV instance:
+
+- instance identity and ordinal;
+- KV set membership;
+- storage medium and explicitly non-secret locator metadata;
+- current relationship tier;
+- relationship governance state;
+- pending relationship request identifiers;
+- whether governed connect, disconnect, and tier-change requests can be initiated.
+
+The projection is status-only. It cannot authorize or execute provider mutation, relationship mutation, data movement, replication, AI corpus exposure, credential access, or runtime activation.
+
+## Required safety posture
+
+```text
+private_content_included = false
+credential_material_included = false
+provider_mutation_authorized = false
+relationship_mutation_authorized = false
+authority_effect = NONE_STATUS_ONLY
+activation_effect = false
+```
+
+A MyKV consumer must fail closed if those fixed values are not present.
+
+## Relationship tiers
+
+The projection carries one of:
+
+- `NOT_CONNECTED`
+- `CONNECTED`
+- `SYNCED`
+- `AI_INTERACTION`
+
+The tier is read from durable relationship state when present. Pending requests are projected separately and do not alter the current tier.
+
+## Multi-instance set projection
+
+A set projection may aggregate multiple roots only when every projected instance carries the same `kv_set_id`. Mixed-set aggregation is rejected.
+
+Instance entries are deterministically ordered by `instance_number`, then `instance_id`.
+
+## Consumer boundary
+
+Site/MyKV may render the projection and produce governed request intents. It must not infer that request support means provider or relationship execution authority. Actual mutation remains subject to Interlock/InTr and the corresponding provider/runtime path.

--- a/runtime/kv_my_kv_projection.py
+++ b/runtime/kv_my_kv_projection.py
@@ -1,0 +1,123 @@
+"""Bounded MyKV projection for KnowledgeVault multi-instance state.
+
+This module exposes instance/storage/relationship metadata only. It never includes
+private KV content, credentials, provider tokens, or provider-operation authority.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from runtime.kv_relationship_state_store import canonical_paths as relationship_paths
+
+PROJECTION_SCHEMA = "stegverse.kv.my-kv-instance-projection/v1"
+SET_PROJECTION_SCHEMA = "stegverse.kv.my-kv-set-projection/v1"
+INSTANCE_RECORD = Path("_System/Instances/instance.json")
+
+
+class MyKVProjectionError(ValueError):
+    pass
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise MyKVProjectionError(f"unreadable JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise MyKVProjectionError(f"expected object: {path}")
+    return value
+
+
+def build_instance_projection(kv_root: Path) -> dict[str, Any]:
+    root = kv_root.expanduser().resolve()
+    instance_path = root / INSTANCE_RECORD
+    if not instance_path.is_file():
+        raise MyKVProjectionError("instance identity record missing")
+    instance = _read_json(instance_path)
+
+    instance_id = str(instance.get("instance_id") or "")
+    kv_set_id = str(instance.get("kv_set_id") or "")
+    if not instance_id.startswith("kvi_") or not kv_set_id:
+        raise MyKVProjectionError("invalid instance identity")
+
+    storage = instance.get("storage") or {}
+    if not isinstance(storage, dict):
+        raise MyKVProjectionError("storage metadata invalid")
+
+    state_path = relationship_paths(root)["state"]
+    if state_path.is_file():
+        state = _read_json(state_path)
+        if state.get("instance_id") != instance_id or state.get("kv_set_id") != kv_set_id:
+            raise MyKVProjectionError("relationship state identity binding mismatch")
+        relationship = state.get("relationship") or {}
+        relationship_tier = str(relationship.get("tier") or "NOT_CONNECTED")
+        relationship_governance_state = str(state.get("governance_state") or "NOT_CONNECTED")
+        last_admitted_request_id = state.get("last_admitted_request_id")
+    else:
+        relationship_tier = str((instance.get("relationship") or {}).get("tier") or "NOT_CONNECTED")
+        relationship_governance_state = "NOT_CONNECTED"
+        last_admitted_request_id = None
+
+    requests_dir = relationship_paths(root)["requests"]
+    pending_request_ids = []
+    if requests_dir.is_dir():
+        for path in sorted(requests_dir.glob("kvrel_*.json")):
+            try:
+                request = _read_json(path)
+            except MyKVProjectionError:
+                continue
+            if request.get("governance_state") == "PENDING_INTERLOCK_INTR":
+                pending_request_ids.append(str(request.get("request_id") or path.stem))
+
+    return {
+        "schema": PROJECTION_SCHEMA,
+        "instance_id": instance_id,
+        "instance_number": instance.get("instance_number"),
+        "logical_name": instance.get("logical_name"),
+        "kv_set_id": kv_set_id,
+        "storage": {
+            "medium": storage.get("medium"),
+            "locator": storage.get("locator"),
+            "provider_authority_effect": "NONE",
+        },
+        "relationship": {
+            "tier": relationship_tier,
+            "governance_state": relationship_governance_state,
+            "last_admitted_request_id": last_admitted_request_id,
+            "pending_request_ids": pending_request_ids,
+        },
+        "management": {
+            "request_connect_supported": True,
+            "request_disconnect_supported": True,
+            "request_tier_change_supported": True,
+            "provider_mutation_authorized": False,
+            "relationship_mutation_authorized": False,
+        },
+        "private_content_included": False,
+        "credential_material_included": False,
+        "authority_effect": "NONE_STATUS_ONLY",
+        "activation_effect": False,
+    }
+
+
+def build_set_projection(kv_roots: Iterable[Path]) -> dict[str, Any]:
+    projections = [build_instance_projection(root) for root in kv_roots]
+    if not projections:
+        raise MyKVProjectionError("at least one KV instance is required")
+    set_ids = {item["kv_set_id"] for item in projections}
+    if len(set_ids) != 1:
+        raise MyKVProjectionError("all projected instances must share one kv_set_id")
+    projections.sort(key=lambda item: (int(item.get("instance_number") or 0), item["instance_id"]))
+    return {
+        "schema": SET_PROJECTION_SCHEMA,
+        "kv_set_id": next(iter(set_ids)),
+        "instances": projections,
+        "instance_count": len(projections),
+        "private_content_included": False,
+        "credential_material_included": False,
+        "authority_effect": "NONE_STATUS_ONLY",
+        "activation_effect": False,
+    }

--- a/schemas/kv-my-kv-instance-projection.schema.json
+++ b/schemas/kv-my-kv-instance-projection.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stegverse.kv.my-kv-instance-projection/v1",
+  "type": "object",
+  "required": ["schema","instance_id","instance_number","logical_name","kv_set_id","storage","relationship","management","private_content_included","credential_material_included","authority_effect","activation_effect"],
+  "properties": {
+    "schema": {"const": "stegverse.kv.my-kv-instance-projection/v1"},
+    "instance_id": {"type": "string", "pattern": "^kvi_"},
+    "instance_number": {"type": "integer", "minimum": 1},
+    "logical_name": {"type": "string", "minLength": 1},
+    "kv_set_id": {"type": "string", "minLength": 1},
+    "storage": {
+      "type": "object",
+      "required": ["medium","locator","provider_authority_effect"],
+      "properties": {
+        "medium": {"type": ["string","null"]},
+        "locator": {"type": ["string","null"]},
+        "provider_authority_effect": {"const": "NONE"}
+      },
+      "additionalProperties": false
+    },
+    "relationship": {
+      "type": "object",
+      "required": ["tier","governance_state","last_admitted_request_id","pending_request_ids"],
+      "properties": {
+        "tier": {"enum": ["NOT_CONNECTED","CONNECTED","SYNCED","AI_INTERACTION"]},
+        "governance_state": {"type": "string", "minLength": 1},
+        "last_admitted_request_id": {"type": ["string","null"]},
+        "pending_request_ids": {"type": "array", "items": {"type": "string", "pattern": "^kvrel_"}, "uniqueItems": true}
+      },
+      "additionalProperties": false
+    },
+    "management": {
+      "type": "object",
+      "required": ["request_connect_supported","request_disconnect_supported","request_tier_change_supported","provider_mutation_authorized","relationship_mutation_authorized"],
+      "properties": {
+        "request_connect_supported": {"const": true},
+        "request_disconnect_supported": {"const": true},
+        "request_tier_change_supported": {"const": true},
+        "provider_mutation_authorized": {"const": false},
+        "relationship_mutation_authorized": {"const": false}
+      },
+      "additionalProperties": false
+    },
+    "private_content_included": {"const": false},
+    "credential_material_included": {"const": false},
+    "authority_effect": {"const": "NONE_STATUS_ONLY"},
+    "activation_effect": {"const": false}
+  },
+  "additionalProperties": false
+}

--- a/tests/test_kv_my_kv_projection.py
+++ b/tests/test_kv_my_kv_projection.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from runtime.kv_instance_relationships import transition_request
+from runtime.kv_my_kv_projection import MyKVProjectionError, build_instance_projection, build_set_projection
+from runtime.kv_relationship_state_store import initialize_store, persist_transition_request
+
+
+def _make_instance(root: Path, *, number: int, instance_id: str, set_id: str = "personal") -> None:
+    path = root / "_System/Instances/instance.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "schema": "stegverse.kv.instance/v1",
+        "instance_id": instance_id,
+        "instance_number": number,
+        "logical_name": f"KV #{number}",
+        "kv_set_id": set_id,
+        "relationship": {"tier": "NOT_CONNECTED"},
+        "storage": {"medium": "icloud-drive", "locator": f"icloud-slot-{number}", "provider_authority_effect": "NONE"},
+    }), encoding="utf-8")
+    initialize_store(root, kv_set_id=set_id, instance_id=instance_id)
+
+
+def test_projection_exposes_metadata_only(tmp_path: Path) -> None:
+    kv1 = tmp_path / "KnowledgeVault"
+    _make_instance(kv1, number=1, instance_id="kvi_one")
+    projection = build_instance_projection(kv1)
+    assert projection["instance_id"] == "kvi_one"
+    assert projection["relationship"]["tier"] == "NOT_CONNECTED"
+    assert projection["management"]["request_connect_supported"] is True
+    assert projection["management"]["provider_mutation_authorized"] is False
+    assert projection["private_content_included"] is False
+    assert projection["credential_material_included"] is False
+    assert projection["authority_effect"] == "NONE_STATUS_ONLY"
+    assert "content" not in projection
+    assert "credentials" not in projection
+
+
+def test_pending_request_is_visible_without_changing_tier(tmp_path: Path) -> None:
+    kv1 = tmp_path / "KnowledgeVault"
+    _make_instance(kv1, number=1, instance_id="kvi_one")
+    request = transition_request(
+        kv_set_id="personal",
+        participant_instance_ids=["kvi_one", "kvi_two"],
+        current_tier="NOT_CONNECTED",
+        target_tier="CONNECTED",
+    )
+    persist_transition_request(kv1, request)
+    projection = build_instance_projection(kv1)
+    assert projection["relationship"]["tier"] == "NOT_CONNECTED"
+    assert projection["relationship"]["pending_request_ids"] == [request["request_id"]]
+
+
+def test_set_projection_orders_instances_and_requires_same_set(tmp_path: Path) -> None:
+    kv1 = tmp_path / "KnowledgeVault"
+    kv2 = tmp_path / "KnowledgeVault-2"
+    _make_instance(kv2, number=2, instance_id="kvi_two")
+    _make_instance(kv1, number=1, instance_id="kvi_one")
+    projection = build_set_projection([kv2, kv1])
+    assert projection["instance_count"] == 2
+    assert [item["instance_number"] for item in projection["instances"]] == [1, 2]
+    assert projection["private_content_included"] is False
+
+    kv3 = tmp_path / "KnowledgeVault-3"
+    _make_instance(kv3, number=3, instance_id="kvi_three", set_id="other")
+    with pytest.raises(MyKVProjectionError):
+        build_set_projection([kv1, kv3])
+
+
+def test_relationship_identity_mismatch_fails_closed(tmp_path: Path) -> None:
+    kv1 = tmp_path / "KnowledgeVault"
+    _make_instance(kv1, number=1, instance_id="kvi_one")
+    state_path = kv1 / "_System/Instances/Relationships/relationship-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["instance_id"] = "kvi_tampered"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    with pytest.raises(MyKVProjectionError):
+        build_instance_projection(kv1)


### PR DESCRIPTION
Canonical StegVerse task binding:
- GOAL TASK ID: `KV-CONNECTION-REVALIDATION-WORKER-001`
- COSV ID: `50000000102000`
- canonical COSV handoff: `StegVerse-Labs/.github/KV_CONNECTION_REVALIDATION_COSV_MIRROR_HANDOFF.md`
- capability handoff: `KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md`

Continues the existing KV multi-instance workstream after merged PRs #196 and #197; no new task is created.

Changes:
- add bounded MyKV instance projection source;
- project instance identity, storage medium/locator metadata, relationship tier/governance state, and pending relationship request IDs;
- add deterministic same-set aggregation for KV #1 / #2 / #n;
- expose request-surface flags without provider or relationship mutation authority;
- fail closed on relationship-state/instance identity mismatch;
- fix private-content and credential-material inclusion false;
- add JSON schema, tests, README documentation, and consumer contract documentation;
- advance the COSV capability handoff to the MyKV projection slice.

Runtime boundary: this projection is status-only. It cannot connect/disconnect storage, change tiers, move data, replicate content, expose a unified AI corpus, authenticate a provider, or create execution/governance authority.