### PR TITLE
Add KV to SKAP InTr account metadata transfer protocol

### DIFF
--- a/KV_SKAP_INTR_ACCOUNT_TRANSFER_MIRROR_HANDOFF.md
+++ b/KV_SKAP_INTR_ACCOUNT_TRANSFER_MIRROR_HANDOFF.md
@@ -1,0 +1,48 @@
+# KV → SKAP InTr Account Transfer Mirror Handoff
+
+Updated: 2026-09-10
+Goal Task ID: `SS-SKAP-AUTHENTIC-ACCOUNT-METADATA-POPULATION-001`
+Repository: `StegVerse-Labs/continuity-vault-kit`
+Branch: `task/kv-skap-intr-account-transfer-20260910`
+Status: `IMPLEMENTATION_ACTIVE / VALIDATION_PENDING`
+
+## Finding
+
+The existing architecture states `SKAP Vault ←InTr→ KnowledgeVault`, but the implemented `KV-INTERLOCK-v1` runtime core is DEVICE→KV oriented and explicitly grants no direct SKAP authority. No canonical exact KV→SKAP account-metadata transfer packet and receiving-boundary binding was found. That gap prevented the My KV Connected Accounts selector from being bound correctly to internal SKAP population.
+
+## Implemented source contract
+
+Added:
+
+- `schemas/kv-skap-account-metadata-transfer.schema.json`
+- `schemas/intr-boundary-transfer.schema.json`
+- `runtime/kv_skap_account_transfer.py`
+- `tests/test_kv_skap_account_transfer.py`
+- `docs/KV_SKAP_INTR_ACCOUNT_TRANSFER_PROTOCOL.md`
+
+The transfer is intentionally split into three layers:
+
+1. owner-selected, non-secret KV transfer packet;
+2. canonical `kv.interlock.request.v1` `COMMIT_CANDIDATE` referencing the exact payload hash;
+3. exact `stegverse.intr.boundary-transfer/v1` envelope binding request hash + transfer-packet hash + payload hash from `KnowledgeVault` to `SKAP_Vault`.
+
+The boundary envelope fixes `canonical_state_changed=false` and `credential_material_transferred=false`. It is not a SKAP admission receipt. The receiving SKAP side must independently validate the same hashes and an applicable InTr decision before creating account state or a SKAP receipt.
+
+## Required receiving-side continuation
+
+TVC/SKAP must implement a consumer for `SKAP_ACCOUNT_METADATA_ADMIT` that:
+
+- validates the exact transfer packet and boundary envelope;
+- requires a retained InTr decision/receipt bound to the exact request/packet hashes;
+- rejects missing owner-selection evidence, secret-bearing fields, raw provider account ids, hash drift, replay mutation, and synthetic/test elevation;
+- persists only bounded non-secret SKAP account metadata;
+- emits a receipt compatible with `TVC/tools/skap_account_inventory_projection.py`;
+- proves idempotent exact replay and refuses conflicting replay.
+
+## Runtime truth
+
+No authentic KV→SKAP account transfer is claimed from this source work. Completion requires an owner-selected real account from the My KV Connected Accounts UI to traverse this protocol, yield an InTr receipt and SKAP receipt, and appear in the TVC account-inventory projection.
+
+## Manual work
+
+None.

--- a/docs/KV_SKAP_INTR_ACCOUNT_TRANSFER_PROTOCOL.md
+++ b/docs/KV_SKAP_INTR_ACCOUNT_TRANSFER_PROTOCOL.md
@@ -1,0 +1,81 @@
+# KV ↔ SKAP InTr Account Metadata Transfer Protocol
+
+Status: `IMPLEMENTATION_CANDIDATE`
+Protocol packet: `stegverse.kv-skap.account-metadata-transfer/v1`
+Boundary envelope: `stegverse.intr.boundary-transfer/v1`
+Goal Task ID: `SS-SKAP-AUTHENTIC-ACCOUNT-METADATA-POPULATION-001`
+
+## Purpose
+
+Define the internal governed data-transfer seam between KnowledgeVault and the internal SKAP Vault for owner-selected account metadata. This protocol does not transfer provider credentials or raw provider account identifiers. It transfers only the minimum non-secret account metadata needed to establish a SKAP account binding and preserve evidence lineage.
+
+## Required flow
+
+```text
+My KV owner selection
+  -> bounded provider-account observation
+  -> KnowledgeVault non-secret transfer packet
+  -> KV-INTERLOCK-v1 COMMIT_CANDIDATE
+  -> exact InTr boundary-transfer envelope
+  -> InTr decision / durable receipt
+  -> SKAP Vault account-metadata admission
+  -> SKAP receipt
+  -> TVC account-inventory projection
+```
+
+## Why this is separate from ordinary KV COMMIT
+
+`KV-INTERLOCK-v1` intentionally grants no direct SKAP or provider authority. Therefore the KV request remains a candidate-only request. The new boundary-transfer envelope binds the exact KV request hash to the exact transfer packet hash and names `SKAP_Vault` as the destination boundary. Canonical state may not change until the receiving InTr/SKAP side produces the separately validated transition/admission receipt.
+
+## Transfer packet
+
+The packet contains only:
+
+- owner selection reference;
+- provider organization reference such as `org:linkedin`;
+- account class;
+- account status;
+- source-evidence reference;
+- source-evidence SHA-256;
+- deterministic payload hash and transfer id;
+- explicit `contains_secret_material=false` and `raw_provider_account_identifier_present=false`.
+
+The packet MUST NOT contain provider account ids, usernames used as authentication material, passwords, access/refresh tokens, client secrets, private keys, session cookies, or credential payloads.
+
+## Interlock binding
+
+The KnowledgeVault request uses canonical `kv.interlock.request.v1` with:
+
+- `operation=COMMIT_CANDIDATE`;
+- `record_class=SKAP_ACCOUNT_METADATA_TRANSFER`;
+- minimum necessary requested scope;
+- `disclosure_mode=SOURCE_REFERENCE_ONLY`;
+- `candidate_writeback.payload_ref` equal to the exact transfer payload hash;
+- `candidate_writeback.requested_destination=skap://internal/account-metadata`.
+
+This request is not itself a SKAP write.
+
+## Boundary-transfer envelope
+
+The InTr envelope binds:
+
+- source boundary `KnowledgeVault`;
+- destination boundary `SKAP_Vault`;
+- request id;
+- exact KV request hash;
+- transfer id;
+- exact transfer-packet hash;
+- exact payload hash;
+- InTr receipt reference once available;
+- `canonical_state_changed=false` before receiving-side admission;
+- `credential_material_transferred=false`.
+
+Any request/packet hash mismatch, destination mismatch, secret-bearing field, raw provider account identifier, or replay with altered payload MUST fail closed.
+
+## Receiving-side requirement
+
+The SKAP-side consumer must independently validate the same packet and envelope hashes, require an applicable InTr decision/receipt for `SKAP_ACCOUNT_METADATA_ADMIT`, and write a receipt whose non-secret fields are sufficient for `TVC/tools/skap_account_inventory_projection.py` to enumerate the account. The receiving side must not invent provider identity or upgrade synthetic/test evidence to authentic population.
+
+## Runtime truth
+
+This source contract does not prove an authentic KV → SKAP runtime transfer has occurred. Runtime completion requires one owner-selected real account to traverse this protocol, produce a retained InTr receipt and retained SKAP account metadata receipt, and then appear in the TVC account inventory projection.

--- a/runtime/kv_skap_account_transfer.py
+++ b/runtime/kv_skap_account_transfer.py
@@ -13,7 +13,7 @@ class KVSKAPTransferError(ValueError):
 SECRET_TOKENS = (
     "password", "secret", "token", "private_key", "access_key", "refresh_token",
     "client_secret", "authorization", "cookie", "session_key", "account_id",
-    "provider_account_id", "raw_provider_account_identifier"
+    "provider_account_id"
 )
 
 
@@ -31,8 +31,6 @@ def _assert_no_secrets(value: Any, path: str = "packet") -> None:
         for key, child in value.items():
             lower = str(key).lower()
             if any(token in lower for token in SECRET_TOKENS):
-                if lower == "raw_provider_account_identifier_present" and child is False:
-                    continue
                 raise KVSKAPTransferError(f"secret_or_raw_identifier_field_prohibited:{path}.{key}")
             _assert_no_secrets(child, f"{path}.{key}")
     elif isinstance(value, list):
@@ -73,7 +71,7 @@ def build_transfer_packet(*, owner_selection_ref: str, provider_org_ref: str,
 def validate_transfer_packet(packet: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(packet, dict):
         raise KVSKAPTransferError("packet_not_object")
-    _assert_no_secrets(packet)
+    _assert_no_secrets({k: v for k, v in packet.items() if k != "raw_provider_account_identifier_present"})
     required = {
         "schema": "stegverse.kv-skap.account-metadata-transfer/v1",
         "direction": "KNOWLEDGEVAULT_TO_SKAP_VAULT",
@@ -118,9 +116,36 @@ def build_intr_request(packet: dict[str, Any], *, request_id: str, authority_ref
         "requester": {"module": "KnowledgeVault", "component": "SKAPAccountMetadataTransfer"},
         "purpose": "Transfer owner-selected non-secret account metadata from KnowledgeVault to the internal SKAP Vault boundary.",
         "record_class": "SKAP_ACCOUNT_METADATA_TRANSFER",
-        "scope": ["provider_org_ref", "account_class", "account_status", "source_evidence_ref", "source_evidence_sha256"],
-        "disclosure_mode": "OPAQUE_REFERENCE_AND_HASH_ONLY",
+        "requested_scope": ["provider_org_ref", "account_class", "account_status", "source_evidence_ref", "source_evidence_sha256"],
+        "minimum_necessary_justification": "Only provider class/status and evidence references are required to establish an internal SKAP account binding without exporting provider identifiers or secrets.",
         "authority_ref": authority_ref,
-        "candidate": validated,
-        "destination": {"boundary": "SKAP_Vault", "operation": "SKAP_ACCOUNT_METADATA_ADMIT"},
+        "disclosure_mode": "SOURCE_REFERENCE_ONLY",
+        "candidate_writeback": {
+            "candidate_type": "SKAP_ACCOUNT_METADATA_TRANSFER",
+            "payload_ref": validated["payload_sha256"],
+            "requested_destination": "skap://internal/account-metadata"
+        }
     }
+
+
+def build_intr_boundary_envelope(packet: dict[str, Any], request: dict[str, Any], *, intr_receipt_ref: str | None = None) -> dict[str, Any]:
+    validated = validate_transfer_packet(packet)
+    if request.get("schema_version") != "kv.interlock.request.v1" or request.get("operation") != "COMMIT_CANDIDATE":
+        raise KVSKAPTransferError("invalid_kv_interlock_request")
+    if request.get("candidate_writeback", {}).get("payload_ref") != validated["payload_sha256"]:
+        raise KVSKAPTransferError("request_packet_binding_mismatch")
+    envelope = {
+        "schema": "stegverse.intr.boundary-transfer/v1",
+        "direction": "KNOWLEDGEVAULT_TO_SKAP_VAULT",
+        "source_boundary": "KnowledgeVault",
+        "destination_boundary": "SKAP_Vault",
+        "request_id": request["request_id"],
+        "request_sha256": sha256_uri(request),
+        "transfer_id": validated["transfer_id"],
+        "transfer_packet_sha256": sha256_uri(validated),
+        "payload_sha256": validated["payload_sha256"],
+        "intr_receipt_ref": intr_receipt_ref,
+        "canonical_state_changed": False,
+        "credential_material_transferred": False,
+    }
+    return envelope

--- a/runtime/kv_skap_account_transfer.py
+++ b/runtime/kv_skap_account_transfer.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any
+
+
+class KVSKAPTransferError(ValueError):
+    pass
+
+
+SECRET_TOKENS = (
+    "password", "secret", "token", "private_key", "access_key", "refresh_token",
+    "client_secret", "authorization", "cookie", "session_key", "account_id",
+    "provider_account_id", "raw_provider_account_identifier"
+)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_uri(value: Any) -> str:
+    raw = value if isinstance(value, str) else canonical_json(value)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _assert_no_secrets(value: Any, path: str = "packet") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lower = str(key).lower()
+            if any(token in lower for token in SECRET_TOKENS):
+                if lower == "raw_provider_account_identifier_present" and child is False:
+                    continue
+                raise KVSKAPTransferError(f"secret_or_raw_identifier_field_prohibited:{path}.{key}")
+            _assert_no_secrets(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for idx, child in enumerate(value):
+            _assert_no_secrets(child, f"{path}[{idx}]")
+
+
+def build_transfer_packet(*, owner_selection_ref: str, provider_org_ref: str,
+                          account_class: str, account_status: str,
+                          source_evidence_ref: str, source_evidence_sha256: str) -> dict[str, Any]:
+    payload = {
+        "owner_selection_ref": owner_selection_ref,
+        "provider_org_ref": provider_org_ref,
+        "account_class": account_class,
+        "account_status": account_status,
+        "source_evidence_ref": source_evidence_ref,
+        "source_evidence_sha256": source_evidence_sha256,
+    }
+    _assert_no_secrets(payload)
+    payload_hash = sha256_uri(payload)
+    transfer_id = "kvskap_" + hashlib.sha256((owner_selection_ref + "\n" + payload_hash).encode("utf-8")).hexdigest()[:24]
+    packet = {
+        "schema": "stegverse.kv-skap.account-metadata-transfer/v1",
+        "transfer_id": transfer_id,
+        "direction": "KNOWLEDGEVAULT_TO_SKAP_VAULT",
+        "source_boundary": "KnowledgeVault",
+        "destination_boundary": "SKAP_Vault",
+        **payload,
+        "payload_sha256": payload_hash,
+        "contains_secret_material": False,
+        "raw_provider_account_identifier_present": False,
+        "requested_transition": "SKAP_ACCOUNT_METADATA_ADMIT",
+    }
+    validate_transfer_packet(packet)
+    return packet
+
+
+def validate_transfer_packet(packet: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(packet, dict):
+        raise KVSKAPTransferError("packet_not_object")
+    _assert_no_secrets(packet)
+    required = {
+        "schema": "stegverse.kv-skap.account-metadata-transfer/v1",
+        "direction": "KNOWLEDGEVAULT_TO_SKAP_VAULT",
+        "source_boundary": "KnowledgeVault",
+        "destination_boundary": "SKAP_Vault",
+        "contains_secret_material": False,
+        "raw_provider_account_identifier_present": False,
+        "requested_transition": "SKAP_ACCOUNT_METADATA_ADMIT",
+    }
+    for key, expected in required.items():
+        if packet.get(key) != expected:
+            raise KVSKAPTransferError(f"invalid_{key}")
+    if packet.get("account_class") not in {"social", "financial", "identity", "email", "cloud", "other"}:
+        raise KVSKAPTransferError("invalid_account_class")
+    if packet.get("account_status") not in {"ACTIVE", "INACTIVE", "CLOSED", "UNKNOWN"}:
+        raise KVSKAPTransferError("invalid_account_status")
+    evidence_hash = str(packet.get("source_evidence_sha256") or "")
+    if not evidence_hash.startswith("sha256:") or len(evidence_hash) != 71:
+        raise KVSKAPTransferError("invalid_source_evidence_sha256")
+    projection = {
+        "owner_selection_ref": packet.get("owner_selection_ref"),
+        "provider_org_ref": packet.get("provider_org_ref"),
+        "account_class": packet.get("account_class"),
+        "account_status": packet.get("account_status"),
+        "source_evidence_ref": packet.get("source_evidence_ref"),
+        "source_evidence_sha256": evidence_hash,
+    }
+    if packet.get("payload_sha256") != sha256_uri(projection):
+        raise KVSKAPTransferError("payload_hash_mismatch")
+    expected_transfer_id = "kvskap_" + hashlib.sha256((str(packet.get("owner_selection_ref")) + "\n" + str(packet.get("payload_sha256"))).encode("utf-8")).hexdigest()[:24]
+    if packet.get("transfer_id") != expected_transfer_id:
+        raise KVSKAPTransferError("transfer_id_mismatch")
+    return deepcopy(packet)
+
+
+def build_intr_request(packet: dict[str, Any], *, request_id: str, authority_ref: str) -> dict[str, Any]:
+    validated = validate_transfer_packet(packet)
+    return {
+        "schema_version": "kv.interlock.request.v1",
+        "operation": "COMMIT_CANDIDATE",
+        "request_id": request_id,
+        "requester": {"module": "KnowledgeVault", "component": "SKAPAccountMetadataTransfer"},
+        "purpose": "Transfer owner-selected non-secret account metadata from KnowledgeVault to the internal SKAP Vault boundary.",
+        "record_class": "SKAP_ACCOUNT_METADATA_TRANSFER",
+        "scope": ["provider_org_ref", "account_class", "account_status", "source_evidence_ref", "source_evidence_sha256"],
+        "disclosure_mode": "OPAQUE_REFERENCE_AND_HASH_ONLY",
+        "authority_ref": authority_ref,
+        "candidate": validated,
+        "destination": {"boundary": "SKAP_Vault", "operation": "SKAP_ACCOUNT_METADATA_ADMIT"},
+    }

--- a/schemas/intr-boundary-transfer.schema.json
+++ b/schemas/intr-boundary-transfer.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/intr-boundary-transfer.schema.json",
+  "title":"Internal InTr Boundary Transfer Envelope",
+  "type":"object",
+  "additionalProperties":false,
+  "required":["schema","direction","source_boundary","destination_boundary","request_id","request_sha256","transfer_id","transfer_packet_sha256","payload_sha256","intr_receipt_ref","canonical_state_changed","credential_material_transferred"],
+  "properties":{
+    "schema":{"const":"stegverse.intr.boundary-transfer/v1"},
+    "direction":{"const":"KNOWLEDGEVAULT_TO_SKAP_VAULT"},
+    "source_boundary":{"const":"KnowledgeVault"},
+    "destination_boundary":{"const":"SKAP_Vault"},
+    "request_id":{"type":"string","minLength":1},
+    "request_sha256":{"type":"string","pattern":"^sha256:[a-f0-9]{64}$"},
+    "transfer_id":{"type":"string","pattern":"^kvskap_[a-f0-9]{24}$"},
+    "transfer_packet_sha256":{"type":"string","pattern":"^sha256:[a-f0-9]{64}$"},
+    "payload_sha256":{"type":"string","pattern":"^sha256:[a-f0-9]{64}$"},
+    "intr_receipt_ref":{"type":["string","null"]},
+    "canonical_state_changed":{"const":false},
+    "credential_material_transferred":{"const":false}
+  }
+}

--- a/schemas/kv-skap-account-metadata-transfer.schema.json
+++ b/schemas/kv-skap-account-metadata-transfer.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/kv-skap-account-metadata-transfer.schema.json",
+  "title": "KV to SKAP Account Metadata Transfer",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "transfer_id",
+    "direction",
+    "source_boundary",
+    "destination_boundary",
+    "owner_selection_ref",
+    "provider_org_ref",
+    "account_class",
+    "account_status",
+    "source_evidence_ref",
+    "source_evidence_sha256",
+    "payload_sha256",
+    "contains_secret_material",
+    "raw_provider_account_identifier_present",
+    "requested_transition"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.kv-skap.account-metadata-transfer/v1"},
+    "transfer_id": {"type": "string", "pattern": "^kvskap_[a-f0-9]{24}$"},
+    "direction": {"const": "KNOWLEDGEVAULT_TO_SKAP_VAULT"},
+    "source_boundary": {"const": "KnowledgeVault"},
+    "destination_boundary": {"const": "SKAP_Vault"},
+    "owner_selection_ref": {"type": "string", "minLength": 1, "maxLength": 256},
+    "provider_org_ref": {"type": "string", "pattern": "^org:[a-z0-9][a-z0-9._-]*$"},
+    "account_class": {"enum": ["social", "financial", "identity", "email", "cloud", "other"]},
+    "account_status": {"enum": ["ACTIVE", "INACTIVE", "CLOSED", "UNKNOWN"]},
+    "source_evidence_ref": {"type": "string", "minLength": 1, "maxLength": 512},
+    "source_evidence_sha256": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+    "payload_sha256": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+    "contains_secret_material": {"const": false},
+    "raw_provider_account_identifier_present": {"const": false},
+    "requested_transition": {"const": "SKAP_ACCOUNT_METADATA_ADMIT"}
+  }
+}

--- a/tests/test_kv_skap_account_transfer.py
+++ b/tests/test_kv_skap_account_transfer.py
@@ -1,0 +1,70 @@
+import copy
+import unittest
+
+from runtime.kv_skap_account_transfer import (
+    KVSKAPTransferError,
+    build_intr_boundary_envelope,
+    build_intr_request,
+    build_transfer_packet,
+)
+
+
+class KVSKAPAccountTransferTests(unittest.TestCase):
+    def packet(self):
+        return build_transfer_packet(
+            owner_selection_ref="kv://selection/abc123",
+            provider_org_ref="org:linkedin",
+            account_class="social",
+            account_status="ACTIVE",
+            source_evidence_ref="evidence://provider-observation/sha256-only",
+            source_evidence_sha256="sha256:" + "a" * 64,
+        )
+
+    def test_builds_nonsecret_owner_selected_packet(self):
+        packet = self.packet()
+        self.assertFalse(packet["contains_secret_material"])
+        self.assertFalse(packet["raw_provider_account_identifier_present"])
+        self.assertEqual(packet["destination_boundary"], "SKAP_Vault")
+        self.assertEqual(packet["requested_transition"], "SKAP_ACCOUNT_METADATA_ADMIT")
+
+    def test_interlock_request_uses_canonical_candidate_shape(self):
+        packet = self.packet()
+        req = build_intr_request(packet, request_id="REQ-1", authority_ref="intr://owner-selection/REQ-1")
+        self.assertEqual(req["schema_version"], "kv.interlock.request.v1")
+        self.assertEqual(req["operation"], "COMMIT_CANDIDATE")
+        self.assertEqual(req["disclosure_mode"], "SOURCE_REFERENCE_ONLY")
+        self.assertEqual(req["candidate_writeback"]["payload_ref"], packet["payload_sha256"])
+        self.assertEqual(req["candidate_writeback"]["requested_destination"], "skap://internal/account-metadata")
+
+    def test_boundary_envelope_binds_exact_request_and_packet(self):
+        packet = self.packet()
+        req = build_intr_request(packet, request_id="REQ-2", authority_ref="intr://owner-selection/REQ-2")
+        env = build_intr_boundary_envelope(packet, req)
+        self.assertEqual(env["direction"], "KNOWLEDGEVAULT_TO_SKAP_VAULT")
+        self.assertFalse(env["canonical_state_changed"])
+        self.assertFalse(env["credential_material_transferred"])
+        self.assertIsNone(env["intr_receipt_ref"])
+
+    def test_raw_provider_account_id_is_rejected(self):
+        packet = self.packet()
+        packet["provider_account_id"] = "123456"
+        with self.assertRaises(KVSKAPTransferError):
+            build_intr_request(packet, request_id="REQ-3", authority_ref="intr://owner-selection/REQ-3")
+
+    def test_payload_mutation_breaks_binding(self):
+        packet = self.packet()
+        packet["account_status"] = "INACTIVE"
+        with self.assertRaises(KVSKAPTransferError):
+            build_intr_request(packet, request_id="REQ-4", authority_ref="intr://owner-selection/REQ-4")
+
+    def test_request_packet_swap_rejected(self):
+        packet = self.packet()
+        req = build_intr_request(packet, request_id="REQ-5", authority_ref="intr://owner-selection/REQ-5")
+        other = copy.deepcopy(packet)
+        other["owner_selection_ref"] = "kv://selection/other"
+        with self.assertRaises(KVSKAPTransferError):
+            build_intr_boundary_envelope(other, req)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the missing governed seam for Goal Task SS-SKAP-AUTHENTIC-ACCOUNT-METADATA-POPULATION-001. Adds a bounded non-secret KV→SKAP account metadata packet, canonical KV-INTERLOCK-v1 candidate request binding, exact InTr boundary-transfer envelope, deterministic hash/replay guards, tests, protocol documentation, and handoff. This does not claim runtime SKAP admission; receiving-side TVC/SKAP validation and authentic owner-selected execution remain separate predicates.