### PR TITLE
Produce KV-bound ephemeral browser projection context

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Each independently governed ingress boundary evaluates its own HANDOFF and, when
 
 The full runtime Interlock/InTr integration is an activation lane separate from baseline file-only KnowledgeVault use.
 
+## KV-bound ephemeral browser projection
+
+For governed browser actions, KV remains the private continuity boundary while the physical browser/container is an ephemeral capability and presentation surface. The source producer `scripts/materialize_ephemeral_browser_projection_context.py` consumes an already-admitted KV entry-transition receipt and a compatible browser-capability observation from the same KV lineage, then emits only opaque SHA-256 commitments plus purpose/state metadata for the StegOS projection gate.
+
+The producer does not decide Interlock/InTr admission, infer capability from browser identity, persist browser state, expose the KV lineage identifier, authenticate TV/TVC, or grant execution authority. Missing admission, mismatched KV lineage, non-KV continuity, or browser-identity authority fails closed.
+
+See [`docs/KV_EPHEMERAL_BROWSER_PROJECTION_MIRROR_HANDOFF.md`](./docs/KV_EPHEMERAL_BROWSER_PROJECTION_MIRROR_HANDOFF.md) and [`docs/KV_PRIVACY_STATE_TRANSITION_CONTINUITY.md`](./docs/KV_PRIVACY_STATE_TRANSITION_CONTINUITY.md).
+
 ## Safety
 
 KnowledgeVault's baseline file structure is not itself encryption. Do not place passwords, private keys, seed phrases, authentication recovery codes, or equivalent secrets into ordinary plaintext KV files. In the StegVerse architecture, those belong behind the SKAP Vault boundary.

--- a/docs/KV_EPHEMERAL_BROWSER_PROJECTION_MIRROR_HANDOFF.md
+++ b/docs/KV_EPHEMERAL_BROWSER_PROJECTION_MIRROR_HANDOFF.md
@@ -1,0 +1,67 @@
+# KV Ephemeral Browser Projection Mirror Handoff
+
+Updated: 2026-09-09
+
+Goal Task ID: `KV-BOUND-EPHEMERAL-BROWSER-PROJECTION-001`
+Canonical issue: `StegVerse-Labs/.github#1299`
+Consumer PR: `StegVerse-Labs/StegOS#314`
+
+## Purpose
+
+Produce the narrow, non-authorizing, purpose-bound projection context consumed by the current-iPhone TestFlight bootstrap only after KV has an admitted entry transition and a compatible browser-capability observation from the same KV lineage.
+
+## Producer contract
+
+`script/materialize_ephemeral_browser_projection_context.py` does not decide admission and does not observe a browser. It consumes two already-established KV receipts:
+
+```text
+stegverse.kv.entry-transition-admission/v1
+stegverse.kv.browser-capability-observation/v1
+```
+
+Both receipts must:
+
+- be bound to purpose `CURRENT_IPHONE_TESTFLIGHT_SIGNING`;
+- name `KV` as the continuity boundary;
+- have `authority_effect=NONE`;
+- carry the same non-empty `kv_lineage_id`.
+
+The entry receipt must be `ADMITTED` and carry an exact SHA-256 transition commitment. The capability receipt must be `OBSERVED_COMPATIBLE`, carry an exact SHA-256 capability commitment, and explicitly set `browser_identity_authority=false`.
+
+The producer emits only:
+
+```text
+stegos.kv-bound-ephemeral-projection-context/v1
+purpose=CURRENT_IPHONE_TESTFLIGHT_SIGNING
+entry_state=ADMITTED
+kv_transition_commitment=<opaque sha256>
+admission_commitment=<derived opaque sha256>
+browser_capability_state=OBSERVED_COMPATIBLE
+browser_capability_commitment=<opaque sha256>
+persistence_effect=NONE_EPHEMERAL_CONTEXT_ONLY
+authority_effect=NONE_PROJECTION_GATE_ONLY
+```
+
+The raw KV lineage identifier is deliberately not exported into the browser projection.
+
+## Authority boundary
+
+The producer cannot mint an Interlock/InTr admission, cannot infer browser compatibility from user-agent identity, cannot persist browser state, cannot authenticate TV/TVC, cannot sign an IPA, and cannot claim TestFlight/runtime execution.
+
+The emitted context is a one-purpose projection gate input only. Missing, mismatched, cross-lineage, non-KV, non-admitted, or browser-authorizing source evidence fails closed.
+
+## Files
+
+- `scripts/materialize_ephemeral_browser_projection_context.py`
+- `schemas/kv-ephemeral-browser-projection-context.schema.json`
+- `tests/test_materialize_ephemeral_browser_projection_context.py`
+
+## Remaining integration
+
+1. Establish the authentic runtime producers of the KV entry-transition admission receipt and browser-capability observation receipt.
+2. Package or transfer the resulting projection context to the StegOS current-iPhone bootstrap without browser-local durable storage.
+3. Validate consumer/producer exact-schema compatibility.
+4. Merge both source slices only after CI is green.
+5. Continue TVC signing/upload and authentic current-iPhone execution separately.
+
+No runtime admission, browser observation, signing, TestFlight installation, or resident execution is claimed by this source contract.

--- a/schemas/kv-ephemeral-browser-projection-context.schema.json
+++ b/schemas/kv-ephemeral-browser-projection-context.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-ephemeral-browser-projection-context.schema.json",
+  "title": "KV Ephemeral Browser Projection Context",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "purpose",
+    "entry_state",
+    "kv_transition_commitment",
+    "admission_commitment",
+    "browser_capability_state",
+    "browser_capability_commitment",
+    "persistence_effect",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema": {"const": "stegos.kv-bound-ephemeral-projection-context/v1"},
+    "purpose": {"const": "CURRENT_IPHONE_TESTFLIGHT_SIGNING"},
+    "entry_state": {"const": "ADMITTED"},
+    "kv_transition_commitment": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "admission_commitment": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "browser_capability_state": {"const": "OBSERVED_COMPATIBLE"},
+    "browser_capability_commitment": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "persistence_effect": {"const": "NONE_EPHEMERAL_CONTEXT_ONLY"},
+    "authority_effect": {"const": "NONE_PROJECTION_GATE_ONLY"}
+  }
+}

--- a/scripts/materialize_ephemeral_browser_projection_context.py
+++ b/scripts/materialize_ephemeral_browser_projection_context.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Materialize a non-authorizing ephemeral browser projection context from KV receipts."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+PURPOSE = "CURRENT_IPHONE_TESTFLIGHT_SIGNING"
+ENTRY_SCHEMA = "stegverse.kv.entry-transition-admission/v1"
+CAPABILITY_SCHEMA = "stegverse.kv.browser-capability-observation/v1"
+OUTPUT_SCHEMA = "stegos.kv-bound-ephemeral-projection-context/v1"
+
+
+def _canonical_digest(payload: dict) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _require_digest(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.startswith("sha256:") or len(value) != 71:
+        raise ValueError(f"{field} must be sha256:<64 lowercase hex>")
+    suffix = value[7:]
+    if any(c not in "0123456789abcdef" for c in suffix):
+        raise ValueError(f"{field} must be sha256:<64 lowercase hex>")
+    return value
+
+
+def validate_entry(entry: dict) -> str:
+    if entry.get("schema") != ENTRY_SCHEMA:
+        raise ValueError("KV entry receipt schema mismatch")
+    if entry.get("purpose") != PURPOSE:
+        raise ValueError("KV entry purpose mismatch")
+    if entry.get("state") != "ADMITTED":
+        raise ValueError("KV entry must be ADMITTED")
+    if entry.get("authority_effect") != "NONE":
+        raise ValueError("KV entry authority_effect must be NONE")
+    if entry.get("continuity_boundary") != "KV":
+        raise ValueError("KV entry continuity boundary mismatch")
+    return _require_digest(entry.get("transition_commitment"), "transition_commitment")
+
+
+def validate_capability(capability: dict) -> str:
+    if capability.get("schema") != CAPABILITY_SCHEMA:
+        raise ValueError("browser capability receipt schema mismatch")
+    if capability.get("purpose") != PURPOSE:
+        raise ValueError("browser capability purpose mismatch")
+    if capability.get("state") != "OBSERVED_COMPATIBLE":
+        raise ValueError("browser capability must be OBSERVED_COMPATIBLE")
+    if capability.get("authority_effect") != "NONE":
+        raise ValueError("browser capability authority_effect must be NONE")
+    if capability.get("continuity_boundary") != "KV":
+        raise ValueError("browser capability continuity boundary mismatch")
+    if capability.get("browser_identity_authority") is not False:
+        raise ValueError("browser identity may not be authority")
+    return _require_digest(capability.get("capability_commitment"), "capability_commitment")
+
+
+def materialize(entry: dict, capability: dict) -> dict:
+    transition_commitment = validate_entry(entry)
+    capability_commitment = validate_capability(capability)
+    if entry.get("kv_lineage_id") != capability.get("kv_lineage_id"):
+        raise ValueError("KV lineage mismatch")
+    if not isinstance(entry.get("kv_lineage_id"), str) or not entry["kv_lineage_id"]:
+        raise ValueError("KV lineage id missing")
+    admission_commitment = _canonical_digest({
+        "schema": ENTRY_SCHEMA,
+        "purpose": PURPOSE,
+        "state": "ADMITTED",
+        "kv_lineage_id": entry["kv_lineage_id"],
+        "transition_commitment": transition_commitment,
+        "entry_receipt_commitment": _canonical_digest(entry),
+    })
+    return {
+        "schema": OUTPUT_SCHEMA,
+        "purpose": PURPOSE,
+        "entry_state": "ADMITTED",
+        "kv_transition_commitment": transition_commitment,
+        "admission_commitment": admission_commitment,
+        "browser_capability_state": "OBSERVED_COMPATIBLE",
+        "browser_capability_commitment": capability_commitment,
+        "persistence_effect": "NONE_EPHEMERAL_CONTEXT_ONLY",
+        "authority_effect": "NONE_PROJECTION_GATE_ONLY",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("entry_receipt", type=Path)
+    parser.add_argument("browser_capability_receipt", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        entry = json.loads(args.entry_receipt.read_text(encoding="utf-8"))
+        capability = json.loads(args.browser_capability_receipt.read_text(encoding="utf-8"))
+        context = materialize(entry, capability)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print("KV_EPHEMERAL_BROWSER_PROJECTION_CONTEXT_FAIL")
+        print(str(exc))
+        return 1
+    args.output.write_text(json.dumps(context, indent=2) + "\n", encoding="utf-8")
+    print("KV_EPHEMERAL_BROWSER_PROJECTION_CONTEXT_PASS")
+    print(f"PURPOSE={PURPOSE}")
+    print("AUTHORITY_EFFECT=NONE_PROJECTION_GATE_ONLY")
+    print("PERSISTENCE_EFFECT=NONE_EPHEMERAL_CONTEXT_ONLY")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_materialize_ephemeral_browser_projection_context.py
+++ b/tests/test_materialize_ephemeral_browser_projection_context.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "materialize_ephemeral_browser_projection_context.py"
+
+spec = importlib.util.spec_from_file_location("projection", MODULE_PATH)
+projection = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(projection)
+
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+
+
+def entry(**overrides):
+    payload = {
+        "schema": projection.ENTRY_SCHEMA,
+        "purpose": projection.PURPOSE,
+        "state": "ADMITTED",
+        "authority_effect": "NONE",
+        "continuity_boundary": "KV",
+        "kv_lineage_id": "kv-lineage-test-001",
+        "transition_commitment": DIGEST_A,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def capability(**overrides):
+    payload = {
+        "schema": projection.CAPABILITY_SCHEMA,
+        "purpose": projection.PURPOSE,
+        "state": "OBSERVED_COMPATIBLE",
+        "authority_effect": "NONE",
+        "continuity_boundary": "KV",
+        "browser_identity_authority": False,
+        "kv_lineage_id": "kv-lineage-test-001",
+        "capability_commitment": DIGEST_B,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_materializes_only_non_authorizing_ephemeral_context():
+    result = projection.materialize(entry(), capability())
+    assert result["schema"] == projection.OUTPUT_SCHEMA
+    assert result["purpose"] == projection.PURPOSE
+    assert result["entry_state"] == "ADMITTED"
+    assert result["kv_transition_commitment"] == DIGEST_A
+    assert result["admission_commitment"].startswith("sha256:")
+    assert result["browser_capability_state"] == "OBSERVED_COMPATIBLE"
+    assert result["browser_capability_commitment"] == DIGEST_B
+    assert result["persistence_effect"] == "NONE_EPHEMERAL_CONTEXT_ONLY"
+    assert result["authority_effect"] == "NONE_PROJECTION_GATE_ONLY"
+    assert "kv_lineage_id" not in result
+
+
+def test_rejects_unadmitted_entry():
+    try:
+        projection.materialize(entry(state="REQUESTED"), capability())
+    except ValueError as exc:
+        assert "ADMITTED" in str(exc)
+    else:
+        raise AssertionError("unadmitted KV entry was accepted")
+
+
+def test_rejects_browser_identity_as_authority():
+    try:
+        projection.materialize(entry(), capability(browser_identity_authority=True))
+    except ValueError as exc:
+        assert "browser identity" in str(exc)
+    else:
+        raise AssertionError("browser identity authority was accepted")
+
+
+def test_rejects_cross_kv_lineage_mix():
+    try:
+        projection.materialize(entry(), capability(kv_lineage_id="other-kv-lineage"))
+    except ValueError as exc:
+        assert "lineage mismatch" in str(exc)
+    else:
+        raise AssertionError("cross-lineage projection was accepted")
+
+
+def test_rejects_non_kv_continuity_boundary():
+    try:
+        projection.materialize(entry(continuity_boundary="BROWSER"), capability())
+    except ValueError as exc:
+        assert "continuity boundary" in str(exc)
+    else:
+        raise AssertionError("browser continuity boundary was accepted")


### PR DESCRIPTION
Goal Task ID: KV-BOUND-EPHEMERAL-BROWSER-PROJECTION-001
Canonical issue: StegVerse-Labs/.github#1299
Consumer: StegVerse-Labs/StegOS#314

Adds the KV-side producer contract for the current-iPhone ephemeral TestFlight projection seam.

This slice does not decide admission or observe browser capability. It requires two already-established KV receipts from the same KV lineage: an ADMITTED purpose-bound entry-transition receipt and an OBSERVED_COMPATIBLE purpose-bound browser-capability receipt. Browser identity must explicitly have no authority.

The producer emits only the opaque projection context consumed by StegOS: KV transition commitment, derived admission commitment, browser-capability commitment, purpose, states, and non-authority/non-persistence effects. The raw KV lineage identifier is deliberately not exported.

Files:
- scripts/materialize_ephemeral_browser_projection_context.py
- schemas/kv-ephemeral-browser-projection-context.schema.json
- tests/test_materialize_ephemeral_browser_projection_context.py
- docs/KV_EPHEMERAL_BROWSER_PROJECTION_MIRROR_HANDOFF.md

Remaining after this source slice: connect authentic runtime producers for the two source receipts; transport the resulting projection context to StegOS without browser-local durable storage; reconcile PR #314 against main; validate both sides; then continue TVC signing/upload and physical current-iPhone evidence.

No runtime admission, browser observation, TestFlight installation, or resident execution is claimed here.