### PR TITLE
Add KV storage provider adapter contracts

### DIFF
--- a/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
+++ b/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
@@ -1,10 +1,10 @@
 # KV Multi-Instance COSV Binding Mirror Handoff
 
-Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MERGED / MYKV_PROJECTION_IN_PROGRESS / CANONICAL_COSV_BOUND / RUNTIME_ACTIVATION_PENDING
+Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MERGED / MYKV_PROJECTION_MERGED / STORAGE_PROVIDER_ADAPTERS_IN_PROGRESS / CANONICAL_COSV_BOUND / RUNTIME_ACTIVATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
-Current branch: `kv-my-kv-instance-projection`
-Merged source PRs: `#196`, `#197`
-Merged commits: `2a2a5273a684fedfaf10f6c4ea93d195d9d9ae6f`, `ea4da1e58e74c7f2690d26e82cb9c6a6e30aca03`
+Current branch: `kv-storage-provider-adapters`
+Merged source PRs: `#196`, `#197`, `#198`
+Merged commits: `2a2a5273a684fedfaf10f6c4ea93d195d9d9ae6f`, `ea4da1e58e74c7f2690d26e82cb9c6a6e30aca03`, `4ee4232aec19f2bbc469bf712403185ab799ab0d`
 Updated: 2026-09-08
 Authority effect: NONE
 Activation effect: false
@@ -27,48 +27,54 @@ The organization-level COSV handoff remains authoritative for the task vector. T
 
 PR #196 is validated and merged. The repository defines isolated `KV #1`, `KV #2`, and `KV #n` roots; unique per-instance identity and receipt binding; provider-neutral storage metadata; four cumulative relationship tiers (`NOT_CONNECTED`, `CONNECTED`, `SYNCED`, `AI_INTERACTION`); default `NOT_CONNECTED`; and non-authorizing governed transition requests.
 
-PR #197 is validated and merged. Relationship state is durably represented under:
+PR #197 is validated and merged. Relationship state is durably represented under `_System/Instances/Relationships/`, with transition materialization gated by matching set/current-tier state and authentic admitted Interlock/InTr receipt references.
 
-```text
-_System/Instances/Relationships/
-  relationship-state.json
-  Requests/<request_id>.json
-  Receipts/<request_id>.json
-```
+PR #198 is validated and merged. MyKV can consume a bounded multi-instance status projection carrying identity/storage/relationship metadata and pending request identifiers while private content, credentials, provider mutation authority, relationship mutation authority, and activation remain false.
 
-State transitions remain fail-closed and require matching `kv_set_id`, current-tier binding, `ADMITTED` evidence, and both Interlock and InTr receipt references before source materialization.
+## Current storage-provider adapter slice
 
-## Current MyKV projection slice
-
-The current source slice gives MyKV a bounded multi-instance status surface without exposing private KV content or granting provider/runtime authority.
+The current source slice provides a provider-neutral request adapter layer for storage providers without claiming live provider execution.
 
 Current artifacts:
 
-- `runtime/kv_my_kv_projection.py`
-- `schemas/kv-my-kv-instance-projection.schema.json`
-- `tests/test_kv_my_kv_projection.py`
+- `runtime/kv_storage_provider_adapter.py`
+- `schemas/kv-storage-provider-operation-request.schema.json`
+- `tests/test_kv_storage_provider_adapter.py`
 - `README.md`
 
-The projection exposes only:
+Default declarative adapters are defined for:
 
-- `instance_id`, `instance_number`, logical KV name, and `kv_set_id`;
-- storage medium and explicitly non-secret locator metadata already present in the instance record;
-- current relationship tier and relationship governance state;
-- last admitted relationship request ID and pending relationship request IDs;
-- request-surface capability flags for connect, disconnect, and relationship-tier-change requests.
+- `icloud-drive`
+- `google-drive`
+- `onedrive`
+- `dropbox`
 
-The projection fixes these boundaries:
+Each adapter can represent these normalized operation intents:
 
 ```text
-private_content_included: false
-credential_material_included: false
-provider_mutation_authorized: false
-relationship_mutation_authorized: false
-authority_effect: NONE_STATUS_ONLY
+CONNECT
+VERIFY
+READ
+WRITE
+SYNC
+DISCONNECT
+```
+
+Every source request is deterministic and fixed fail-closed:
+
+```text
+governance_state: PENDING_INTERLOCK_INTR
+skap_credential_ref_required: true
+credential_material_present: false
+provider_session_established: false
+provider_operation_executed: false
+data_moved: false
+replication_started: false
+authority_effect: NONE
 activation_effect: false
 ```
 
-MyKV may render these fields and initiate governed requests. The projection itself cannot connect/disconnect storage, change tiers, move data, replicate content, expose a unified AI corpus, authenticate a provider, or create execution/governance authority.
+The adapter layer therefore defines the shape needed now for MyKV add/remove/connect/sync flows while leaving authentication, provider sessions, actual read/write/sync execution, and admission to the later SKAP + Interlock/InTr runtime binding.
 
 ## Canonical relationship tiers
 
@@ -102,11 +108,11 @@ AI_INTERACTION
 
 ## Remaining work
 
-- validate and merge the MyKV projection source slice;
-- coordinate the Site/MyKV consumer against this bounded projection contract without inventing a parallel provider/relationship authority;
+- validate and merge the storage-provider adapter source slice;
+- coordinate the Site/MyKV consumer so add/remove/connect/sync UI emits these governed provider-operation requests rather than invoking provider authority directly;
 - materialize a real KV #2 instance without altering KV #1 when an admissible storage/user flow is available;
-- bind actual CONNECTED/SYNCED/AI_INTERACTION transitions to authentic Interlock/InTr runtime evidence;
-- add real provider adapters and MyKV add/remove-drive request execution only when the corresponding admitted runtime paths exist.
+- bind actual provider sessions and CONNECTED/SYNCED/AI_INTERACTION transitions to authentic SKAP + Interlock/InTr runtime evidence;
+- implement provider-specific live execution bindings only after those authority paths are available.
 
 ## Manual work
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Relationship state is durably represented inside each KV at `_System/Instances/R
 
 MyKV-facing source may consume a bounded multi-instance projection rather than private KV content. `runtime/kv_my_kv_projection.py` projects instance identity, storage metadata, current relationship tier, governance state, and pending relationship request IDs while fixing `private_content_included=false`, `credential_material_included=false`, provider/relationship mutation authority to false, and `authority_effect=NONE_STATUS_ONLY`. The projection supports rendering and request initiation; it does not itself connect/disconnect storage, change tiers, move data, replicate content, or expose a unified AI corpus.
 
+The storage-provider adapter layer in `runtime/kv_storage_provider_adapter.py` now provides a provider-neutral request contract for iCloud Drive, Google Drive, Microsoft OneDrive, and Dropbox. Each adapter can represent `CONNECT`, `VERIFY`, `READ`, `WRITE`, `SYNC`, and `DISCONNECT` intents without embedding credentials or claiming provider execution. Every request remains `PENDING_INTERLOCK_INTR`, requires a SKAP credential reference at runtime, fixes raw credential material absent, and fixes provider-session/operation/data-movement/replication effects false until an admitted runtime performs them.
+
 See [`docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md`](./docs/KV_MULTI_INSTANCE_RELATIONSHIPS.md) for the complete relationship contract.
 
 ### Use

--- a/runtime/kv_storage_provider_adapter.py
+++ b/runtime/kv_storage_provider_adapter.py
@@ -1,0 +1,136 @@
+"""Provider-neutral storage adapter contract for KnowledgeVault.
+
+Adapters in this module construct normalized provider-operation intents only. They do
+not authenticate, open provider sessions, read/write remote storage, synchronize data,
+or grant Interlock/InTr authority. Provider credentials remain outside ordinary KV state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable, Protocol
+
+
+SUPPORTED_OPERATIONS = (
+    "CONNECT",
+    "VERIFY",
+    "READ",
+    "WRITE",
+    "SYNC",
+    "DISCONNECT",
+)
+REQUEST_SCHEMA = "stegverse.kv.storage-provider-operation-request/v1"
+
+
+class KVStorageProviderError(ValueError):
+    pass
+
+
+class KVStorageProviderAdapter(Protocol):
+    provider_id: str
+    display_name: str
+    provider_family: str
+
+    def supports(self, operation: str) -> bool: ...
+    def descriptor(self) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class DeclarativeStorageProviderAdapter:
+    provider_id: str
+    display_name: str
+    provider_family: str
+    operations: tuple[str, ...] = SUPPORTED_OPERATIONS
+
+    def supports(self, operation: str) -> bool:
+        return operation.upper() in self.operations
+
+    def descriptor(self) -> dict[str, Any]:
+        return {
+            "provider_id": self.provider_id,
+            "display_name": self.display_name,
+            "provider_family": self.provider_family,
+            "operations": list(self.operations),
+            "credential_material_location": "SKAP_ONLY",
+            "provider_session_required": True,
+            "provider_execution_implemented": False,
+            "authority_effect": "NONE",
+        }
+
+
+@dataclass
+class StorageProviderRegistry:
+    adapters: list[KVStorageProviderAdapter]
+
+    def __post_init__(self) -> None:
+        ids = [adapter.provider_id for adapter in self.adapters]
+        if len(ids) != len(set(ids)):
+            raise KVStorageProviderError("provider_id values must be unique")
+
+    def get(self, provider_id: str) -> KVStorageProviderAdapter:
+        matches = [adapter for adapter in self.adapters if adapter.provider_id == provider_id]
+        if len(matches) != 1:
+            raise KVStorageProviderError("provider adapter unavailable or ambiguous")
+        return matches[0]
+
+    def descriptors(self) -> list[dict[str, Any]]:
+        return [self.get(provider_id).descriptor() for provider_id in sorted(a.provider_id for a in self.adapters)]
+
+
+def build_operation_request(
+    *,
+    adapter: KVStorageProviderAdapter,
+    instance_id: str,
+    kv_set_id: str,
+    operation: str,
+    storage_locator: str | None = None,
+    requested_by: str = "owner",
+    object_ref: str | None = None,
+) -> dict[str, Any]:
+    op = operation.upper().strip()
+    if op not in SUPPORTED_OPERATIONS:
+        raise KVStorageProviderError("unsupported provider operation")
+    if not adapter.supports(op):
+        raise KVStorageProviderError("provider adapter does not support requested operation")
+    if not instance_id.startswith("kvi_"):
+        raise KVStorageProviderError("instance_id must use kvi_ identifier")
+    if not kv_set_id.strip():
+        raise KVStorageProviderError("kv_set_id is required")
+    if not requested_by.strip():
+        raise KVStorageProviderError("requested_by is required")
+
+    canonical = {
+        "provider_id": adapter.provider_id,
+        "instance_id": instance_id,
+        "kv_set_id": kv_set_id.strip(),
+        "operation": op,
+        "storage_locator": storage_locator,
+        "object_ref": object_ref,
+        "requested_by": requested_by.strip(),
+    }
+    digest = hashlib.sha256(json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return {
+        "schema": REQUEST_SCHEMA,
+        "request_id": f"kvprov_{digest[:24]}",
+        **canonical,
+        "governance_state": "PENDING_INTERLOCK_INTR",
+        "skap_credential_ref_required": True,
+        "credential_material_present": False,
+        "provider_session_established": False,
+        "provider_operation_executed": False,
+        "data_moved": False,
+        "replication_started": False,
+        "authority_effect": "NONE",
+        "activation_effect": False,
+    }
+
+
+def default_registry() -> StorageProviderRegistry:
+    return StorageProviderRegistry([
+        DeclarativeStorageProviderAdapter("icloud-drive", "iCloud Drive", "apple-cloud-storage"),
+        DeclarativeStorageProviderAdapter("google-drive", "Google Drive", "google-cloud-storage"),
+        DeclarativeStorageProviderAdapter("onedrive", "Microsoft OneDrive", "microsoft-cloud-storage"),
+        DeclarativeStorageProviderAdapter("dropbox", "Dropbox", "dropbox-cloud-storage"),
+    ])

--- a/schemas/kv-storage-provider-operation-request.schema.json
+++ b/schemas/kv-storage-provider-operation-request.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stegverse.kv.storage-provider-operation-request/v1",
+  "type": "object",
+  "required": ["schema","request_id","provider_id","instance_id","kv_set_id","operation","storage_locator","object_ref","requested_by","governance_state","skap_credential_ref_required","credential_material_present","provider_session_established","provider_operation_executed","data_moved","replication_started","authority_effect","activation_effect"],
+  "properties": {
+    "schema": {"const": "stegverse.kv.storage-provider-operation-request/v1"},
+    "request_id": {"type": "string", "pattern": "^kvprov_"},
+    "provider_id": {"enum": ["icloud-drive","google-drive","onedrive","dropbox"]},
+    "instance_id": {"type": "string", "pattern": "^kvi_"},
+    "kv_set_id": {"type": "string", "minLength": 1},
+    "operation": {"enum": ["CONNECT","VERIFY","READ","WRITE","SYNC","DISCONNECT"]},
+    "storage_locator": {"type": ["string","null"]},
+    "object_ref": {"type": ["string","null"]},
+    "requested_by": {"type": "string", "minLength": 1},
+    "governance_state": {"const": "PENDING_INTERLOCK_INTR"},
+    "skap_credential_ref_required": {"const": true},
+    "credential_material_present": {"const": false},
+    "provider_session_established": {"const": false},
+    "provider_operation_executed": {"const": false},
+    "data_moved": {"const": false},
+    "replication_started": {"const": false},
+    "authority_effect": {"const": "NONE"},
+    "activation_effect": {"const": false}
+  },
+  "additionalProperties": false
+}

--- a/tests/test_kv_storage_provider_adapter.py
+++ b/tests/test_kv_storage_provider_adapter.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from runtime.kv_storage_provider_adapter import (
+    KVStorageProviderError,
+    StorageProviderRegistry,
+    build_operation_request,
+    default_registry,
+)
+
+
+def test_default_registry_contains_expected_provider_adapters() -> None:
+    registry = default_registry()
+    ids = [item["provider_id"] for item in registry.descriptors()]
+    assert ids == ["dropbox", "google-drive", "icloud-drive", "onedrive"]
+    for descriptor in registry.descriptors():
+        assert descriptor["credential_material_location"] == "SKAP_ONLY"
+        assert descriptor["provider_session_required"] is True
+        assert descriptor["provider_execution_implemented"] is False
+        assert descriptor["authority_effect"] == "NONE"
+
+
+def test_operation_request_is_non_authorizing_and_deterministic() -> None:
+    adapter = default_registry().get("icloud-drive")
+    one = build_operation_request(
+        adapter=adapter,
+        instance_id="kvi_two",
+        kv_set_id="personal",
+        operation="CONNECT",
+        storage_locator="icloud-slot-2",
+    )
+    two = build_operation_request(
+        adapter=adapter,
+        instance_id="kvi_two",
+        kv_set_id="personal",
+        operation="CONNECT",
+        storage_locator="icloud-slot-2",
+    )
+    assert one == two
+    assert one["request_id"].startswith("kvprov_")
+    assert one["governance_state"] == "PENDING_INTERLOCK_INTR"
+    assert one["skap_credential_ref_required"] is True
+    assert one["credential_material_present"] is False
+    assert one["provider_session_established"] is False
+    assert one["provider_operation_executed"] is False
+    assert one["data_moved"] is False
+    assert one["authority_effect"] == "NONE"
+    assert one["activation_effect"] is False
+
+
+def test_all_declared_operations_are_representable() -> None:
+    registry = default_registry()
+    for provider_id in ["icloud-drive", "google-drive", "onedrive", "dropbox"]:
+        adapter = registry.get(provider_id)
+        for operation in ["CONNECT", "VERIFY", "READ", "WRITE", "SYNC", "DISCONNECT"]:
+            request = build_operation_request(
+                adapter=adapter,
+                instance_id="kvi_one",
+                kv_set_id="personal",
+                operation=operation,
+            )
+            assert request["provider_id"] == provider_id
+            assert request["operation"] == operation
+            assert request["provider_operation_executed"] is False
+
+
+def test_unknown_provider_and_bad_instance_fail_closed() -> None:
+    registry = default_registry()
+    with pytest.raises(KVStorageProviderError):
+        registry.get("unknown")
+    with pytest.raises(KVStorageProviderError):
+        build_operation_request(
+            adapter=registry.get("icloud-drive"),
+            instance_id="bad",
+            kv_set_id="personal",
+            operation="CONNECT",
+        )
+
+
+def test_duplicate_provider_ids_are_rejected() -> None:
+    adapter = default_registry().get("icloud-drive")
+    with pytest.raises(KVStorageProviderError):
+        StorageProviderRegistry([adapter, adapter])


### PR DESCRIPTION
Canonical StegVerse task binding:
- GOAL TASK ID: `KV-CONNECTION-REVALIDATION-WORKER-001`
- COSV ID: `50000000102000`
- canonical COSV handoff: `StegVerse-Labs/.github/KV_CONNECTION_REVALIDATION_COSV_MIRROR_HANDOFF.md`
- capability handoff: `KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md`

Continues the existing KV multi-instance workstream after merged PRs #196-#198; no new task is created.

Changes:
- add provider-neutral KV storage adapter protocol and registry;
- add declarative adapters for iCloud Drive, Google Drive, Microsoft OneDrive, and Dropbox;
- represent CONNECT/VERIFY/READ/WRITE/SYNC/DISCONNECT as deterministic governed operation intents;
- require later SKAP credential references without storing raw credentials;
- fix provider session, provider execution, data movement, replication, authority, and activation false in source requests;
- add schema, tests, README documentation, and handoff reconciliation.

Runtime boundary: these adapters define operation intent and provider discovery/selection only. They do not authenticate, establish provider sessions, access remote storage, move data, synchronize KVs, or grant Interlock/InTr authority.