### PR TITLE
Adopt existing KnowledgeVault as bounded KV #1

### DIFF
--- a/.github/workflows/kv-existing-instance-adoption.yml
+++ b/.github/workflows/kv-existing-instance-adoption.yml
@@ -1,0 +1,67 @@
+name: KV Existing Instance Adoption
+
+on:
+  pull_request:
+    paths:
+      - "tools/adopt_existing_kv_instance.py"
+      - "tools/test_adopt_existing_kv_instance.py"
+      - "runtime/kv_my_kv_projection.py"
+      - "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md"
+      - "data/session-work-claims.d/cvk-kv1-adoption-projection-20260908.json"
+      - ".github/workflows/kv-existing-instance-adoption.yml"
+  push:
+    paths:
+      - "tools/adopt_existing_kv_instance.py"
+      - "tools/test_adopt_existing_kv_instance.py"
+      - "runtime/kv_my_kv_projection.py"
+      - "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md"
+      - "data/session-work-claims.d/cvk-kv1-adoption-projection-20260908.json"
+      - ".github/workflows/kv-existing-instance-adoption.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate existing-KV adoption contract
+        run: python3 tools/test_adopt_existing_kv_instance.py
+      - name: Validate direct CLI import path
+        run: python3 tools/adopt_existing_kv_instance.py --help >/dev/null
+      - name: Prove fail-closed migration boundary
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          src=Path('tools/adopt_existing_kv_instance.py').read_text(encoding='utf-8')
+          required=[
+            'installation receipt SHA-256 mismatch; refusing adoption',
+            'would be overwritten',
+            'private_content_modified": False',
+            'installation_receipt_modified": False',
+            'provider_operation_executed": False',
+            'relationship_tier": "NOT_CONNECTED"',
+            'credential_material_present": False',
+            'provider_mutation_authorized": False',
+            'relationship_mutation_authorized": False',
+            'NONE_STATUS_ONLY',
+            '_System/my-kv-set-projection.json',
+          ]
+          missing=[x for x in required if x not in src]
+          if missing:
+            raise SystemExit('missing fail-closed adoption markers: '+', '.join(missing))
+          forbidden=['provider_operation_executed": True','provider_mutation_authorized": True','relationship_mutation_authorized": True','private_content_modified": True','installation_receipt_modified": True']
+          present=[x for x in forbidden if x in src]
+          if present:
+            raise SystemExit('prohibited adoption authority markers: '+', '.join(present))
+          print('KV_EXISTING_INSTANCE_ADOPTION=PASS')
+          print('KV1_INSTALLATION_RECEIPT_HASH_BINDING=REQUIRED')
+          print('KV1_PRIVATE_CONTENT_MUTATION=NONE')
+          print('KV1_PROVIDER_EXECUTION_AUTHORITY=NONE')
+          print('KV1_SET_PROJECTION=BOUNDED_STATUS_ONLY')
+          PY

--- a/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
+++ b/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
@@ -1,9 +1,10 @@
 # KV Multi-Instance COSV Binding Mirror Handoff
 
-Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MERGED / MYKV_PROJECTION_MERGED / STORAGE_PROVIDER_ADAPTERS_MERGED / PROVIDER_OPERATION_STATE_MERGED / MYKV_PROVIDER_STATUS_MERGED / SITE_CONSUMER_BINDING_NEXT / CANONICAL_COSV_BOUND / RUNTIME_ACTIVATION_PENDING
+Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MERGED / MYKV_PROJECTION_MERGED / STORAGE_PROVIDER_ADAPTERS_MERGED / PROVIDER_OPERATION_STATE_MERGED / MYKV_PROVIDER_STATUS_MERGED / SITE_DEVICE_KV_TRANSPORT_MERGED / SITE_PREPUBLICATION_UI_MERGED / EXISTING_KV1_ADOPTION_SOURCE_IMPLEMENTED / PHYSICAL_KV1_ADOPTION_PENDING / PROVIDER_ACTIVATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
 Merged source PRs: `#196`, `#197`, `#198`, `#199`, `#200`, `#201`
 Merged commits: `2a2a5273a684fedfaf10f6c4ea93d195d9d9ae6f`, `ea4da1e58e74c7f2690d26e82cb9c6a6e30aca03`, `4ee4232aec19f2bbc469bf712403185ab799ab0d`, `18067f09d16f8573797b837f5997297bc278e952`, `009bcc2d77f65b70c9aaa890b586addf3fc4dc2e`, `36bdcd26e64b081857fd3028da225060b15818e6`
+Site continuation merged: PR `#1109` at `1c5396d186b2a8674f265733d91c542d472d20fd`; prepublication UI PR `#1110` at `5977b53c8ac43099b4d2cecf27cdc4c78e4c4882`
 Updated: 2026-09-08
 Authority effect: NONE
 Activation effect: false
@@ -36,6 +37,39 @@ PR #200: durable provider-operation state under `_System/Instances/Providers/`; 
 
 PR #201: bounded MyKV projection now includes provider connection/verification status, last provider operation/result references, and pending provider request identifiers/operations. It explicitly excludes raw credentials, SKAP credential references, Interlock/InTr receipt references, provider tokens/session secrets, and private KV content. Provider and relationship mutation authority remain false.
 
+Site PR #1109 binds the bounded set/provider/relationship surfaces through a registered-Node generated-InTr/HB-derived-carrier DEVICE_KV client and a dedicated fail-closed resident receiver. The receiver can return a set projection only from an already-admitted `_System/my-kv-set-projection.json` and keeps provider/relationship requests pending with zero runtime effects.
+
+Site PR #1110 adds an intentionally unlinked prepublication MyKV #1/#2/#n UI candidate over that merged transport. It does not infer missing KV #2/provider state and does not activate ordinary public MyKV navigation.
+
+## Existing Google Drive KV #1 observation
+
+Connected Drive observation on 2026-09-08 found the existing `KnowledgeVault` root and `_System/installation.receipt.json`, but no `_System/Instances` folder. Therefore the current physical KV predates the multi-instance identity layout. It must be adopted as KV #1 before an authentic multi-instance projection can exist; no identity or provider state may be invented from Site.
+
+## Existing-KV adoption source — current branch
+
+`tools/adopt_existing_kv_instance.py` provides a non-destructive migration/materialization path for an existing KnowledgeVault.
+
+Plan mode:
+
+- requires an existing vault root and schema-1.1 installation receipt;
+- computes the exact receipt SHA-256;
+- reports only the three generated paths;
+- performs no mutation.
+
+Apply mode additionally requires the caller-supplied expected installation-receipt SHA-256 to match exactly. It refuses to overwrite any existing:
+
+```text
+_System/Instances/instance.json
+_System/Instances/adoption.receipt.json
+_System/my-kv-set-projection.json
+```
+
+On exact match it creates canonical `stegverse.kv.instance/v1` identity metadata for the chosen instance number/set/storage medium, defaults relationship to `NOT_CONNECTED`, then calls the merged `runtime.kv_my_kv_projection.build_set_projection()` implementation and emits `stegverse.kv.my-kv-set-projection/v1`.
+
+The adoption receipt records that private content and the original installation receipt were not modified, provider execution did not occur, credentials are absent, and provider/relationship mutation authority remain false. Any projection-generation failure removes the generated adoption artifacts rather than leaving a partial identity/projection state.
+
+Validation is in `tools/test_adopt_existing_kv_instance.py` and `.github/workflows/kv-existing-instance-adoption.yml`.
+
 ## Canonical relationship tiers
 
 ```text
@@ -64,18 +98,21 @@ AI_INTERACTION
   unified AI corpus: true
 ```
 
-`AI_INTERACTION` means the admitted participating KVs are treated as one logical corpus for an authorized AI interaction. It does not physically merge roots, erase provenance, collapse contradictions, or make AI canonical authority.
+`AI_INTERACTION` means admitted participating KVs are treated as one logical corpus for an authorized AI interaction. It does not physically merge roots, erase provenance, collapse contradictions, or make AI canonical authority.
 
 ## Next machine-executable work
 
-1. Bind the Site/MyKV consumer to the merged bounded instance/provider projection.
-2. Add Site request surfaces that emit governed provider-operation and relationship-transition requests rather than invoking provider authority directly.
-3. Extend the device-local DEVICE_KV query/return path to transport the bounded KV-set projection without exposing private content or credentials.
-4. Preserve all existing direct-source and connection-health security boundaries; do not weaken those contracts to fit multi-provider operations.
-5. After source validation, exercise a real KV #2 installation and provider path through admitted owner/runtime flow.
+1. Validate and merge the existing-KV adoption source.
+2. Correct Site provider rendering to consume the canonical plural `instance.providers.items` / `pending_requests` projection emitted by PR #201 rather than a singular placeholder provider shape.
+3. Perform owner-controlled adoption of the existing Google Drive KnowledgeVault as KV #1, exact-bound to its current installation receipt.
+4. Admit the emitted `_System/my-kv-set-projection.json` through the bounded DEVICE_KV path and verify exact Site readback.
+5. Integrate the validated MyKV #n candidate into public MyKV navigation/README without changing authority semantics.
+6. Only then create/authenticate a real KV #2 provider path.
 
 ## Runtime activation still required for full capability
 
+- physical adoption of the existing Google Drive vault as KV #1;
+- exact DEVICE_KV admission/readback of the resulting bounded set projection;
 - materialize a real KV #2 without altering KV #1;
 - resolve provider credentials through SKAP without copying credential material into ordinary KV or Site state;
 - execute provider `CONNECT`, `VERIFY`, `READ`, `WRITE`, `SYNC`, and `DISCONNECT` through authentic Interlock/InTr admission and provider-result evidence;
@@ -85,4 +122,4 @@ AI_INTERACTION
 
 ## Manual work
 
-No manual work is required for the current Site/source integration slice. A later owner-controlled provider authorization/install action is expected for real iCloud-backed KV #2 and live provider proof.
+No user action yet. Do not manually create `_System/Instances`, do not manually author `_System/my-kv-set-projection.json`, and do not authorize KV #2 yet. After this source branch merges and the Site plural-provider consumer is corrected, the next manual action will be the exact owner-controlled KV #1 adoption procedure bound to the observed Google Drive installation receipt; that procedure must identify the exact files to create and preserve the existing installation receipt/private content unchanged.

--- a/data/session-work-claims.d/cvk-kv1-adoption-projection-20260908.json
+++ b/data/session-work-claims.d/cvk-kv1-adoption-projection-20260908.json
@@ -23,11 +23,12 @@
       "claimed_paths": [
         "tools/adopt_existing_kv_instance.py",
         "tools/test_adopt_existing_kv_instance.py",
+        ".github/workflows/kv-existing-instance-adoption.yml",
         "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md",
         "data/session-work-claims.d/cvk-kv1-adoption-projection-20260908.json"
       ],
       "handoff": "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md",
-      "handoff_revision": "KV1_ADOPTION_PROJECTION_SOURCE_PENDING_20260908",
+      "handoff_revision": "EXISTING_KV1_ADOPTION_SOURCE_IMPLEMENTED_20260908",
       "claim_created_at": "2026-09-08T17:43:00-05:00",
       "claim_expires_when": "Release after source validation and merge. Physical Google Drive KV #1 adoption remains owner-controlled and must bind the exact existing installation receipt before writing identity/projection files.",
       "expected_evidence": [
@@ -39,7 +40,8 @@
         "KV #1 instance identity uses canonical stegverse.kv.instance/v1 shape",
         "bounded stegverse.kv.my-kv-set-projection/v1 emitted",
         "private content and credential material excluded",
-        "provider and relationship mutation authority remain false"
+        "provider and relationship mutation authority remain false",
+        "KV Existing Instance Adoption workflow PASS"
       ],
       "collision_boundaries": [
         "Do not modify CVK-LEGACY-KV-UPGRADE-174 physical-vault lane",

--- a/data/session-work-claims.d/cvk-kv1-adoption-projection-20260908.json
+++ b/data/session-work-claims.d/cvk-kv1-adoption-projection-20260908.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "1.0.0",
+  "registry_fragment_type": "stegverse_session_work_claim_registry_fragment",
+  "repository": "StegVerse-Labs/continuity-vault-kit",
+  "claims": [
+    {
+      "claim_id": "CVK-KV1-ADOPTION-PROJECTION-20260908",
+      "session_worker_id": "chatgpt:cvk-kv1-adoption-projection-20260908",
+      "task_id": "KV-CONNECTION-REVALIDATION-WORKER-001",
+      "originating_goal": "Non-destructively adopt an existing pre-multi-instance KnowledgeVault as canonical KV #1 by binding a new instance identity to its existing installation receipt, then emit the bounded MyKV set projection without modifying private content or provider authority.",
+      "repository": "StegVerse-Labs/continuity-vault-kit",
+      "branch": "kv-n-adopt-existing-kv1-projection",
+      "role": "SOURCE_IMPLEMENTATION",
+      "state": "CLAIMED_FOR_IMPLEMENTATION",
+      "normalized_work_key": "cvk-kv1-adoption-projection",
+      "dependency_surface_keys": [
+        "kv:multi-instance-identity",
+        "kv:installation-receipt",
+        "kv:my-kv-set-projection",
+        "site:my-kv-device-kv-projection-admission"
+      ],
+      "governing_dependency_keys": ["kv:multi-instance-identity", "kv:installation-receipt"],
+      "claimed_paths": [
+        "tools/adopt_existing_kv_instance.py",
+        "tools/test_adopt_existing_kv_instance.py",
+        "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md",
+        "data/session-work-claims.d/cvk-kv1-adoption-projection-20260908.json"
+      ],
+      "handoff": "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md",
+      "handoff_revision": "KV1_ADOPTION_PROJECTION_SOURCE_PENDING_20260908",
+      "claim_created_at": "2026-09-08T17:43:00-05:00",
+      "claim_expires_when": "Release after source validation and merge. Physical Google Drive KV #1 adoption remains owner-controlled and must bind the exact existing installation receipt before writing identity/projection files.",
+      "expected_evidence": [
+        "existing vault required",
+        "existing installation receipt required",
+        "exact installation receipt SHA-256 binding required for apply",
+        "existing instance identity never overwritten",
+        "existing projection never silently overwritten",
+        "KV #1 instance identity uses canonical stegverse.kv.instance/v1 shape",
+        "bounded stegverse.kv.my-kv-set-projection/v1 emitted",
+        "private content and credential material excluded",
+        "provider and relationship mutation authority remain false"
+      ],
+      "collision_boundaries": [
+        "Do not modify CVK-LEGACY-KV-UPGRADE-174 physical-vault lane",
+        "Do not alter the existing installation receipt",
+        "Do not rewrite private KV content",
+        "Do not create KV #2",
+        "Do not authenticate or execute any provider operation",
+        "Do not materialize relationship tiers beyond NOT_CONNECTED",
+        "No NON-TV/TVC secret/token",
+        "No GitHub-token runtime authority"
+      ],
+      "next_task_after_release": "Run owner-controlled KV #1 adoption against the existing Google Drive KnowledgeVault, admit the emitted bounded projection into DEVICE_KV, verify Site readback, then proceed to real KV #2 provider authorization.",
+      "credential_authority": "TV/TVC",
+      "credential_requirement": "NONE_FOR_SOURCE_IMPLEMENTATION",
+      "github_token_runtime_authority": "NONE",
+      "non_tv_tvc_secret_or_token_used": false,
+      "authority_effect": false,
+      "activation_effect": false,
+      "archive_eligible": false
+    }
+  ]
+}

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -4,6 +4,7 @@ import unittest
 
 ROOT=Path(__file__).resolve().parents[1]
 WORKFLOW_ROOT=ROOT/".github/workflows"
+EXPECTED_WORKFLOW_COUNT=51
 
 class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
     def test_all_workflows_declare_permissions_and_no_authority_markers(self):
@@ -16,7 +17,7 @@ class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
             "helm upgrade","repository_dispatch",
         )
         workflows=sorted(WORKFLOW_ROOT.glob("*.yml"))
-        self.assertEqual(len(workflows),50)
+        self.assertEqual(len(workflows),EXPECTED_WORKFLOW_COUNT)
         for path in workflows:
             text=path.read_text(encoding="utf-8")
             self.assertIn("permissions:",text,path.name)

--- a/tools/adopt_existing_kv_instance.py
+++ b/tools/adopt_existing_kv_instance.py
@@ -13,10 +13,15 @@ import argparse
 import hashlib
 import json
 import os
+import sys
 import tempfile
 import time
 import uuid
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from runtime.kv_my_kv_projection import build_set_projection
 

--- a/tools/adopt_existing_kv_instance.py
+++ b/tools/adopt_existing_kv_instance.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Non-destructively adopt an existing KnowledgeVault into the multi-instance model.
+
+This tool is intentionally narrow. It never creates a new vault, rewrites private
+content, changes the existing installation receipt, authenticates a provider, or
+materializes relationship/provider authority. Apply mode is bound to the caller's
+expected SHA-256 of the existing installation receipt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+from runtime.kv_my_kv_projection import build_set_projection
+
+INSTANCE_SCHEMA = "stegverse.kv.instance/v1"
+INSTANCE_RECORD = Path("_System/Instances/instance.json")
+INSTALLATION_RECEIPT = Path("_System/installation.receipt.json")
+SET_PROJECTION_RECORD = Path("_System/my-kv-set-projection.json")
+ADOPTION_RECEIPT = Path("_System/Instances/adoption.receipt.json")
+ADOPTION_RECEIPT_SCHEMA = "stegverse.kv.existing-instance-adoption-receipt/v1"
+
+
+class AdoptionError(ValueError):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise AdoptionError(f"unreadable JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise AdoptionError(f"expected JSON object: {path}")
+    return value
+
+
+def atomic_write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+
+
+def validate_existing_vault(root: Path) -> tuple[Path, str, dict]:
+    if not root.is_dir():
+        raise AdoptionError(f"KnowledgeVault root not found: {root}")
+    receipt_path = root / INSTALLATION_RECEIPT
+    if not receipt_path.is_file():
+        raise AdoptionError("existing installation receipt missing")
+    receipt = read_json(receipt_path)
+    if str(receipt.get("schema_version") or "") != "1.1":
+        raise AdoptionError("existing installation receipt schema must be 1.1")
+    if not isinstance(receipt.get("source"), str) or "KnowledgeVault" not in receipt["source"]:
+        raise AdoptionError("installation receipt source is not a KnowledgeVault source")
+    return receipt_path, sha256_file(receipt_path), receipt
+
+
+def build_instance_record(*, instance_number: int, set_id: str, storage_medium: str, storage_locator: str | None, created_utc: str) -> dict:
+    if instance_number < 1:
+        raise AdoptionError("instance number must be >= 1")
+    if not set_id.strip():
+        raise AdoptionError("set id cannot be empty")
+    if not storage_medium.strip():
+        raise AdoptionError("storage medium cannot be empty")
+    return {
+        "schema": INSTANCE_SCHEMA,
+        "instance_id": f"kvi_{uuid.uuid4().hex}",
+        "instance_number": instance_number,
+        "logical_name": f"KV #{instance_number}",
+        "kv_set_id": set_id.strip(),
+        "relationship": {
+            "set_membership": "PEER",
+            "tier": "NOT_CONNECTED",
+            "tier_order": 0,
+            "inter_comms": False,
+            "data_movement": False,
+            "replication": False,
+            "unified_ai_corpus": False,
+            "ordinal_is_authority": False,
+            "inherits_authority_from_kv_1": False,
+            "authority_effect": "NONE",
+            "activation_effect": False,
+            "notes": "Existing vault adopted into the multi-instance identity model. Relationship changes require separate governed admission.",
+        },
+        "storage": {
+            "medium": storage_medium.strip(),
+            "locator": storage_locator,
+            "provider_authority_effect": "NONE",
+        },
+        "created_utc": created_utc,
+        "adoption": {
+            "existing_vault": True,
+            "private_content_modified": False,
+            "installation_receipt_modified": False,
+            "provider_operation_executed": False,
+            "authority_effect": "NONE",
+            "activation_effect": False,
+        },
+    }
+
+
+def plan(root: Path, *, instance_number: int, set_id: str, storage_medium: str, storage_locator: str | None) -> dict:
+    root = root.expanduser().resolve()
+    receipt_path, receipt_sha256, _ = validate_existing_vault(root)
+    instance_path = root / INSTANCE_RECORD
+    projection_path = root / SET_PROJECTION_RECORD
+    adoption_receipt_path = root / ADOPTION_RECEIPT
+    return {
+        "schema": "stegverse.kv.existing-instance-adoption-plan/v1",
+        "vault_root": str(root),
+        "installation_receipt": str(receipt_path),
+        "installation_receipt_sha256": f"sha256:{receipt_sha256}",
+        "instance_number": instance_number,
+        "logical_name": f"KV #{instance_number}",
+        "kv_set_id": set_id.strip(),
+        "storage": {"medium": storage_medium.strip(), "locator": storage_locator},
+        "writes": [str(INSTANCE_RECORD), str(ADOPTION_RECEIPT), str(SET_PROJECTION_RECORD)],
+        "instance_record_exists": instance_path.exists(),
+        "adoption_receipt_exists": adoption_receipt_path.exists(),
+        "set_projection_exists": projection_path.exists(),
+        "private_content_modified": False,
+        "installation_receipt_modified": False,
+        "provider_operation_executed": False,
+        "relationship_tier_materialized": "NOT_CONNECTED",
+        "authority_effect": "NONE_PLAN_ONLY",
+        "activation_effect": False,
+    }
+
+
+def apply_adoption(root: Path, *, instance_number: int, set_id: str, storage_medium: str, storage_locator: str | None, expected_receipt_sha256: str) -> dict:
+    root = root.expanduser().resolve()
+    receipt_path, actual_sha256, _ = validate_existing_vault(root)
+    expected = expected_receipt_sha256.removeprefix("sha256:").lower()
+    if expected != actual_sha256:
+        raise AdoptionError("installation receipt SHA-256 mismatch; refusing adoption")
+
+    instance_path = root / INSTANCE_RECORD
+    adoption_receipt_path = root / ADOPTION_RECEIPT
+    projection_path = root / SET_PROJECTION_RECORD
+    for path, label in ((instance_path, "instance identity"), (adoption_receipt_path, "adoption receipt"), (projection_path, "set projection")):
+        if path.exists():
+            raise AdoptionError(f"existing {label} would be overwritten: {path}")
+
+    created_utc = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    instance = build_instance_record(
+        instance_number=instance_number,
+        set_id=set_id,
+        storage_medium=storage_medium,
+        storage_locator=storage_locator,
+        created_utc=created_utc,
+    )
+    atomic_write_json(instance_path, instance)
+    try:
+        projection = build_set_projection([root])
+        if projection.get("private_content_included") is not False or projection.get("credential_material_included") is not False:
+            raise AdoptionError("bounded projection violated content boundary")
+        if projection.get("authority_effect") != "NONE_STATUS_ONLY" or projection.get("activation_effect") is not False:
+            raise AdoptionError("bounded projection violated authority boundary")
+        atomic_write_json(projection_path, projection)
+        adoption_receipt = {
+            "schema": ADOPTION_RECEIPT_SCHEMA,
+            "state": "EXISTING_KV_ADOPTED_AS_INSTANCE",
+            "created_utc": created_utc,
+            "vault_root": str(root),
+            "installation_receipt_path": str(INSTALLATION_RECEIPT),
+            "installation_receipt_sha256": f"sha256:{actual_sha256}",
+            "instance_record_path": str(INSTANCE_RECORD),
+            "instance_id": instance["instance_id"],
+            "instance_number": instance_number,
+            "kv_set_id": set_id.strip(),
+            "set_projection_path": str(SET_PROJECTION_RECORD),
+            "set_projection_schema": projection["schema"],
+            "private_content_modified": False,
+            "installation_receipt_modified": False,
+            "provider_operation_executed": False,
+            "relationship_tier": "NOT_CONNECTED",
+            "credential_material_present": False,
+            "provider_mutation_authorized": False,
+            "relationship_mutation_authorized": False,
+            "authority_effect": "NONE",
+            "activation_effect": False,
+        }
+        atomic_write_json(adoption_receipt_path, adoption_receipt)
+    except Exception:
+        for generated in (adoption_receipt_path, projection_path, instance_path):
+            try:
+                generated.unlink()
+            except FileNotFoundError:
+                pass
+        raise
+    return adoption_receipt
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Adopt an existing KnowledgeVault as a bounded multi-instance KV without overwriting existing state.")
+    parser.add_argument("vault_root", type=Path)
+    parser.add_argument("--instance", type=int, default=1)
+    parser.add_argument("--set-id", required=True)
+    parser.add_argument("--storage-medium", required=True)
+    parser.add_argument("--storage-locator")
+    parser.add_argument("--apply", action="store_true", help="Create identity/adoption receipt/set projection after exact receipt-hash validation.")
+    parser.add_argument("--expected-installation-receipt-sha256", help="Required with --apply. Accepts raw hex or sha256:<hex>.")
+    args = parser.parse_args()
+    if args.instance < 1:
+        parser.error("--instance must be >= 1")
+    if args.apply and not args.expected_installation_receipt_sha256:
+        parser.error("--expected-installation-receipt-sha256 is required with --apply")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if not args.apply:
+            value = plan(args.vault_root, instance_number=args.instance, set_id=args.set_id, storage_medium=args.storage_medium, storage_locator=args.storage_locator)
+            print(json.dumps(value, indent=2, sort_keys=True))
+            return 0
+        value = apply_adoption(
+            args.vault_root,
+            instance_number=args.instance,
+            set_id=args.set_id,
+            storage_medium=args.storage_medium,
+            storage_locator=args.storage_locator,
+            expected_receipt_sha256=args.expected_installation_receipt_sha256,
+        )
+        print(json.dumps(value, indent=2, sort_keys=True))
+        return 0
+    except AdoptionError as exc:
+        print(f"ADOPTION_REFUSED: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_adopt_existing_kv_instance.py
+++ b/tools/test_adopt_existing_kv_instance.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from tools.adopt_existing_kv_instance import (
     ADOPTION_RECEIPT,

--- a/tools/test_adopt_existing_kv_instance.py
+++ b/tools/test_adopt_existing_kv_instance.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.adopt_existing_kv_instance import (
+    ADOPTION_RECEIPT,
+    INSTANCE_RECORD,
+    SET_PROJECTION_RECORD,
+    AdoptionError,
+    apply_adoption,
+    plan,
+)
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def receipt(root: Path) -> tuple[Path, str]:
+    path = root / "_System" / "installation.receipt.json"
+    write_json(path, {
+        "schema_version": "1.1",
+        "source": "continuity-vault-kit:vault_template/KnowledgeVault",
+        "destination": str(root),
+        "verification": {"full_template_parity": "VALIDATED"},
+    })
+    return path, hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class AdoptionTests(unittest.TestCase):
+    def test_plan_is_no_mutation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "KnowledgeVault"
+            root.mkdir()
+            _, digest = receipt(root)
+            private = root / "private.txt"
+            private.write_text("owner data", encoding="utf-8")
+            before = private.read_bytes()
+            value = plan(root, instance_number=1, set_id="personal", storage_medium="google-drive", storage_locator="drive-folder:test")
+            self.assertEqual(value["installation_receipt_sha256"], "sha256:" + digest)
+            self.assertFalse(value["instance_record_exists"])
+            self.assertEqual(private.read_bytes(), before)
+            self.assertFalse((root / INSTANCE_RECORD).exists())
+
+    def test_apply_requires_exact_receipt_hash_and_preserves_private_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "KnowledgeVault"
+            root.mkdir()
+            _, digest = receipt(root)
+            private = root / "owner-private.json"
+            private.write_text('{"secret_to_owner":"unchanged"}\n', encoding="utf-8")
+            before = private.read_bytes()
+            with self.assertRaises(AdoptionError):
+                apply_adoption(root, instance_number=1, set_id="personal", storage_medium="google-drive", storage_locator=None, expected_receipt_sha256="00" * 32)
+            self.assertFalse((root / INSTANCE_RECORD).exists())
+            result = apply_adoption(root, instance_number=1, set_id="personal", storage_medium="google-drive", storage_locator="drive-folder:test", expected_receipt_sha256=digest)
+            self.assertEqual(result["state"], "EXISTING_KV_ADOPTED_AS_INSTANCE")
+            self.assertEqual(result["instance_number"], 1)
+            self.assertEqual(result["relationship_tier"], "NOT_CONNECTED")
+            self.assertFalse(result["provider_operation_executed"])
+            self.assertEqual(private.read_bytes(), before)
+            projection = json.loads((root / SET_PROJECTION_RECORD).read_text(encoding="utf-8"))
+            self.assertEqual(projection["schema"], "stegverse.kv.my-kv-set-projection/v1")
+            self.assertEqual(projection["instance_count"], 1)
+            self.assertFalse(projection["private_content_included"])
+            self.assertFalse(projection["credential_material_included"])
+            self.assertEqual(projection["authority_effect"], "NONE_STATUS_ONLY")
+            self.assertFalse(projection["activation_effect"])
+
+    def test_apply_refuses_overwrite(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "KnowledgeVault"
+            root.mkdir()
+            _, digest = receipt(root)
+            (root / INSTANCE_RECORD).parent.mkdir(parents=True)
+            (root / INSTANCE_RECORD).write_text('{"existing":true}\n', encoding="utf-8")
+            with self.assertRaisesRegex(AdoptionError, "would be overwritten"):
+                apply_adoption(root, instance_number=1, set_id="personal", storage_medium="google-drive", storage_locator=None, expected_receipt_sha256=digest)
+            self.assertFalse((root / SET_PROJECTION_RECORD).exists())
+            self.assertFalse((root / ADOPTION_RECEIPT).exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Continues `KV-CONNECTION-REVALIDATION-WORKER-001` / COSV `50000000102000` after merged multi-instance source PRs #196-#201 and Site PRs #1109/#1110.

The connected Google Drive KnowledgeVault has a canonical `_System/installation.receipt.json` but no `_System/Instances` layout, so it predates the multi-instance identity contract.

This PR adds a non-destructive existing-vault adoption tool:
- requires an existing schema-1.1 installation receipt;
- plan mode performs no mutation and reports the exact receipt SHA-256;
- apply mode requires that expected receipt SHA-256 to match exactly;
- refuses to overwrite existing instance/adoption/projection records;
- creates canonical `stegverse.kv.instance/v1` metadata only for the selected existing vault;
- defaults relationship to `NOT_CONNECTED`;
- emits `_System/my-kv-set-projection.json` through the already-merged `build_set_projection()` implementation;
- preserves private content and the original installation receipt unchanged;
- grants no provider, relationship, credential, execution, or activation authority;
- rolls back generated adoption artifacts if projection generation fails.

Adds deterministic tests and a dedicated read-only validation workflow. This PR does not touch the physical Google Drive vault, create KV #2, or authorize any provider. Physical KV #1 adoption remains a later owner-controlled runtime action bound to the exact observed receipt.