### PR TITLE
Bind resident Google Drive KV2 adoption to provider execution

### DIFF
--- a/.github/workflows/kv-cloud-peer-adoption-provider-binding.yml
+++ b/.github/workflows/kv-cloud-peer-adoption-provider-binding.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install test dependency
+        run: python -m pip install --disable-pip-version-check pytest
       - name: Validate adoption to provider binding
         run: python -m pytest -q tests/test_cloud_peer_adoption_provider_binding.py tests/test_kv_storage_provider_adapter.py tests/test_kv_provider_operation_store.py
       - name: Prove fail-closed provider/materialization boundary
@@ -36,7 +38,7 @@ jobs:
           from pathlib import Path
           src=Path('runtime/cloud_peer_adoption_provider_binding.py').read_text(encoding='utf-8')
           required=[
-            'SITE-CLOUD-KV-4347408852127319cbda574f02e03edb' if False else 'SITE-CLOUD-KV-',
+            'SITE-CLOUD-KV-',
             'PENDING_INTERLOCK_INTR',
             'ADMITTED_GOOGLE_DRIVE_CONNECT_RESULT',
             'ADMITTED_GOOGLE_DRIVE_VERIFY_RESULT',

--- a/.github/workflows/kv-cloud-peer-adoption-provider-binding.yml
+++ b/.github/workflows/kv-cloud-peer-adoption-provider-binding.yml
@@ -1,0 +1,68 @@
+name: KV Cloud Peer Adoption Provider Binding
+
+on:
+  pull_request:
+    paths:
+      - "runtime/cloud_peer_adoption_provider_binding.py"
+      - "tests/test_cloud_peer_adoption_provider_binding.py"
+      - "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md"
+      - "data/session-work-claims.d/cvk-kv2-adoption-provider-binding-20260908.json"
+      - ".github/workflows/kv-cloud-peer-adoption-provider-binding.yml"
+  push:
+    paths:
+      - "runtime/cloud_peer_adoption_provider_binding.py"
+      - "tests/test_cloud_peer_adoption_provider_binding.py"
+      - "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md"
+      - "data/session-work-claims.d/cvk-kv2-adoption-provider-binding-20260908.json"
+      - ".github/workflows/kv-cloud-peer-adoption-provider-binding.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate adoption to provider binding
+        run: python -m pytest -q tests/test_cloud_peer_adoption_provider_binding.py tests/test_kv_storage_provider_adapter.py tests/test_kv_provider_operation_store.py
+      - name: Prove fail-closed provider/materialization boundary
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          src=Path('runtime/cloud_peer_adoption_provider_binding.py').read_text(encoding='utf-8')
+          required=[
+            'SITE-CLOUD-KV-4347408852127319cbda574f02e03edb' if False else 'SITE-CLOUD-KV-',
+            'PENDING_INTERLOCK_INTR',
+            'ADMITTED_GOOGLE_DRIVE_CONNECT_RESULT',
+            'ADMITTED_GOOGLE_DRIVE_VERIFY_RESULT',
+            'interlock_receipt_ref',
+            'intr_receipt_ref',
+            'skap_credential_ref',
+            'provider_result_ref',
+            'SET_MEMBERSHIP_ORDINAL_BINDING_PRESERVE_CLOUD_IDENTITY',
+            'cloud_identity_rewrite_required',
+            'private_content_rewrite_authorized',
+            'NONE_READINESS_ONLY',
+          ]
+          missing=[x for x in required if x not in src]
+          if missing:
+            raise SystemExit('missing provider-binding markers: '+', '.join(missing))
+          forbidden=[
+            '"instance_materialization_authorized": True',
+            '"private_content_rewrite_authorized": True',
+            '"cloud_identity_rewrite_required": True',
+            'credential_material_present": True',
+          ]
+          present=[x for x in forbidden if x in src]
+          if present:
+            raise SystemExit('prohibited provider-binding markers: '+', '.join(present))
+          print('KV_CLOUD_PEER_ADOPTION_PROVIDER_BINDING=PASS')
+          print('GOOGLE_DRIVE_CONNECT_VERIFY_EVIDENCE=REQUIRED')
+          print('KV2_CLOUD_IDENTITY_REWRITE=NONE')
+          print('KV2_MATERIALIZATION_FROM_SOURCE_ONLY=PROHIBITED')
+          PY

--- a/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
+++ b/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
@@ -1,7 +1,8 @@
 # KV Multi-Instance COSV Binding Mirror Handoff
 
-Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MERGED / MYKV_PROJECTION_MERGED / STORAGE_PROVIDER_ADAPTERS_MERGED / PROVIDER_OPERATION_STATE_MERGED / MYKV_PROVIDER_STATUS_MERGED / SITE_DEVICE_KV_TRANSPORT_MERGED / SITE_PREPUBLICATION_UI_MERGED / SITE_PROVIDER_SHAPE_MERGED / EXISTING_KV1_ADOPTION_SOURCE_MERGED / PHYSICAL_KV1_ADOPTION_VERIFIED / SITE_PROJECTION_ADMISSION_MERGED_DEPLOYED / CURRENT_DEVICE_READBACK_PENDING / KV2_PROVIDER_ACTIVATION_PENDING
+Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MERGED / MYKV_PROJECTION_MERGED / STORAGE_PROVIDER_ADAPTERS_MERGED / PROVIDER_OPERATION_STATE_MERGED / MYKV_PROVIDER_STATUS_MERGED / DEVICE_LOCAL_KV_OWNER_OBSERVED / GOOGLE_DRIVE_EXISTING_PEER_EXACT_EVIDENCE_RECOVERED / GOOGLE_DRIVE_KV2_OWNER_REQUEST_INGRESS_OBSERVED / KV2_ADOPTION_PROVIDER_BINDING_IMPLEMENTED / HOSTED_VALIDATION_PENDING / GOOGLE_DRIVE_CONNECT_VERIFY_EXECUTION_PENDING / KV2_MATERIALIZATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
+Branch: `kv2-adoption-provider-binding-20260908`
 Updated: 2026-09-08
 Authority effect: NONE
 Activation effect: false
@@ -18,50 +19,104 @@ REPOSITORY HANDOFF: CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
 
 ## Merged capability baseline
 
-- PR #196: isolated `KV #1`, `KV #2`, and `KV #n` identity roots and four relationship tiers.
+- PR #196: KV #1/#2/#n identity roots and four relationship tiers.
 - PR #197: durable governed relationship state.
-- PR #198: bounded multi-instance MyKV projection.
-- PR #199: provider-neutral iCloud Drive / Google Drive / OneDrive / Dropbox intent adapters.
-- PR #200: durable provider-operation state requiring admitted Interlock/InTr + SKAP reference + provider-result evidence.
-- PR #201: bounded plural provider status projection with private content/credentials/governance receipt references excluded.
-- Site PR #1109: registered-Node/HB-derived-carrier resident DEVICE_KV transport.
-- Site PR #1110: unlinked prepublication MyKV #1/#2/#n UI candidate.
-- Site PR #1113: canonical plural `instance.providers.items` / `pending_requests` validation and rendering.
-- continuity-vault-kit PR #203: non-destructive existing-KV adoption source, merged at `4f2f47120ab162273abba6eae3e2155a46db2c16`.
-- Site PR #1114: owner-mediated exact-byte KV-set projection admission into resident DEVICE_KV, merged at `f928ca203a89566c6862c7b93b9f204ab36ba6c6`; push validation and Pages deployment succeeded.
+- PR #198: bounded MyKV multi-instance projection.
+- PR #199: provider-neutral iCloud Drive / Google Drive / OneDrive / Dropbox request adapters.
+- PR #200: durable provider-operation state gated by admitted Interlock/InTr evidence, SKAP credential reference, and provider-result evidence.
+- PR #201: plural provider status projection.
+- PR #203: non-destructive existing-KV adoption source.
+- PR #204: exact physical Google Drive adoption evidence.
+- Site PRs #1115/#1116: first-class device-local resident KV plus cloud-peer request surfaces.
+- Site PR #1122: prepared Google Drive KV #2 resident adoption transport.
+- Site PR #1124: legacy current-device Node compatibility repair.
+- Site PR #1127: authentic owner retry reconciliation.
+- `.github` PR #1209: canonical COSV reconciliation of authentic resident ingress.
 
-## Authentic physical Google Drive KV #1
+## Authentic current-device resident KV
 
-The existing owner-controlled Google Drive KnowledgeVault was observed with a schema-1.1 installation receipt but no pre-existing multi-instance identity/projection records. The adoption preflight therefore satisfied the no-overwrite predicates.
-
-The original installation receipt was bound before mutation at:
-
-```text
-sha256:f00378cd1f68e08a39c837f2a80e7e105e822a321c0eea17a91318b4b6e5ea19
-```
-
-The adoption bundle was written in completion-safe order and raw-read back exactly:
+Owner-visible deployed Site evidence:
 
 ```text
-_System/Instances/instance.json
-sha256:8bf5ba7d911a52506a582f064315c9831a84c0c5fbb6ec7a031c325a79af090a
-
-_System/my-kv-set-projection.json
-sha256:187ab43f0bb09d88da154af26d57e1bfe7199fd90affd2dd81af5532f0e34cf4
-
-_System/Instances/adoption.receipt.json
-sha256:64a3af27be0bd6ae36b05b35e52894581413fff048cea237d370d0ec6248b552
+resident instance: KV #1
+instance_id: kvi_0d5d4cfd531db51bbcf7fdfc0311f5dc
+kv_set_id: personal
+storage: device-local-browser-indexeddb
+relationship: NOT_CONNECTED
+exact_readback: true
+durability: BEST_EFFORT_BROWSER_ORIGIN
 ```
 
-The original installation receipt was raw-read again after all writes and retained the identical 3,179-byte SHA-256. Private source does not need to be copied into this repository; only non-secret evidence hashes are retained here.
+## Existing Google Drive cloud KV evidence
 
-The physical vault is now a single-member `personal` set representing authentic KV #1. Its relationship is `NOT_CONNECTED`; provider status is unobserved/empty; provider and relationship mutation authority are false; no provider operation executed; no data moved or replicated; no AI corpus was exposed; activation remains false.
+```text
+existing cloud instance_id: kvi_a31335d2cc3745fa987b635432cfed2c
+historical cloud ordinal: KV #1
+requested peer ordinal: KV #2
+relationship: NOT_CONNECTED
+installation receipt: sha256:f00378cd1f68e08a39c837f2a80e7e105e822a321c0eea17a91318b4b6e5ea19
+instance record: sha256:8bf5ba7d911a52506a582f064315c9831a84c0c5fbb6ec7a031c325a79af090a
+adoption receipt: sha256:64a3af27be0bd6ae36b05b35e52894581413fff048cea237d370d0ec6248b552
+set projection: sha256:187ab43f0bb09d88da154af26d57e1bfe7199fd90affd2dd81af5532f0e34cf4
+```
 
-## Resident DEVICE_KV admission
+The cloud instance identity and private content must be preserved; KV #2 is a set-membership ordinal binding, not a destructive cloud identity rewrite.
 
-Physical cloud materialization does not prove the current browser's resident DEVICE_KV contains the projection. Site PR #1114 adds a separate admission path that requires the owner to select the canonical raw `_System/my-kv-set-projection.json` file. The raw bytes are canonical-schema validated, SHA-256 bound, transported through the registered Node + generated InTr + HB-derived carrier, written only to the resident `_System/my-kv-set-projection.json` key, and read back exactly before success can be reported.
+## Authentic Google Drive KV #2 adoption request ingress
 
-The status projection is replaceable so later authentic KV #2/#n state can refresh it, but every replacement remains owner-mediated, validated, exact-byte-bound, path-restricted, and non-authorizing. Provider execution, relationship mutation, credential authority, data movement, replication, AI-corpus exposure, and activation remain false.
+The current iPhone emitted:
+
+```text
+request_id: SITE-CLOUD-KV-4347408852127319cbda574f02e03edb
+governance_state: PENDING_INTERLOCK_INTR
+resident_ingress_observed: true
+requested: KV #2
+instance_materialized: false
+provider_operation_authorized: false
+```
+
+No provider execution, relationship mutation, data movement, replication, AI-corpus exposure, credential material, authority effect, or activation is inferred from that ingress result.
+
+## Current source slice — adoption to provider execution binding
+
+`runtime/cloud_peer_adoption_provider_binding.py` converts the authentic resident adoption request into canonical Google Drive `CONNECT` and `VERIFY` requests through the existing storage-provider adapter. It requires a private runtime storage locator but does not publish that locator or raw credential material.
+
+The resulting provider requests remain:
+
+```text
+governance_state=PENDING_INTERLOCK_INTR
+skap_credential_ref_required=true
+provider_operation_executed=false
+data_moved=false
+replication_started=false
+authority_effect=NONE
+activation_effect=false
+```
+
+Materialization readiness remains false until both Google Drive `CONNECT` and `VERIFY` receipts prove all of:
+
+```text
+governance_state=ADMITTED
+provider_operation_executed=true
+interlock_receipt_ref=<non-empty>
+intr_receipt_ref=<non-empty>
+skap_credential_ref=<non-empty reference only>
+provider_result_ref=<non-empty>
+credential_material_present=false
+authority_effect=NONE
+```
+
+When those two admitted results exist, readiness may become true using:
+
+```text
+materialization_mode=SET_MEMBERSHIP_ORDINAL_BINDING_PRESERVE_CLOUD_IDENTITY
+requested_instance_number=2
+cloud_identity_rewrite_required=false
+private_content_rewrite_authorized=false
+relationship_tier_after_materialization=NOT_CONNECTED
+```
+
+The readiness function does not itself materialize KV #2.
 
 ## Canonical relationship tiers
 
@@ -72,19 +127,18 @@ SYNCED         -> inter-comms + movement + replication; no unified AI corpus
 AI_INTERACTION -> inter-comms + movement + replication + admitted logical unified AI corpus
 ```
 
-`AI_INTERACTION` does not physically merge roots, erase provenance, collapse contradictions, or make AI canonical authority.
-
 ## Remaining sequence
 
-1. On the current iPhone, admit the already-existing physical `_System/my-kv-set-projection.json` through the deployed Site MyKV instances surface.
-2. Require `PROJECTION_ADMITTED`, exact source hash binding, `exact_readback_verified=true`, then resident `MY_KV_INSTANCE_SET_PROJECTION` readback showing one authentic KV #1 instance.
-3. Integrate the validated instances surface into ordinary MyKV navigation and README/public capability semantics.
-4. Materialize real KV #2 without altering KV #1.
-5. Resolve provider authorization through SKAP without copying credential material into ordinary KV/Site state.
-6. Prove provider `CONNECT`, `VERIFY`, `READ`, `WRITE`, `SYNC`, `DISCONNECT` with admitted provider-result evidence.
-7. Prove relationship upgrades/downgrades across `NOT_CONNECTED`, `CONNECTED`, `SYNCED`, and `AI_INTERACTION`, plus disconnect/recovery/reconnect/revalidation and independent-root/provenance preservation.
-8. Complete end-to-end current-iPhone readback evidence before claiming full capability activation.
+1. Run exact-head validation for this adoption→provider binding slice and repair failures.
+2. Merge source only after all required checks pass.
+3. Resolve the Google Drive credential through SKAP as a reference; never copy credential material into Site/ordinary KV/evidence.
+4. Submit canonical Google Drive `CONNECT` through authentic Interlock/InTr and retain its receipts/provider result.
+5. Submit canonical Google Drive `VERIFY` through authentic Interlock/InTr and retain its receipts/provider result.
+6. Apply those already-admitted results to the provider-operation store.
+7. Re-evaluate materialization readiness; only if true, materialize the existing cloud instance into the `personal` set as KV #2 without rewriting its cloud identity/private content.
+8. Refresh MyKV projection/readback and then test CONNECTED/SYNCED/AI_INTERACTION progression and recovery separately.
+9. Add iCloud/new cloud KV #3/#n only after the existing Google Drive peer path is proven.
 
 ## Manual work
 
-The next action is now owner/current-device work, not source development: on the current iPhone open the deployed MyKV instances surface and select the existing canonical `KnowledgeVault/_System/my-kv-set-projection.json` from Files/Google Drive. Do not edit the file and do not enter provider credentials. Return the page's projection-admission/readback result before KV #2 authorization begins.
+None required while this source slice validates. Do not tap the adoption button again, authorize Google Drive, clear Safari data, reinstall the resident KV, or create KV #3 yet.

--- a/data/session-work-claims.d/cvk-kv2-adoption-provider-binding-20260908.json
+++ b/data/session-work-claims.d/cvk-kv2-adoption-provider-binding-20260908.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "1.0.0",
+  "registry_fragment_type": "stegverse_session_work_claim_registry_fragment",
+  "repository": "StegVerse-Labs/continuity-vault-kit",
+  "claims": [
+    {
+      "claim_id": "CVK-KV2-ADOPTION-PROVIDER-BINDING-20260908",
+      "session_worker_id": "chatgpt:cvk-kv2-adoption-provider-binding-20260908",
+      "task_id": "KV-CONNECTION-REVALIDATION-WORKER-001",
+      "originating_goal": "Bind the authentic resident Google Drive KV #2 adoption request to the canonical provider CONNECT/VERIFY operation lane and expose a fail-closed materialization-readiness gate without executing providers or rewriting cloud identity.",
+      "repository": "StegVerse-Labs/continuity-vault-kit",
+      "branch": "kv2-adoption-provider-binding-20260908",
+      "role": "SOURCE_IMPLEMENTATION",
+      "state": "CLAIMED_FOR_IMPLEMENTATION",
+      "normalized_work_key": "cvk-kv2-adoption-provider-binding",
+      "dependency_surface_keys": ["kv:storage-provider-adapter","kv:provider-operation-state","kv:multi-instance-identity","site:google-drive-kv2-resident-ingress"],
+      "governing_dependency_keys": ["kv:provider-operation-state","kv:multi-instance-identity"],
+      "claimed_paths": [
+        "runtime/cloud_peer_adoption_provider_binding.py",
+        "tests/test_cloud_peer_adoption_provider_binding.py",
+        ".github/workflows/kv-cloud-peer-adoption-provider-binding.yml",
+        "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md",
+        "data/session-work-claims.d/cvk-kv2-adoption-provider-binding-20260908.json"
+      ],
+      "handoff": "KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md",
+      "handoff_revision": "KV2_ADOPTION_PROVIDER_BINDING_IN_PROGRESS_20260908",
+      "claim_created_at": "2026-09-08T21:40:00-05:00",
+      "claim_expires_when": "Release after exact-head validation and merge. Authentic Interlock/InTr admission, SKAP resolution, Google Drive CONNECT/VERIFY execution, and KV #2 materialization remain runtime work.",
+      "expected_evidence": [
+        "authentic SITE-CLOUD-KV request binding",
+        "resident ingress evidence required",
+        "canonical Google Drive CONNECT request",
+        "canonical Google Drive VERIFY request",
+        "PENDING_INTERLOCK_INTR preserved",
+        "Interlock receipt required before readiness",
+        "InTr receipt required before readiness",
+        "SKAP credential reference required before readiness",
+        "provider result evidence required before readiness",
+        "cloud identity rewrite not required",
+        "private content rewrite false",
+        "materialization readiness false without admitted CONNECT and VERIFY",
+        "materialization mode preserves existing cloud identity",
+        "provider/materialization source tests PASS"
+      ],
+      "collision_boundaries": [
+        "Do not execute Google Drive operations from CI or repository source",
+        "Do not store raw provider credentials or private cloud locator in public evidence",
+        "Do not rewrite existing cloud instance identity or private content",
+        "Do not mark KV #2 materialized from resident ingress alone",
+        "Do not advance relationship beyond NOT_CONNECTED in this slice",
+        "Do not use GitHub token as provider/runtime authority",
+        "No NON-TV/TVC secret/token"
+      ],
+      "next_task_after_release": "Consume authentic Interlock/InTr + SKAP + Google Drive CONNECT and VERIFY results, then materialize KV #2 as a set-membership ordinal binding that preserves the existing cloud identity.",
+      "credential_authority": "TV/TVC",
+      "credential_requirement": "SKAP_REFERENCE_REQUIRED_AT_RUNTIME_PROVIDER_EXECUTION",
+      "github_token_runtime_authority": "NONE",
+      "non_tv_tvc_secret_or_token_used": false,
+      "authority_effect": false,
+      "activation_effect": false,
+      "archive_eligible": false
+    }
+  ]
+}

--- a/runtime/cloud_peer_adoption_provider_binding.py
+++ b/runtime/cloud_peer_adoption_provider_binding.py
@@ -1,0 +1,163 @@
+"""Bind an authenticated resident cloud-peer adoption request to provider operations.
+
+This module does not authenticate providers, resolve credentials, decide Interlock/InTr
+admission, or mutate a KnowledgeVault.  It converts an already-observed Site adoption
+request into the canonical storage-provider CONNECT/VERIFY lane and exposes a strict
+materialization-readiness gate.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from runtime.kv_storage_provider_adapter import build_operation_request, default_registry
+
+SITE_ADOPTION_SCHEMA = "stegverse.site.cloud-kv-peer-adoption-request/v1"
+BINDING_SCHEMA = "stegverse.kv.cloud-peer-adoption-provider-binding/v1"
+READINESS_SCHEMA = "stegverse.kv.cloud-peer-adoption-materialization-readiness/v1"
+PROVIDER_RECEIPT_SCHEMA = "stegverse.kv.storage-provider-operation-receipt/v1"
+
+
+class CloudPeerAdoptionProviderBindingError(ValueError):
+    pass
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise CloudPeerAdoptionProviderBindingError(message)
+
+
+def _validate_site_request(request: Dict[str, Any]) -> None:
+    _require(request.get("schema") == SITE_ADOPTION_SCHEMA, "unexpected Site adoption schema")
+    _require(request.get("operation") == "ADOPT_EXISTING_CLOUD_KV_PEER", "unexpected adoption operation")
+    _require(str(request.get("request_id") or "").startswith("SITE-CLOUD-KV-"), "Site request_id invalid")
+    _require(request.get("governance_state") == "PENDING_INTERLOCK_INTR", "adoption request must remain pending")
+    _require(request.get("storage_medium") == "google-drive", "only recovered Google Drive peer is bound in this slice")
+    _require(request.get("requested_instance_number") == 2, "requested peer ordinal must be KV #2")
+    _require(str(request.get("existing_instance_id") or "").startswith("kvi_"), "existing cloud instance_id invalid")
+    _require(request.get("kv_set_id") == "personal", "kv_set_id mismatch")
+    _require(request.get("credential_material_present") is False, "credential material prohibited")
+    _require(request.get("provider_operation_authorized") is False, "request cannot pre-authorize provider execution")
+    _require(request.get("instance_materialized") is False, "request cannot pre-materialize KV #2")
+    _require(request.get("relationship_mutation_authorized") is False, "request cannot mutate relationship state")
+    _require(request.get("data_moved") is False, "request cannot claim data movement")
+    _require(request.get("replication_started") is False, "request cannot claim replication")
+    _require(request.get("ai_corpus_exposed") is False, "request cannot expose AI corpus")
+    _require(request.get("existing_identity_rewrite_authorized") is False, "existing cloud identity rewrite prohibited")
+    _require(request.get("private_content_rewrite_authorized") is False, "private content rewrite prohibited")
+
+
+def build_provider_binding(
+    *,
+    site_request: Dict[str, Any],
+    resident_ingress_evidence: Dict[str, Any],
+    private_storage_locator: str,
+) -> Dict[str, Any]:
+    """Build deterministic Google Drive CONNECT + VERIFY requests from resident ingress.
+
+    ``private_storage_locator`` is runtime-private input.  Callers must not publish the
+    resulting provider request or copy the locator into public Site/COSV projections.
+    """
+    _validate_site_request(site_request)
+    _require(bool(private_storage_locator.strip()), "private storage locator required")
+    _require(resident_ingress_evidence.get("request_id") == site_request["request_id"], "resident ingress request binding mismatch")
+    _require(resident_ingress_evidence.get("resident_ingress_observed") is True, "resident ingress evidence required")
+    _require(resident_ingress_evidence.get("governance_state") == "PENDING_INTERLOCK_INTR", "resident evidence must preserve pending governance")
+    _require(resident_ingress_evidence.get("instance_materialized") is False, "resident evidence cannot claim materialization")
+    _require(resident_ingress_evidence.get("provider_operation_authorized") is False, "resident evidence cannot authorize provider operation")
+
+    adapter = default_registry().get("google-drive")
+    common = dict(
+        adapter=adapter,
+        instance_id=site_request["existing_instance_id"],
+        kv_set_id=site_request["kv_set_id"],
+        storage_locator=private_storage_locator.strip(),
+        requested_by="owner",
+        object_ref=site_request["request_id"],
+    )
+    connect = build_operation_request(operation="CONNECT", **common)
+    verify = build_operation_request(operation="VERIFY", **common)
+
+    return {
+        "schema": BINDING_SCHEMA,
+        "source_site_request_id": site_request["request_id"],
+        "resident_instance_id": site_request["resident_instance_id"],
+        "existing_cloud_instance_id": site_request["existing_instance_id"],
+        "kv_set_id": site_request["kv_set_id"],
+        "provider_id": "google-drive",
+        "requested_instance_number": 2,
+        "requested_logical_name": "KV #2",
+        "initial_relationship_tier": "NOT_CONNECTED",
+        "connect_request": connect,
+        "verify_request": verify,
+        "interlock_intr_admission_required": True,
+        "skap_credential_reference_required": True,
+        "provider_result_evidence_required": True,
+        "cloud_identity_rewrite_required": False,
+        "private_content_rewrite_authorized": False,
+        "instance_materialization_authorized": False,
+        "relationship_mutation_authorized": False,
+        "credential_material_present": False,
+        "authority_effect": "NONE_REQUEST_BINDING_ONLY",
+        "activation_effect": False,
+    }
+
+
+def _validate_provider_receipt(receipt: Dict[str, Any], *, request: Dict[str, Any], operation: str) -> None:
+    _require(receipt.get("schema") == PROVIDER_RECEIPT_SCHEMA, f"{operation} receipt schema mismatch")
+    _require(receipt.get("request_id") == request.get("request_id"), f"{operation} receipt request mismatch")
+    _require(receipt.get("instance_id") == request.get("instance_id"), f"{operation} receipt instance mismatch")
+    _require(receipt.get("kv_set_id") == request.get("kv_set_id"), f"{operation} receipt set mismatch")
+    _require(receipt.get("provider_id") == "google-drive", f"{operation} receipt provider mismatch")
+    _require(receipt.get("operation") == operation, f"{operation} receipt operation mismatch")
+    _require(receipt.get("governance_state") == "ADMITTED", f"{operation} requires ADMITTED governance")
+    _require(receipt.get("provider_operation_executed") is True, f"{operation} execution evidence required")
+    _require(bool(str(receipt.get("interlock_receipt_ref") or "").strip()), f"{operation} Interlock receipt required")
+    _require(bool(str(receipt.get("intr_receipt_ref") or "").strip()), f"{operation} InTr receipt required")
+    _require(bool(str(receipt.get("skap_credential_ref") or "").strip()), f"{operation} SKAP reference required")
+    _require(bool(str(receipt.get("provider_result_ref") or "").strip()), f"{operation} provider result required")
+    _require(receipt.get("credential_material_present") is False, f"{operation} receipt cannot contain credential material")
+    _require(receipt.get("authority_effect") == "NONE", f"{operation} receipt cannot grant source authority")
+    _require(receipt.get("data_moved") is False, f"{operation} cannot claim data movement")
+    _require(receipt.get("replication_started") is False, f"{operation} cannot claim replication")
+
+
+def evaluate_materialization_readiness(
+    *,
+    binding: Dict[str, Any],
+    connect_receipt: Dict[str, Any] | None = None,
+    verify_receipt: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Return fail-closed readiness; it never performs materialization itself."""
+    _require(binding.get("schema") == BINDING_SCHEMA, "unexpected provider binding schema")
+    _require(binding.get("instance_materialization_authorized") is False, "binding cannot pre-authorize materialization")
+
+    missing: list[str] = []
+    if connect_receipt is None:
+        missing.append("ADMITTED_GOOGLE_DRIVE_CONNECT_RESULT")
+    else:
+        _validate_provider_receipt(connect_receipt, request=binding["connect_request"], operation="CONNECT")
+    if verify_receipt is None:
+        missing.append("ADMITTED_GOOGLE_DRIVE_VERIFY_RESULT")
+    else:
+        _validate_provider_receipt(verify_receipt, request=binding["verify_request"], operation="VERIFY")
+
+    ready = not missing
+    return {
+        "schema": READINESS_SCHEMA,
+        "source_site_request_id": binding["source_site_request_id"],
+        "existing_cloud_instance_id": binding["existing_cloud_instance_id"],
+        "requested_instance_number": 2,
+        "requested_logical_name": "KV #2",
+        "provider_id": "google-drive",
+        "provider_connect_verified": ready,
+        "materialization_ready": ready,
+        "materialization_mode": "SET_MEMBERSHIP_ORDINAL_BINDING_PRESERVE_CLOUD_IDENTITY" if ready else None,
+        "cloud_identity_rewrite_required": False,
+        "private_content_rewrite_authorized": False,
+        "relationship_tier_after_materialization": "NOT_CONNECTED",
+        "missing_evidence": missing,
+        "credential_material_present": False,
+        "authority_effect": "NONE_READINESS_ONLY",
+        "activation_effect": False,
+    }

--- a/tests/test_cloud_peer_adoption_provider_binding.py
+++ b/tests/test_cloud_peer_adoption_provider_binding.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from runtime.cloud_peer_adoption_provider_binding import (
+    CloudPeerAdoptionProviderBindingError,
+    build_provider_binding,
+    evaluate_materialization_readiness,
+)
+
+REQUEST_ID = "SITE-CLOUD-KV-4347408852127319cbda574f02e03edb"
+CLOUD_ID = "kvi_a31335d2cc3745fa987b635432cfed2c"
+RESIDENT_ID = "kvi_0d5d4cfd531db51bbcf7fdfc0311f5dc"
+
+
+def site_request():
+    return {
+        "schema":"stegverse.site.cloud-kv-peer-adoption-request/v1",
+        "operation":"ADOPT_EXISTING_CLOUD_KV_PEER",
+        "request_id":REQUEST_ID,
+        "resident_instance_id":RESIDENT_ID,
+        "resident_instance_number":1,
+        "existing_instance_id":CLOUD_ID,
+        "kv_set_id":"personal",
+        "requested_instance_number":2,
+        "requested_logical_name":"KV #2",
+        "storage_medium":"google-drive",
+        "initial_relationship_tier":"NOT_CONNECTED",
+        "governance_state":"PENDING_INTERLOCK_INTR",
+        "credential_material_present":False,
+        "provider_operation_authorized":False,
+        "instance_materialized":False,
+        "relationship_mutation_authorized":False,
+        "data_moved":False,
+        "replication_started":False,
+        "ai_corpus_exposed":False,
+        "private_content_rewrite_authorized":False,
+        "existing_identity_rewrite_authorized":False,
+    }
+
+
+def ingress():
+    return {
+        "request_id":REQUEST_ID,
+        "governance_state":"PENDING_INTERLOCK_INTR",
+        "resident_ingress_observed":True,
+        "instance_materialized":False,
+        "provider_operation_authorized":False,
+    }
+
+
+def admitted(request, operation):
+    return {
+        "schema":"stegverse.kv.storage-provider-operation-receipt/v1",
+        "request_id":request["request_id"],
+        "instance_id":request["instance_id"],
+        "kv_set_id":request["kv_set_id"],
+        "provider_id":"google-drive",
+        "operation":operation,
+        "governance_state":"ADMITTED",
+        "provider_operation_executed":True,
+        "data_moved":False,
+        "replication_started":False,
+        "interlock_receipt_ref":f"interlock:{operation.lower()}:receipt",
+        "intr_receipt_ref":f"intr:{operation.lower()}:receipt",
+        "skap_credential_ref":"skap:google-drive:credential-ref",
+        "provider_result_ref":f"provider:google-drive:{operation.lower()}:result",
+        "authority_effect":"NONE",
+        "credential_material_present":False,
+    }
+
+
+def test_owner_ingress_binds_to_canonical_connect_verify_requests():
+    value = build_provider_binding(
+        site_request=site_request(), resident_ingress_evidence=ingress(),
+        private_storage_locator="Google Drive:/KnowledgeVault",
+    )
+    assert value["source_site_request_id"] == REQUEST_ID
+    assert value["existing_cloud_instance_id"] == CLOUD_ID
+    assert value["requested_instance_number"] == 2
+    assert value["provider_id"] == "google-drive"
+    assert value["connect_request"]["operation"] == "CONNECT"
+    assert value["verify_request"]["operation"] == "VERIFY"
+    assert value["connect_request"]["object_ref"] == REQUEST_ID
+    assert value["connect_request"]["governance_state"] == "PENDING_INTERLOCK_INTR"
+    assert value["connect_request"]["provider_operation_executed"] is False
+    assert value["verify_request"]["provider_operation_executed"] is False
+    assert value["instance_materialization_authorized"] is False
+    assert value["cloud_identity_rewrite_required"] is False
+    assert value["credential_material_present"] is False
+
+
+def test_missing_provider_results_remain_not_ready():
+    binding = build_provider_binding(
+        site_request=site_request(), resident_ingress_evidence=ingress(),
+        private_storage_locator="Google Drive:/KnowledgeVault",
+    )
+    readiness = evaluate_materialization_readiness(binding=binding)
+    assert readiness["materialization_ready"] is False
+    assert readiness["missing_evidence"] == [
+        "ADMITTED_GOOGLE_DRIVE_CONNECT_RESULT",
+        "ADMITTED_GOOGLE_DRIVE_VERIFY_RESULT",
+    ]
+
+
+def test_connect_and_verify_receipts_make_readiness_true_without_rewrite():
+    binding = build_provider_binding(
+        site_request=site_request(), resident_ingress_evidence=ingress(),
+        private_storage_locator="Google Drive:/KnowledgeVault",
+    )
+    readiness = evaluate_materialization_readiness(
+        binding=binding,
+        connect_receipt=admitted(binding["connect_request"], "CONNECT"),
+        verify_receipt=admitted(binding["verify_request"], "VERIFY"),
+    )
+    assert readiness["materialization_ready"] is True
+    assert readiness["provider_connect_verified"] is True
+    assert readiness["materialization_mode"] == "SET_MEMBERSHIP_ORDINAL_BINDING_PRESERVE_CLOUD_IDENTITY"
+    assert readiness["cloud_identity_rewrite_required"] is False
+    assert readiness["relationship_tier_after_materialization"] == "NOT_CONNECTED"
+    assert readiness["authority_effect"] == "NONE_READINESS_ONLY"
+
+
+@pytest.mark.parametrize("field,value", [
+    ("provider_operation_authorized", True),
+    ("instance_materialized", True),
+    ("credential_material_present", True),
+    ("existing_identity_rewrite_authorized", True),
+    ("private_content_rewrite_authorized", True),
+])
+def test_source_overclaims_fail_closed(field, value):
+    request = site_request()
+    request[field] = value
+    with pytest.raises(CloudPeerAdoptionProviderBindingError):
+        build_provider_binding(
+            site_request=request, resident_ingress_evidence=ingress(),
+            private_storage_locator="Google Drive:/KnowledgeVault",
+        )
+
+
+def test_receipt_missing_interlock_intr_skap_or_provider_result_fails_closed():
+    binding = build_provider_binding(
+        site_request=site_request(), resident_ingress_evidence=ingress(),
+        private_storage_locator="Google Drive:/KnowledgeVault",
+    )
+    good_connect = admitted(binding["connect_request"], "CONNECT")
+    good_verify = admitted(binding["verify_request"], "VERIFY")
+    for field in ("interlock_receipt_ref", "intr_receipt_ref", "skap_credential_ref", "provider_result_ref"):
+        bad = copy.deepcopy(good_connect)
+        bad[field] = ""
+        with pytest.raises(CloudPeerAdoptionProviderBindingError):
+            evaluate_materialization_readiness(binding=binding, connect_receipt=bad, verify_receipt=good_verify)

--- a/tests/test_global_hosted_workflow_authority.py
+++ b/tests/test_global_hosted_workflow_authority.py
@@ -4,7 +4,7 @@ import unittest
 
 ROOT=Path(__file__).resolve().parents[1]
 WORKFLOW_ROOT=ROOT/".github/workflows"
-EXPECTED_WORKFLOW_COUNT=51
+EXPECTED_WORKFLOW_COUNT=52
 
 class GlobalHostedWorkflowAuthorityTests(unittest.TestCase):
     def test_all_workflows_declare_permissions_and_no_authority_markers(self):


### PR DESCRIPTION
Continues `KV-CONNECTION-REVALIDATION-WORKER-001` / COSV `50000000102000` after authentic current-iPhone resident ingress for request `SITE-CLOUD-KV-4347408852127319cbda574f02e03edb`.

This PR closes the source gap between resident adoption ingress and the existing governed storage-provider operation store:

- validates the bounded Site adoption request and resident-ingress evidence;
- binds the existing Google Drive cloud identity to canonical provider `CONNECT` and `VERIFY` requests;
- keeps both requests `PENDING_INTERLOCK_INTR` with raw credential material absent;
- requires Interlock receipt, InTr receipt, SKAP credential reference, and provider-result evidence before readiness;
- requires both admitted CONNECT and VERIFY execution results before `materialization_ready=true`;
- defines KV #2 materialization as `SET_MEMBERSHIP_ORDINAL_BINDING_PRESERVE_CLOUD_IDENTITY`, avoiding destructive rewrite of the historical cloud instance/private content;
- does not execute Google Drive, decide governance, materialize KV #2, move/replicate data, alter relationship state, or grant authority.

The upstream multi-instance handoff is also reconciled with the now-authentic device-local KV and resident adoption-ingress state.