### PR TITLE
Preserve recovered cloud KV identity during KV2 materialization

### DIFF
--- a/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
+++ b/KV_MULTI_INSTANCE_COSV_BINDING_MIRROR_HANDOFF.md
@@ -1,9 +1,9 @@
 # KV Multi-Instance COSV Binding Mirror Handoff
 
-Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MERGED / MYKV_PROJECTION_MERGED / STORAGE_PROVIDER_ADAPTERS_MERGED / PROVIDER_OPERATION_STATE_MERGED / MYKV_PROVIDER_STATUS_MERGED / DEVICE_LOCAL_KV_OWNER_OBSERVED / GOOGLE_DRIVE_EXISTING_PEER_EXACT_EVIDENCE_RECOVERED / GOOGLE_DRIVE_KV2_OWNER_REQUEST_INGRESS_OBSERVED / KV2_ADOPTION_PROVIDER_BINDING_IMPLEMENTED / HOSTED_VALIDATION_PENDING / GOOGLE_DRIVE_CONNECT_VERIFY_EXECUTION_PENDING / KV2_MATERIALIZATION_PENDING
+Status: SOURCE_MULTI_INSTANCE_MERGED / RELATIONSHIP_STATE_MERGED / MYKV_PROJECTION_MERGED / STORAGE_PROVIDER_ADAPTERS_MERGED / PROVIDER_OPERATION_STATE_MERGED / DEVICE_LOCAL_KV_OWNER_OBSERVED / GOOGLE_DRIVE_EXISTING_PEER_EXACT_EVIDENCE_RECOVERED / GOOGLE_DRIVE_KV2_OWNER_REQUEST_INGRESS_OBSERVED / KV2_ADOPTION_PROVIDER_BINDING_MERGED / IDENTITY_PRESERVING_KV2_MATERIALIZER_IMPLEMENTED_AWAITING_VALIDATION / GOOGLE_DRIVE_CONNECT_VERIFY_EXECUTION_PENDING / KV2_RUNTIME_MATERIALIZATION_PENDING
 Repository: `StegVerse-Labs/continuity-vault-kit`
-Branch: `kv2-adoption-provider-binding-20260908`
-Updated: 2026-09-08
+Branch: `skap-kv-device-roundtrip-001`
+Updated: 2026-09-10
 Authority effect: NONE
 Activation effect: false
 
@@ -14,131 +14,50 @@ GOAL TASK ID: KV-CONNECTION-REVALIDATION-WORKER-001
 COSV ID: 50000000102000
 CANONICAL COSV HANDOFF: StegVerse-Labs/.github/KV_CONNECTION_REVALIDATION_COSV_MIRROR_HANDOFF.md
 CANONICAL OWNER REPOSITORY: StegVerse-Labs/continuity-vault-kit
-REPOSITORY HANDOFF: CONTINUITY_VAULT_KIT_MIRROR_HANDOFF.md
 ```
 
-## Merged capability baseline
+## Proven baseline
 
-- PR #196: KV #1/#2/#n identity roots and four relationship tiers.
-- PR #197: durable governed relationship state.
-- PR #198: bounded MyKV multi-instance projection.
-- PR #199: provider-neutral iCloud Drive / Google Drive / OneDrive / Dropbox request adapters.
-- PR #200: durable provider-operation state gated by admitted Interlock/InTr evidence, SKAP credential reference, and provider-result evidence.
-- PR #201: plural provider status projection.
-- PR #203: non-destructive existing-KV adoption source.
-- PR #204: exact physical Google Drive adoption evidence.
-- Site PRs #1115/#1116: first-class device-local resident KV plus cloud-peer request surfaces.
-- Site PR #1122: prepared Google Drive KV #2 resident adoption transport.
-- Site PR #1124: legacy current-device Node compatibility repair.
-- Site PR #1127: authentic owner retry reconciliation.
-- `.github` PR #1209: canonical COSV reconciliation of authentic resident ingress.
+- Multi-instance identity, relationship tiers, MyKV projection, provider adapters, provider-operation state, and existing-KV adoption source are merged.
+- Current iPhone resident KV #1 remains `kvi_0d5d4cfd531db51bbcf7fdfc0311f5dc` with exact local readback and BEST_EFFORT_BROWSER_ORIGIN durability.
+- Existing Google Drive cloud vault remains exact-byte identified as `kvi_a31335d2cc3745fa987b635432cfed2c`.
+- Authentic owner request `SITE-CLOUD-KV-4347408852127319cbda574f02e03edb` reached resident ingress but has not executed Google Drive, materialized KV #2, or changed relationship state.
+- PR #205 merged the provider-binding source that creates canonical CONNECT and VERIFY requests and requires admitted Interlock/InTr + SKAP-reference + provider-result evidence before readiness.
 
-## Authentic current-device resident KV
+## Identity-preserving KV #2 materialization
 
-Owner-visible deployed Site evidence:
+`runtime/cloud_peer_set_membership_materialization.py` closes the source gap left by the generic existing-KV adoption tool. The generic tool creates a new `kvi_...` identity and therefore MUST NOT be used for the recovered Google Drive vault.
+
+The new materializer consumes only `materialization_ready=true` evidence after both CONNECT and VERIFY are admitted. It requires:
 
 ```text
-resident instance: KV #1
-instance_id: kvi_0d5d4cfd531db51bbcf7fdfc0311f5dc
-kv_set_id: personal
-storage: device-local-browser-indexeddb
-relationship: NOT_CONNECTED
-exact_readback: true
-durability: BEST_EFFORT_BROWSER_ORIGIN
+existing_cloud_instance_id = kvi_a31335d2cc3745fa987b635432cfed2c
+requested_instance_number = 2
+materialization_mode = SET_MEMBERSHIP_ORDINAL_BINDING_PRESERVE_CLOUD_IDENTITY
+cloud_identity_rewrite_required = false
+private_content_rewrite_authorized = false
+relationship_tier_after_materialization = NOT_CONNECTED
+credential_material_present = false
 ```
 
-## Existing Google Drive cloud KV evidence
+It refuses ordinal collisions, cross-set or cross-ordinal identity reuse, missing CONNECT/VERIFY receipt references, premature readiness, credential material, and identity/private-content rewrite semantics. Output preserves the existing cloud identity and binds only set membership/ordinal; it grants no relationship, provider, transport, credential, or activation authority.
 
-```text
-existing cloud instance_id: kvi_a31335d2cc3745fa987b635432cfed2c
-historical cloud ordinal: KV #1
-requested peer ordinal: KV #2
-relationship: NOT_CONNECTED
-installation receipt: sha256:f00378cd1f68e08a39c837f2a80e7e105e822a321c0eea17a91318b4b6e5ea19
-instance record: sha256:8bf5ba7d911a52506a582f064315c9831a84c0c5fbb6ec7a031c325a79af090a
-adoption receipt: sha256:64a3af27be0bd6ae36b05b35e52894581413fff048cea237d370d0ec6248b552
-set projection: sha256:187ab43f0bb09d88da154af26d57e1bfe7199fd90affd2dd81af5532f0e34cf4
-```
+Tests: `tests/test_cloud_peer_set_membership_materialization.py` cover identity preservation, not-ready refusal, KV #2 ordinal collision, rewrite refusal, and mutation/digest verification.
 
-The cloud instance identity and private content must be preserved; KV #2 is a set-membership ordinal binding, not a destructive cloud identity rewrite.
+## README maintenance determination
 
-## Authentic Google Drive KV #2 adoption request ingress
+Root README was reviewed on current main. No wording change is required for this internal materializer because the README already establishes all repository-level semantics changed/consumed here: KV numbering is not authority, identities remain separately rooted, relationship transitions require Interlock/InTr, provider requests require SKAP references and admitted evidence, and provider-operation state cannot infer execution. This handoff records the new implementation-specific identity-preserving materialization contract.
 
-The current iPhone emitted:
+## Remaining end-to-end sequence
 
-```text
-request_id: SITE-CLOUD-KV-4347408852127319cbda574f02e03edb
-governance_state: PENDING_INTERLOCK_INTR
-resident_ingress_observed: true
-requested: KV #2
-instance_materialized: false
-provider_operation_authorized: false
-```
-
-No provider execution, relationship mutation, data movement, replication, AI-corpus exposure, credential material, authority effect, or activation is inferred from that ingress result.
-
-## Current source slice — adoption to provider execution binding
-
-`runtime/cloud_peer_adoption_provider_binding.py` converts the authentic resident adoption request into canonical Google Drive `CONNECT` and `VERIFY` requests through the existing storage-provider adapter. It requires a private runtime storage locator but does not publish that locator or raw credential material.
-
-The resulting provider requests remain:
-
-```text
-governance_state=PENDING_INTERLOCK_INTR
-skap_credential_ref_required=true
-provider_operation_executed=false
-data_moved=false
-replication_started=false
-authority_effect=NONE
-activation_effect=false
-```
-
-Materialization readiness remains false until both Google Drive `CONNECT` and `VERIFY` receipts prove all of:
-
-```text
-governance_state=ADMITTED
-provider_operation_executed=true
-interlock_receipt_ref=<non-empty>
-intr_receipt_ref=<non-empty>
-skap_credential_ref=<non-empty reference only>
-provider_result_ref=<non-empty>
-credential_material_present=false
-authority_effect=NONE
-```
-
-When those two admitted results exist, readiness may become true using:
-
-```text
-materialization_mode=SET_MEMBERSHIP_ORDINAL_BINDING_PRESERVE_CLOUD_IDENTITY
-requested_instance_number=2
-cloud_identity_rewrite_required=false
-private_content_rewrite_authorized=false
-relationship_tier_after_materialization=NOT_CONNECTED
-```
-
-The readiness function does not itself materialize KV #2.
-
-## Canonical relationship tiers
-
-```text
-NOT_CONNECTED  -> no inter-comms, movement, replication, or unified AI corpus
-CONNECTED      -> inter-comms + admitted movement; no replication/unified AI corpus
-SYNCED         -> inter-comms + movement + replication; no unified AI corpus
-AI_INTERACTION -> inter-comms + movement + replication + admitted logical unified AI corpus
-```
-
-## Remaining sequence
-
-1. Run exact-head validation for this adoption→provider binding slice and repair failures.
-2. Merge source only after all required checks pass.
-3. Resolve the Google Drive credential through SKAP as a reference; never copy credential material into Site/ordinary KV/evidence.
-4. Submit canonical Google Drive `CONNECT` through authentic Interlock/InTr and retain its receipts/provider result.
-5. Submit canonical Google Drive `VERIFY` through authentic Interlock/InTr and retain its receipts/provider result.
-6. Apply those already-admitted results to the provider-operation store.
-7. Re-evaluate materialization readiness; only if true, materialize the existing cloud instance into the `personal` set as KV #2 without rewriting its cloud identity/private content.
-8. Refresh MyKV projection/readback and then test CONNECTED/SYNCED/AI_INTERACTION progression and recovery separately.
-9. Add iCloud/new cloud KV #3/#n only after the existing Google Drive peer path is proven.
+1. Validate and merge the identity-preserving materializer.
+2. Complete the existing TVC/Service-Gateway query-secret-safe callback prerequisite before Google owner-consent execution.
+3. Execute authentic owner consent inside TV/TVC/SKAP; never expose credential plaintext to Site, ordinary KV, repositories, logs, argv, or environment.
+4. Execute canonical Google Drive CONNECT and VERIFY through Interlock/InTr and retain exact provider-result evidence.
+5. Re-evaluate readiness and bind the existing cloud identity into `personal` as KV #2 without rewriting cloud identity/private content.
+6. Return the result through SKAP -> KV -> current StegOS Device and require the canonical four-leg roundtrip proof plus exact device-side readback.
+7. Only after authentic roundtrip evidence may the lane be called runtime-functional.
 
 ## Manual work
 
-None required while this source slice validates. Do not tap the adoption button again, authorize Google Drive, clear Safari data, reinstall the resident KV, or create KV #3 yet.
+None now. Do not repeat the adoption request, authorize Google Drive, clear Safari/stegverse.org data, reinstall KV, or create KV #3 until the callback safety prerequisite and downstream provider execution lane are ready.

--- a/runtime/cloud_peer_set_membership_materialization.py
+++ b/runtime/cloud_peer_set_membership_materialization.py
@@ -1,0 +1,102 @@
+"""Materialize an already-existing cloud KnowledgeVault into a KV set without changing its identity.
+
+This consumes only already-admitted provider-operation evidence. It never authenticates
+a provider, resolves SKAP plaintext, executes Google Drive, rewrites cloud content, or
+grants relationship/transport authority.
+"""
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+from typing import Any, Mapping, Sequence
+
+READINESS_SCHEMA = "stegverse.kv.cloud-peer-adoption-materialization-readiness/v1"
+MATERIALIZATION_SCHEMA = "stegverse.kv.cloud-peer-set-membership-materialization/v1"
+
+class CloudPeerSetMembershipMaterializationError(ValueError):
+    pass
+
+
+def _require(condition: bool, reason: str) -> None:
+    if not condition:
+        raise CloudPeerSetMembershipMaterializationError(reason)
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    raw=json.dumps(value,sort_keys=True,separators=(",",":"),ensure_ascii=False).encode("utf-8")
+    return "sha256:"+sha256(raw).hexdigest()
+
+
+def materialize_existing_cloud_peer(
+    *,
+    readiness: Mapping[str, Any],
+    expected_existing_instance_id: str,
+    kv_set_id: str,
+    existing_instances: Sequence[Mapping[str, Any]],
+    connect_receipt_ref: str,
+    verify_receipt_ref: str,
+) -> dict[str, Any]:
+    _require(readiness.get("schema")==READINESS_SCHEMA,"readiness_schema_invalid")
+    _require(readiness.get("materialization_ready") is True,"materialization_not_ready")
+    _require(readiness.get("provider_connect_verified") is True,"provider_connect_verify_not_proven")
+    _require(readiness.get("provider_id")=="google-drive","provider_mismatch")
+    _require(readiness.get("existing_cloud_instance_id")==expected_existing_instance_id,"existing_cloud_identity_mismatch")
+    _require(isinstance(expected_existing_instance_id,str) and expected_existing_instance_id.startswith("kvi_"),"existing_cloud_identity_invalid")
+    _require(readiness.get("requested_instance_number")==2,"requested_instance_number_invalid")
+    _require(readiness.get("materialization_mode")=="SET_MEMBERSHIP_ORDINAL_BINDING_PRESERVE_CLOUD_IDENTITY","materialization_mode_invalid")
+    _require(readiness.get("cloud_identity_rewrite_required") is False,"cloud_identity_rewrite_forbidden")
+    _require(readiness.get("private_content_rewrite_authorized") is False,"private_content_rewrite_forbidden")
+    _require(readiness.get("relationship_tier_after_materialization")=="NOT_CONNECTED","initial_relationship_must_remain_not_connected")
+    _require(readiness.get("credential_material_present") is False,"credential_material_forbidden")
+    _require(readiness.get("authority_effect")=="NONE_READINESS_ONLY","readiness_authority_drift")
+    _require(isinstance(kv_set_id,str) and bool(kv_set_id.strip()),"kv_set_id_required")
+    _require(isinstance(connect_receipt_ref,str) and bool(connect_receipt_ref.strip()),"connect_receipt_ref_required")
+    _require(isinstance(verify_receipt_ref,str) and bool(verify_receipt_ref.strip()),"verify_receipt_ref_required")
+
+    for row in existing_instances:
+        _require(isinstance(row,Mapping),"existing_instance_record_invalid")
+        if row.get("kv_set_id")==kv_set_id and row.get("instance_number")==2 and row.get("instance_id")!=expected_existing_instance_id:
+            raise CloudPeerSetMembershipMaterializationError("kv2_ordinal_collision")
+        if row.get("instance_id")==expected_existing_instance_id:
+            _require(row.get("instance_number") in (None,2),"existing_cloud_identity_bound_to_other_ordinal")
+            _require(row.get("kv_set_id") in (None,kv_set_id),"existing_cloud_identity_bound_to_other_set")
+
+    body={
+        "schema":MATERIALIZATION_SCHEMA,
+        "state":"EXISTING_CLOUD_PEER_BOUND_TO_KV_SET",
+        "provider_id":"google-drive",
+        "instance_id":expected_existing_instance_id,
+        "instance_number":2,
+        "logical_name":"KV #2",
+        "kv_set_id":kv_set_id.strip(),
+        "set_membership":"PEER",
+        "relationship_tier":"NOT_CONNECTED",
+        "cloud_identity_preserved":True,
+        "cloud_identity_rewritten":False,
+        "private_content_rewritten":False,
+        "provider_connect_verified":True,
+        "connect_receipt_ref":connect_receipt_ref,
+        "verify_receipt_ref":verify_receipt_ref,
+        "credential_material_present":False,
+        "relationship_mutation_authorized":False,
+        "data_moved":False,
+        "replication_started":False,
+        "ai_corpus_exposed":False,
+        "credential_authority":"TV/TVC",
+        "authority_effect":"NONE_SET_MEMBERSHIP_BINDING_ONLY",
+        "activation_effect":False,
+    }
+    return {**body,"materialization_sha256":_digest(body)}
+
+
+def verify_materialization(value: Mapping[str, Any]) -> None:
+    _require(value.get("schema")==MATERIALIZATION_SCHEMA,"materialization_schema_invalid")
+    _require(value.get("state")=="EXISTING_CLOUD_PEER_BOUND_TO_KV_SET","materialization_state_invalid")
+    _require(value.get("cloud_identity_preserved") is True and value.get("cloud_identity_rewritten") is False,"cloud_identity_preservation_invalid")
+    _require(value.get("private_content_rewritten") is False,"private_content_rewrite_detected")
+    _require(value.get("relationship_tier")=="NOT_CONNECTED","relationship_tier_invalid")
+    _require(value.get("credential_material_present") is False,"credential_material_forbidden")
+    _require(value.get("credential_authority")=="TV/TVC","credential_authority_invalid")
+    _require(value.get("authority_effect")=="NONE_SET_MEMBERSHIP_BINDING_ONLY" and value.get("activation_effect") is False,"materialization_authority_drift")
+    body=dict(value); claimed=body.pop("materialization_sha256",None)
+    _require(claimed==_digest(body),"materialization_digest_mismatch")

--- a/tests/test_cloud_peer_set_membership_materialization.py
+++ b/tests/test_cloud_peer_set_membership_materialization.py
@@ -1,0 +1,65 @@
+from copy import deepcopy
+import pytest
+
+from runtime.cloud_peer_set_membership_materialization import (
+    CloudPeerSetMembershipMaterializationError,
+    materialize_existing_cloud_peer,
+    verify_materialization,
+)
+
+CLOUD="kvi_a31335d2cc3745fa987b635432cfed2c"
+
+
+def readiness():
+    return {
+        "schema":"stegverse.kv.cloud-peer-adoption-materialization-readiness/v1",
+        "source_site_request_id":"SITE-CLOUD-KV-4347408852127319cbda574f02e03edb",
+        "existing_cloud_instance_id":CLOUD,
+        "requested_instance_number":2,
+        "requested_logical_name":"KV #2",
+        "provider_id":"google-drive",
+        "provider_connect_verified":True,
+        "materialization_ready":True,
+        "materialization_mode":"SET_MEMBERSHIP_ORDINAL_BINDING_PRESERVE_CLOUD_IDENTITY",
+        "cloud_identity_rewrite_required":False,
+        "private_content_rewrite_authorized":False,
+        "relationship_tier_after_materialization":"NOT_CONNECTED",
+        "missing_evidence":[],
+        "credential_material_present":False,
+        "authority_effect":"NONE_READINESS_ONLY",
+        "activation_effect":False,
+    }
+
+
+def test_preserves_existing_cloud_identity_and_ordinal():
+    value=materialize_existing_cloud_peer(readiness=readiness(),expected_existing_instance_id=CLOUD,kv_set_id="personal",existing_instances=[{"instance_id":"kvi_device","instance_number":1,"kv_set_id":"personal"}],connect_receipt_ref="receipt://connect",verify_receipt_ref="receipt://verify")
+    assert value["instance_id"]==CLOUD
+    assert value["instance_number"]==2
+    assert value["cloud_identity_preserved"] is True
+    assert value["relationship_tier"]=="NOT_CONNECTED"
+    assert value["credential_material_present"] is False
+    verify_materialization(value)
+
+
+def test_refuses_before_connect_and_verify_are_admitted():
+    r=readiness(); r["materialization_ready"]=False
+    with pytest.raises(CloudPeerSetMembershipMaterializationError,match="materialization_not_ready"):
+        materialize_existing_cloud_peer(readiness=r,expected_existing_instance_id=CLOUD,kv_set_id="personal",existing_instances=[],connect_receipt_ref="receipt://connect",verify_receipt_ref="receipt://verify")
+
+
+def test_refuses_kv2_ordinal_collision():
+    with pytest.raises(CloudPeerSetMembershipMaterializationError,match="kv2_ordinal_collision"):
+        materialize_existing_cloud_peer(readiness=readiness(),expected_existing_instance_id=CLOUD,kv_set_id="personal",existing_instances=[{"instance_id":"kvi_other","instance_number":2,"kv_set_id":"personal"}],connect_receipt_ref="receipt://connect",verify_receipt_ref="receipt://verify")
+
+
+def test_refuses_cloud_identity_rewrite_semantics():
+    r=readiness(); r["cloud_identity_rewrite_required"]=True
+    with pytest.raises(CloudPeerSetMembershipMaterializationError,match="cloud_identity_rewrite_forbidden"):
+        materialize_existing_cloud_peer(readiness=r,expected_existing_instance_id=CLOUD,kv_set_id="personal",existing_instances=[],connect_receipt_ref="receipt://connect",verify_receipt_ref="receipt://verify")
+
+
+def test_verifier_rejects_mutated_materialization():
+    value=materialize_existing_cloud_peer(readiness=readiness(),expected_existing_instance_id=CLOUD,kv_set_id="personal",existing_instances=[],connect_receipt_ref="receipt://connect",verify_receipt_ref="receipt://verify")
+    mutated=deepcopy(value); mutated["instance_number"]=3
+    with pytest.raises(CloudPeerSetMembershipMaterializationError,match="materialization_digest_mismatch"):
+        verify_materialization(mutated)


### PR DESCRIPTION
Continues KV-CONNECTION-REVALIDATION-WORKER-001. Adds the missing post-CONNECT/VERIFY materialization gate for the recovered Google Drive KnowledgeVault. The implementation consumes only already-admitted readiness, preserves the existing kvi_ identity, binds it as KV #2 in the personal set, rejects ordinal/identity collisions and rewrite semantics, and contains no credential/provider execution authority. Root README was reviewed and already states the governing identity/authority/provider-admission semantics; implementation-specific behavior is maintained in the canonical repository handoff.