### PR TITLE
Bind Task Registry event custody to governed KV WRITE path

### DIFF
--- a/docs/TASK_REGISTRY_SOVEREIGN_KV_EVENT_CUSTODY_MIRROR_HANDOFF.md
+++ b/docs/TASK_REGISTRY_SOVEREIGN_KV_EVENT_CUSTODY_MIRROR_HANDOFF.md
@@ -1,0 +1,28 @@
+# Task Registry Sovereign KV Event Custody Mirror Handoff
+
+Goal Task ID: `TASK-REGISTRY-SOVEREIGN-KV-EVENT-CUSTODY-001`
+Canonical parent handoff: `StegVerse-Labs/.github/docs/TASK_REGISTRY_SOVEREIGN_KV_EVENT_CUSTODY_MIRROR_HANDOFF.md`
+Status: `ACTIVE / CROSS-REPO PROVIDER WRITE BINDING IMPLEMENTED / AUTHENTIC ADMITTED WRITE + READBACK PENDING`
+
+## Purpose
+Bind the canonical Task Registry sovereign-KV projection request to the existing continuity-vault-kit provider-neutral storage operation contract instead of creating a parallel provider stack.
+
+## Implemented
+- `runtime/task_registry_event_sovereign_kv_binding.py`
+- `tests/test_task_registry_event_sovereign_kv_binding.py`
+
+The binding consumes `stegverse.task-registry-sovereign-kv-projection-request/v1`, preserves the exact Task Registry event hash, resolves the existing provider adapter from `runtime/kv_storage_provider_adapter.py`, and builds the canonical `stegverse.kv.storage-provider-operation-request/v1` with `operation=WRITE`, `governance_state=PENDING_INTERLOCK_INTR`, `skap_credential_ref_required=true`, no credential material, and `object_ref` equal to the exact Task Registry event SHA-256.
+
+The result validator accepts only an admitted/executed `stegverse.kv.storage-provider-operation-receipt/v1` with Interlock, InTr, SKAP, and provider-result references, plus exact stored-event SHA-256 readback. Only then does it emit the `.github` bridge-compatible `stegverse.task-registry-sovereign-kv-projection-receipt/v1`.
+
+## Authority boundaries
+This binding does not authenticate providers, resolve credentials, decide Interlock/InTr admission, execute provider I/O, or grant authority. WorkerCoordinator, Interlock/InTr, TV/TVC, Master Records, and HB authority boundaries remain unchanged.
+
+## Remaining
+1. validate this branch and PR;
+2. bind an admitted provider WRITE receipt produced by the existing runtime path;
+3. obtain exact stored-event hash readback from the target sovereign KV instance;
+4. feed that receipt to `.github/scripts/project_task_registry_event_to_sovereign_kv.py` and close the parent unresolved predicate only after exact-hash custody is observed.
+
+## Manual work
+None.

--- a/runtime/task_registry_event_sovereign_kv_binding.py
+++ b/runtime/task_registry_event_sovereign_kv_binding.py
@@ -1,0 +1,122 @@
+"""Bind canonical Task Registry event custody to the existing governed KV provider path.
+
+This module does not authenticate providers, resolve credentials, decide Interlock/InTr
+admission, execute provider I/O, or grant authority. It converts an already-validated
+Task Registry sovereign-KV projection request into the canonical provider-neutral
+WRITE request used by continuity-vault-kit and validates the resulting admitted
+provider receipt against the exact event hash.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from runtime.kv_storage_provider_adapter import build_operation_request, default_registry
+
+PROJECTION_REQUEST_SCHEMA = "stegverse.task-registry-sovereign-kv-projection-request/v1"
+PROJECTION_RECEIPT_SCHEMA = "stegverse.task-registry-sovereign-kv-projection-receipt/v1"
+PROVIDER_RECEIPT_SCHEMA = "stegverse.kv.storage-provider-operation-receipt/v1"
+BINDING_SCHEMA = "stegverse.kv.task-registry-event-custody-binding/v1"
+CUSTODY_CLASS = "STEGVERSE_SOVEREIGN_KV"
+
+
+class TaskRegistryEventCustodyBindingError(ValueError):
+    pass
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise TaskRegistryEventCustodyBindingError(message)
+
+
+def build_task_registry_event_custody_binding(
+    *,
+    projection_request: Dict[str, Any],
+    provider_id: str,
+    instance_id: str,
+    kv_set_id: str,
+    storage_locator: str | None = None,
+) -> Dict[str, Any]:
+    _require(projection_request.get("schema") == PROJECTION_REQUEST_SCHEMA, "unexpected projection request schema")
+    _require(projection_request.get("custody_class") == CUSTODY_CLASS, "unexpected custody class")
+    _require(projection_request.get("authority_effect") == "NONE", "projection request cannot grant authority")
+    event = projection_request.get("exact_event")
+    _require(isinstance(event, dict), "exact_event required")
+    event_sha256 = projection_request.get("event_sha256")
+    _require(isinstance(event_sha256, str) and event_sha256.startswith("sha256:"), "event_sha256 required")
+    _require(event.get("event_sha256") == event_sha256, "exact_event hash binding mismatch")
+    _require(event.get("authority_effect") == "NONE", "exact event cannot grant authority")
+
+    adapter = default_registry().get(provider_id)
+    provider_write_request = build_operation_request(
+        adapter=adapter,
+        instance_id=instance_id,
+        kv_set_id=kv_set_id,
+        operation="WRITE",
+        storage_locator=storage_locator,
+        requested_by="task-registry-coordination",
+        object_ref=event_sha256,
+    )
+
+    return {
+        "schema": BINDING_SCHEMA,
+        "task_id": projection_request.get("task_id"),
+        "session_id": projection_request.get("session_id"),
+        "event_sha256": event_sha256,
+        "predecessor_event_sha256": projection_request.get("predecessor_event_sha256"),
+        "custody_class": CUSTODY_CLASS,
+        "provider_id": provider_id,
+        "kv_instance_ref": instance_id,
+        "kv_set_id": kv_set_id,
+        "provider_write_request": provider_write_request,
+        "interlock_intr_admission_required": True,
+        "skap_credential_reference_required": True,
+        "provider_result_evidence_required": True,
+        "exact_hash_readback_required": True,
+        "credential_material_present": False,
+        "authority_effect": "NONE",
+    }
+
+
+def validate_task_registry_event_custody_result(
+    *,
+    binding: Dict[str, Any],
+    provider_receipt: Dict[str, Any],
+    stored_event_sha256: str,
+) -> Dict[str, Any]:
+    _require(binding.get("schema") == BINDING_SCHEMA, "unexpected custody binding schema")
+    request = binding.get("provider_write_request")
+    _require(isinstance(request, dict), "provider write request required")
+    _require(provider_receipt.get("schema") == PROVIDER_RECEIPT_SCHEMA, "provider receipt schema mismatch")
+    _require(provider_receipt.get("request_id") == request.get("request_id"), "provider receipt request mismatch")
+    _require(provider_receipt.get("instance_id") == request.get("instance_id"), "provider receipt instance mismatch")
+    _require(provider_receipt.get("kv_set_id") == request.get("kv_set_id"), "provider receipt set mismatch")
+    _require(provider_receipt.get("provider_id") == request.get("provider_id"), "provider receipt provider mismatch")
+    _require(provider_receipt.get("operation") == "WRITE", "provider receipt must prove WRITE")
+    _require(provider_receipt.get("governance_state") == "ADMITTED", "provider WRITE requires ADMITTED governance")
+    _require(provider_receipt.get("provider_operation_executed") is True, "provider WRITE execution evidence required")
+    _require(bool(str(provider_receipt.get("interlock_receipt_ref") or "").strip()), "Interlock receipt required")
+    _require(bool(str(provider_receipt.get("intr_receipt_ref") or "").strip()), "InTr receipt required")
+    _require(bool(str(provider_receipt.get("skap_credential_ref") or "").strip()), "SKAP credential reference required")
+    _require(bool(str(provider_receipt.get("provider_result_ref") or "").strip()), "provider result evidence required")
+    _require(provider_receipt.get("credential_material_present") is False, "credential material prohibited")
+    _require(provider_receipt.get("authority_effect") == "NONE", "provider receipt cannot grant authority")
+    _require(request.get("object_ref") == binding.get("event_sha256"), "provider request object_ref must bind exact event hash")
+    _require(stored_event_sha256 == binding.get("event_sha256"), "stored event hash readback mismatch")
+
+    return {
+        "schema": PROJECTION_RECEIPT_SCHEMA,
+        "task_id": binding.get("task_id"),
+        "session_id": binding.get("session_id"),
+        "event_sha256": binding["event_sha256"],
+        "stored_event_sha256": stored_event_sha256,
+        "custody_class": CUSTODY_CLASS,
+        "provider_adapter_ref": f"continuity-vault-kit:runtime/kv_storage_provider_adapter.py#{request['provider_id']}",
+        "interlock_intr_receipt_ref": f"{provider_receipt['interlock_receipt_ref']}|{provider_receipt['intr_receipt_ref']}",
+        "kv_instance_ref": request["instance_id"],
+        "provider_operation_request_id": request["request_id"],
+        "provider_result_ref": provider_receipt["provider_result_ref"],
+        "skap_credential_ref": provider_receipt["skap_credential_ref"],
+        "exact_hash_readback_verified": True,
+        "authority_effect": "NONE",
+    }

--- a/tests/test_task_registry_event_sovereign_kv_binding.py
+++ b/tests/test_task_registry_event_sovereign_kv_binding.py
@@ -1,0 +1,99 @@
+from runtime.task_registry_event_sovereign_kv_binding import (
+    build_task_registry_event_custody_binding,
+    validate_task_registry_event_custody_result,
+)
+
+
+def projection_request():
+    event_hash = "sha256:" + "a" * 64
+    return {
+        "schema": "stegverse.task-registry-sovereign-kv-projection-request/v1",
+        "task_id": "TASK-REGISTRY-SOVEREIGN-KV-EVENT-CUSTODY-001",
+        "session_id": "session-1",
+        "event_sha256": event_hash,
+        "predecessor_event_sha256": None,
+        "custody_class": "STEGVERSE_SOVEREIGN_KV",
+        "exact_event": {
+            "schema": "stegverse.task-registry-checkin-event/v1",
+            "task_id": "TASK-REGISTRY-SOVEREIGN-KV-EVENT-CUSTODY-001",
+            "session_id": "session-1",
+            "event_sha256": event_hash,
+            "authority_effect": "NONE",
+        },
+        "authority_effect": "NONE",
+    }
+
+
+def provider_receipt(request):
+    return {
+        "schema": "stegverse.kv.storage-provider-operation-receipt/v1",
+        "request_id": request["request_id"],
+        "instance_id": request["instance_id"],
+        "kv_set_id": request["kv_set_id"],
+        "provider_id": request["provider_id"],
+        "operation": "WRITE",
+        "governance_state": "ADMITTED",
+        "provider_operation_executed": True,
+        "data_moved": True,
+        "replication_started": False,
+        "interlock_receipt_ref": "interlock:receipt:1",
+        "intr_receipt_ref": "intr:receipt:1",
+        "skap_credential_ref": "skap:credential:1",
+        "provider_result_ref": "provider:result:1",
+        "authority_effect": "NONE",
+        "credential_material_present": False,
+    }
+
+
+def test_binding_reuses_existing_provider_write_contract():
+    binding = build_task_registry_event_custody_binding(
+        projection_request=projection_request(),
+        provider_id="google-drive",
+        instance_id="kvi_task_registry_001",
+        kv_set_id="stegverse-task-registry",
+        storage_locator="private://task-registry/events",
+    )
+    request = binding["provider_write_request"]
+    assert request["schema"] == "stegverse.kv.storage-provider-operation-request/v1"
+    assert request["operation"] == "WRITE"
+    assert request["governance_state"] == "PENDING_INTERLOCK_INTR"
+    assert request["object_ref"] == binding["event_sha256"]
+    assert request["credential_material_present"] is False
+    assert binding["authority_effect"] == "NONE"
+
+
+def test_admitted_write_plus_exact_readback_yields_projection_receipt():
+    binding = build_task_registry_event_custody_binding(
+        projection_request=projection_request(),
+        provider_id="google-drive",
+        instance_id="kvi_task_registry_001",
+        kv_set_id="stegverse-task-registry",
+    )
+    receipt = validate_task_registry_event_custody_result(
+        binding=binding,
+        provider_receipt=provider_receipt(binding["provider_write_request"]),
+        stored_event_sha256=binding["event_sha256"],
+    )
+    assert receipt["schema"] == "stegverse.task-registry-sovereign-kv-projection-receipt/v1"
+    assert receipt["stored_event_sha256"] == binding["event_sha256"]
+    assert receipt["exact_hash_readback_verified"] is True
+    assert receipt["authority_effect"] == "NONE"
+
+
+def test_hash_readback_mismatch_fails_closed():
+    binding = build_task_registry_event_custody_binding(
+        projection_request=projection_request(),
+        provider_id="google-drive",
+        instance_id="kvi_task_registry_001",
+        kv_set_id="stegverse-task-registry",
+    )
+    try:
+        validate_task_registry_event_custody_result(
+            binding=binding,
+            provider_receipt=provider_receipt(binding["provider_write_request"]),
+            stored_event_sha256="sha256:" + "b" * 64,
+        )
+    except ValueError as exc:
+        assert "readback mismatch" in str(exc)
+    else:
+        raise AssertionError("expected exact hash readback mismatch")


### PR DESCRIPTION
Implements the continuity-vault-kit integration slice for TASK-REGISTRY-SOVEREIGN-KV-EVENT-CUSTODY-001. Reuses the existing provider-neutral storage adapter and operation-request contract to turn the canonical Task Registry sovereign-KV projection request into a governed WRITE request with PENDING_INTERLOCK_INTR state, SKAP reference requirement, and exact event SHA-256 object binding. The result validator accepts only an admitted/executed provider receipt with Interlock, InTr, SKAP, provider-result evidence, and exact stored-event hash readback, then emits the existing .github projection receipt schema. No provider execution, credential resolution, second collision engine, or authority widening is introduced.