### PR TITLE
Validate exact KV to SKAP account metadata wire vector

### DIFF
--- a/tests/fixtures/kv_skap_account_metadata_conformance_v1.json
+++ b/tests/fixtures/kv_skap_account_metadata_conformance_v1.json
@@ -1,0 +1,68 @@
+{
+  "intr_boundary_envelope": {
+    "canonical_state_changed": false,
+    "credential_material_transferred": false,
+    "destination_boundary": "SKAP_Vault",
+    "direction": "KNOWLEDGEVAULT_TO_SKAP_VAULT",
+    "intr_receipt_ref": null,
+    "payload_sha256": "sha256:f77c77ac19d5d70039de92d21989bbb7b48feac62663f461314bc120bfe46807",
+    "request_id": "KVSKAP-CONFORMANCE-001",
+    "request_sha256": "sha256:00e3da1080ad45b4dfe76081dc6e8cdfed5ae7c7c3c65ddb1697da9576201f27",
+    "schema": "stegverse.intr.boundary-transfer/v1",
+    "source_boundary": "KnowledgeVault",
+    "transfer_id": "kvskap_c8564db385394db07006317f",
+    "transfer_packet_sha256": "sha256:d2a76f6d30dc04d404f183e1113dda46b501d4c3870cd57223ebca99028e33d8"
+  },
+  "intr_receipt": {
+    "decision": "ADMITTED",
+    "payload_sha256": "sha256:f77c77ac19d5d70039de92d21989bbb7b48feac62663f461314bc120bfe46807",
+    "receipt_ref": "intr://receipt/KVSKAP-CONFORMANCE-001",
+    "request_sha256": "sha256:00e3da1080ad45b4dfe76081dc6e8cdfed5ae7c7c3c65ddb1697da9576201f27",
+    "transfer_packet_sha256": "sha256:d2a76f6d30dc04d404f183e1113dda46b501d4c3870cd57223ebca99028e33d8",
+    "transition": "SKAP_ACCOUNT_METADATA_ADMIT"
+  },
+  "kv_interlock_request": {
+    "authority_ref": "owner://conformance",
+    "candidate_writeback": {
+      "candidate_type": "SKAP_ACCOUNT_METADATA_TRANSFER",
+      "payload_ref": "sha256:f77c77ac19d5d70039de92d21989bbb7b48feac62663f461314bc120bfe46807",
+      "requested_destination": "skap://internal/account-metadata"
+    },
+    "disclosure_mode": "SOURCE_REFERENCE_ONLY",
+    "minimum_necessary_justification": "Only provider class/status and evidence references are required to establish an internal SKAP account binding without exporting provider identifiers or secrets.",
+    "operation": "COMMIT_CANDIDATE",
+    "purpose": "Transfer owner-selected non-secret account metadata from KnowledgeVault to the internal SKAP Vault boundary.",
+    "record_class": "SKAP_ACCOUNT_METADATA_TRANSFER",
+    "request_id": "KVSKAP-CONFORMANCE-001",
+    "requested_scope": [
+      "provider_org_ref",
+      "account_class",
+      "account_status",
+      "source_evidence_ref",
+      "source_evidence_sha256"
+    ],
+    "requester": {
+      "component": "SKAPAccountMetadataTransfer",
+      "module": "KnowledgeVault"
+    },
+    "schema_version": "kv.interlock.request.v1"
+  },
+  "packet": {
+    "account_class": "social",
+    "account_status": "ACTIVE",
+    "contains_secret_material": false,
+    "destination_boundary": "SKAP_Vault",
+    "direction": "KNOWLEDGEVAULT_TO_SKAP_VAULT",
+    "owner_selection_ref": "kv://selection/conformance-linkedin-001",
+    "payload_sha256": "sha256:f77c77ac19d5d70039de92d21989bbb7b48feac62663f461314bc120bfe46807",
+    "provider_org_ref": "org:linkedin",
+    "raw_provider_account_identifier_present": false,
+    "requested_transition": "SKAP_ACCOUNT_METADATA_ADMIT",
+    "schema": "stegverse.kv-skap.account-metadata-transfer/v1",
+    "source_boundary": "KnowledgeVault",
+    "source_evidence_ref": "evidence://provider-observation/conformance-linkedin-001",
+    "source_evidence_sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "transfer_id": "kvskap_c8564db385394db07006317f"
+  },
+  "schema": "stegverse.kv-skap.account-metadata-conformance-vector/v1"
+}

--- a/tests/test_kv_skap_account_transfer.py
+++ b/tests/test_kv_skap_account_transfer.py
@@ -1,5 +1,7 @@
 import copy
+import json
 import unittest
+from pathlib import Path
 
 from runtime.kv_skap_account_transfer import (
     KVSKAPTransferError,
@@ -7,6 +9,9 @@ from runtime.kv_skap_account_transfer import (
     build_intr_request,
     build_transfer_packet,
 )
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "kv_skap_account_metadata_conformance_v1.json"
 
 
 class KVSKAPAccountTransferTests(unittest.TestCase):
@@ -64,6 +69,26 @@ class KVSKAPAccountTransferTests(unittest.TestCase):
         other["owner_selection_ref"] = "kv://selection/other"
         with self.assertRaises(KVSKAPTransferError):
             build_intr_boundary_envelope(other, req)
+
+    def test_shared_conformance_vector_is_exact_producer_output(self):
+        vector = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        packet = build_transfer_packet(
+            owner_selection_ref="kv://selection/conformance-linkedin-001",
+            provider_org_ref="org:linkedin",
+            account_class="social",
+            account_status="ACTIVE",
+            source_evidence_ref="evidence://provider-observation/conformance-linkedin-001",
+            source_evidence_sha256="sha256:" + "a" * 64,
+        )
+        self.assertEqual(packet, vector["packet"])
+        request = build_intr_request(
+            packet,
+            request_id="KVSKAP-CONFORMANCE-001",
+            authority_ref="owner://conformance",
+        )
+        self.assertEqual(request, vector["kv_interlock_request"])
+        envelope = build_intr_boundary_envelope(packet, request)
+        self.assertEqual(envelope, vector["intr_boundary_envelope"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds one shared deterministic conformance vector for SS-SKAP-AUTHENTIC-ACCOUNT-METADATA-POPULATION-001 and requires the merged CVK producer to regenerate its packet, canonical KV Interlock request, and KV→SKAP InTr boundary envelope byte-for-byte. The same vector is consumed by TVC PR #374. This validates cross-repository wire compatibility without claiming live SKAP admission.